### PR TITLE
ACTIN-16: Add lymph node lesions in clinical JSON and curation

### DIFF
--- a/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastases.java
+++ b/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastases.java
@@ -14,6 +14,6 @@ public class HasBoneMetastases implements EvaluationFunction {
     @NotNull
     @Override
     public Evaluation evaluate(@NotNull PatientRecord record) {
-        return TumorUtil.evaluateBooleanMetastasis(record.clinical().tumor().hasBoneLesions(), "bone");
+        return TumorMetastasisEvaluator.evaluate(record.clinical().tumor().hasBoneLesions(), "bone");
     }
 }

--- a/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastases.java
+++ b/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastases.java
@@ -14,6 +14,6 @@ public class HasLiverMetastases implements EvaluationFunction {
     @NotNull
     @Override
     public Evaluation evaluate(@NotNull PatientRecord record) {
-        return TumorUtil.evaluateBooleanMetastasis(record.clinical().tumor().hasLiverLesions(), "liver");
+        return TumorMetastasisEvaluator.evaluate(record.clinical().tumor().hasLiverLesions(), "liver");
     }
 }

--- a/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastases.java
+++ b/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastases.java
@@ -14,6 +14,6 @@ public class HasLungMetastases implements EvaluationFunction {
     @NotNull
     @Override
     public Evaluation evaluate(@NotNull PatientRecord record) {
-        return TumorUtil.evaluateBooleanMetastasis(record.clinical().tumor().hasLungLesions(), "lung");
+        return TumorMetastasisEvaluator.evaluate(record.clinical().tumor().hasLungLesions(), "lung");
     }
 }

--- a/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastases.java
+++ b/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastases.java
@@ -14,6 +14,6 @@ public class HasLymphNodeMetastases implements EvaluationFunction {
     @NotNull
     @Override
     public Evaluation evaluate(@NotNull PatientRecord record) {
-        return TumorUtil.evaluateBooleanMetastasis(record.clinical().tumor().hasLymphNodeLesions(), "lymph node");
+        return TumorMetastasisEvaluator.evaluate(record.clinical().tumor().hasLymphNodeLesions(), "lymph node");
     }
 }

--- a/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/TumorMetastasisEvaluator.java
+++ b/algo/src/main/java/com/hartwig/actin/algo/evaluation/tumor/TumorMetastasisEvaluator.java
@@ -7,9 +7,10 @@ import com.hartwig.actin.algo.evaluation.EvaluationFactory;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class TumorUtil {
+public final class TumorMetastasisEvaluator {
+
     @NotNull
-    public static Evaluation evaluateBooleanMetastasis(@Nullable Boolean hasMetastases, @NotNull String metastasisType) {
+    public static Evaluation evaluate(@Nullable Boolean hasMetastases, @NotNull String metastasisType) {
         ImmutableEvaluation.Builder builder = EvaluationFactory.unrecoverable();
         if (hasMetastases == null) {
             builder.result(EvaluationResult.UNDETERMINED)

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastasesTest.java
@@ -1,14 +1,13 @@
 package com.hartwig.actin.algo.evaluation.tumor;
 
 import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
-
 import com.hartwig.actin.algo.datamodel.Evaluation;
 import com.hartwig.actin.algo.datamodel.EvaluationResult;
-
 import org.junit.Test;
 
 public class HasBoneMetastasesTest {
-    private final HasBoneMetastases function = new HasBoneMetastases();
+
+    private static final HasBoneMetastases function = new HasBoneMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasBoneLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasBoneMetastasesTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 public class HasBoneMetastasesTest {
 
-    private static final HasBoneMetastases function = new HasBoneMetastases();
+    private final HasBoneMetastases function = new HasBoneMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasBoneLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastasesTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 public class HasLiverMetastasesTest {
 
-    private static final HasLiverMetastases function = new HasLiverMetastases();
+    private final HasLiverMetastases function = new HasLiverMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLiverLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLiverMetastasesTest.java
@@ -1,14 +1,13 @@
 package com.hartwig.actin.algo.evaluation.tumor;
 
 import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
-
 import com.hartwig.actin.algo.datamodel.Evaluation;
 import com.hartwig.actin.algo.datamodel.EvaluationResult;
-
 import org.junit.Test;
 
 public class HasLiverMetastasesTest {
-    private final HasLiverMetastases function = new HasLiverMetastases();
+
+    private static final HasLiverMetastases function = new HasLiverMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLiverLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastasesTest.java
@@ -1,14 +1,13 @@
 package com.hartwig.actin.algo.evaluation.tumor;
 
 import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
-
 import com.hartwig.actin.algo.datamodel.Evaluation;
 import com.hartwig.actin.algo.datamodel.EvaluationResult;
-
 import org.junit.Test;
 
 public class HasLungMetastasesTest {
-    private final HasLungMetastases function = new HasLungMetastases();
+
+    private static final HasLungMetastases function = new HasLungMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLungLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLungMetastasesTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 
 public class HasLungMetastasesTest {
 
-    private static final HasLungMetastases function = new HasLungMetastases();
+    private final HasLungMetastases function = new HasLungMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLungLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastasesTest.java
@@ -1,14 +1,14 @@
 package com.hartwig.actin.algo.evaluation.tumor;
 
+import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
+import static org.junit.Assert.assertTrue;
 import com.hartwig.actin.algo.datamodel.Evaluation;
 import com.hartwig.actin.algo.datamodel.EvaluationResult;
 import org.junit.Test;
 
-import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
-import static org.junit.Assert.assertTrue;
-
 public class HasLymphNodeMetastasesTest {
-    private final HasLymphNodeMetastases function = new HasLymphNodeMetastases();
+
+    private static final HasLymphNodeMetastases function = new HasLymphNodeMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLymphNodeLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastasesTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/HasLymphNodeMetastasesTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 
 public class HasLymphNodeMetastasesTest {
 
-    private static final HasLymphNodeMetastases function = new HasLymphNodeMetastases();
+    private final HasLymphNodeMetastases function = new HasLymphNodeMetastases();
 
     @Test
     public void shouldBeUndeterminedWhenHasLymphNodeLesionsIsNull() {

--- a/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/TumorMetastasisEvaluatorTest.java
+++ b/algo/src/test/java/com/hartwig/actin/algo/evaluation/tumor/TumorMetastasisEvaluatorTest.java
@@ -7,12 +7,12 @@ import org.junit.Test;
 import static com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation;
 import static org.junit.Assert.assertTrue;
 
-public class TumorUtilTest {
+public class TumorMetastasisEvaluatorTest {
     private static final String metastasisType = "bone";
 
     @Test
     public void shouldBeUndeterminedWhenBooleanIsNull() {
-        Evaluation undetermined = TumorUtil.evaluateBooleanMetastasis(null, metastasisType);
+        Evaluation undetermined = TumorMetastasisEvaluator.evaluate(null, metastasisType);
         assertEvaluation(EvaluationResult.UNDETERMINED, undetermined);
         assertTrue(undetermined.undeterminedSpecificMessages().contains(
                 "Data regarding presence of bone metastases is missing"));
@@ -21,7 +21,7 @@ public class TumorUtilTest {
 
     @Test
     public void shouldPassWhenBooleanIsTrue() {
-        Evaluation pass = TumorUtil.evaluateBooleanMetastasis(Boolean.TRUE, metastasisType);
+        Evaluation pass = TumorMetastasisEvaluator.evaluate(Boolean.TRUE, metastasisType);
         assertEvaluation(EvaluationResult.PASS, pass);
         assertTrue(pass.passSpecificMessages().contains("Bone metastases are present"));
         assertTrue(pass.passGeneralMessages().contains("Bone metastases"));
@@ -29,7 +29,7 @@ public class TumorUtilTest {
 
     @Test
     public void shouldFailWhenBooleanIsFalse() {
-        Evaluation fail = TumorUtil.evaluateBooleanMetastasis(Boolean.FALSE, metastasisType);
+        Evaluation fail = TumorMetastasisEvaluator.evaluate(Boolean.FALSE, metastasisType);
         assertEvaluation(EvaluationResult.FAIL, fail);
         assertTrue(fail.failSpecificMessages().contains("No bone metastases present"));
         assertTrue(fail.failGeneralMessages().contains("No bone metastases"));

--- a/clinical/src/main/java/com/hartwig/actin/clinical/curation/CurationModel.java
+++ b/clinical/src/main/java/com/hartwig/actin/clinical/curation/CurationModel.java
@@ -159,38 +159,45 @@ public class CurationModel {
 
         ImmutableTumorDetails.Builder builder = ImmutableTumorDetails.builder().from(tumorDetails);
         if (matches.contains(LesionLocationCategory.BRAIN)) {
-            if (tumorDetails.hasBrainLesions() != null && !tumorDetails.hasBrainLesions()) {
+            if (Boolean.FALSE.equals(tumorDetails.hasBrainLesions())) {
                 LOGGER.debug("  Overriding presence of brain lesions");
             }
             builder.hasBrainLesions(true);
         }
 
         if (matches.contains(LesionLocationCategory.CNS)) {
-            if (tumorDetails.hasCnsLesions() != null && !tumorDetails.hasCnsLesions()) {
+            if (Boolean.FALSE.equals(tumorDetails.hasCnsLesions())) {
                 LOGGER.debug("  Overriding presence of CNS lesions");
             }
             builder.hasCnsLesions(true);
         }
 
         if (matches.contains(LesionLocationCategory.LIVER)) {
-            if (tumorDetails.hasLiverLesions() != null && !tumorDetails.hasLiverLesions()) {
+            if (Boolean.FALSE.equals(tumorDetails.hasLiverLesions())) {
                 LOGGER.debug("  Overriding presence of liver lesions");
             }
             builder.hasLiverLesions(true);
         }
 
         if (matches.contains(LesionLocationCategory.BONE)) {
-            if (tumorDetails.hasBoneLesions() != null && !tumorDetails.hasBoneLesions()) {
+            if (Boolean.FALSE.equals(tumorDetails.hasBoneLesions())) {
                 LOGGER.debug("  Overriding presence of bone lesions");
             }
             builder.hasBoneLesions(true);
         }
 
         if (matches.contains(LesionLocationCategory.LUNG)) {
-            if (tumorDetails.hasLungLesions() != null && !tumorDetails.hasLungLesions()) {
+            if (Boolean.FALSE.equals(tumorDetails.hasLungLesions())) {
                 LOGGER.debug("  Overriding presence of lung lesions");
             }
             builder.hasLungLesions(true);
+        }
+
+        if (matches.contains(LesionLocationCategory.LYMPH_NODE)) {
+            if (Boolean.FALSE.equals(tumorDetails.hasLymphNodeLesions())) {
+                LOGGER.debug("  Overriding presence of lymph node lesions");
+            }
+            builder.hasLymphNodeLesions(true);
         }
 
         return builder.build();

--- a/clinical/src/test/java/com/hartwig/actin/clinical/curation/CurationModelTest.java
+++ b/clinical/src/test/java/com/hartwig/actin/clinical/curation/CurationModelTest.java
@@ -45,7 +45,7 @@ public class CurationModelTest {
 
     private static final String CURATION_DIRECTORY = Resources.getResource("curation").getPath();
 
-    private CurationModel model = TestCurationFactory.createProperTestCurationModel();
+    private final CurationModel model = TestCurationFactory.createProperTestCurationModel();
 
     @Test
     public void canCreateFromCurationDirectory() throws IOException {

--- a/clinical/src/test/java/com/hartwig/actin/clinical/curation/TestCurationFactory.java
+++ b/clinical/src/test/java/com/hartwig/actin/clinical/curation/TestCurationFactory.java
@@ -189,7 +189,8 @@ public final class TestCurationFactory {
                 .category(LesionLocationCategory.LUNG)
                 .build());
 
-        configs.add(ImmutableLesionLocationConfig.builder().input("Lymph node").location("Lymph node").build());
+        configs.add(ImmutableLesionLocationConfig.builder().input("Lymph node").location("Lymph node")
+                .category(LesionLocationCategory.LYMPH_NODE).build());
 
         configs.add(ImmutableLesionLocationConfig.builder().input("Not a lesion").location(Strings.EMPTY).build());
 

--- a/common/src/main/java/com/hartwig/actin/clinical/serialization/ClinicalRecordJson.java
+++ b/common/src/main/java/com/hartwig/actin/clinical/serialization/ClinicalRecordJson.java
@@ -16,7 +16,6 @@ import static com.hartwig.actin.util.json.Json.number;
 import static com.hartwig.actin.util.json.Json.object;
 import static com.hartwig.actin.util.json.Json.string;
 import static com.hartwig.actin.util.json.Json.stringList;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -25,7 +24,6 @@ import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Set;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -86,7 +84,6 @@ import com.hartwig.actin.clinical.datamodel.VitalFunctionCategory;
 import com.hartwig.actin.clinical.sort.ClinicalRecordComparator;
 import com.hartwig.actin.util.Paths;
 import com.hartwig.actin.util.json.GsonSerializer;
-
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -201,6 +198,7 @@ public final class ClinicalRecordJson {
                     .hasBoneLesions(nullableBool(tumor, "hasBoneLesions"))
                     .hasLiverLesions(nullableBool(tumor, "hasLiverLesions"))
                     .hasLungLesions(nullableBool(tumor, "hasLungLesions"))
+                    .hasLymphNodeLesions(nullableBool(tumor, "hasLymphNodeLesions"))
                     .otherLesions(nullableStringList(tumor, "otherLesions"))
                     .biopsyLocation(nullableString(tumor, "biopsyLocation"))
                     .build();

--- a/common/src/test/java/com/hartwig/actin/clinical/datamodel/TestClinicalFactory.java
+++ b/common/src/test/java/com/hartwig/actin/clinical/datamodel/TestClinicalFactory.java
@@ -2,11 +2,9 @@ package com.hartwig.actin.clinical.datamodel;
 
 import java.time.LocalDate;
 import java.util.List;
-
 import com.google.common.collect.Lists;
 import com.hartwig.actin.TestDataFactory;
 import com.hartwig.actin.clinical.interpretation.LabMeasurement;
-
 import org.apache.logging.log4j.util.Strings;
 import org.jetbrains.annotations.NotNull;
 
@@ -95,6 +93,7 @@ public final class TestClinicalFactory {
                 .hasBoneLesions(null)
                 .hasLiverLesions(true)
                 .hasLungLesions(false)
+                .hasLymphNodeLesions(true)
                 .addOtherLesions("Lymph nodes")
                 .biopsyLocation("Liver")
                 .build();

--- a/common/src/test/resources/clinical/patient.clinical.json
+++ b/common/src/test/resources/clinical/patient.clinical.json
@@ -30,6 +30,7 @@
     "hasBoneLesions": false,
     "hasLiverLesions": false,
     "hasLungLesions": false,
+    "hasLymphNodeLesions": false,
     "otherLesions": [
       "Lymph node"
     ],

--- a/database/src/main/resources/generate_database.sql
+++ b/database/src/main/resources/generate_database.sql
@@ -75,7 +75,7 @@ CREATE TABLE priorTumorTreatment
     isSystemic BOOLEAN NOT NULL,
     chemoType varchar(100),
     immunoType varchar(100),
-    targetedType varchar(100),
+    targetedType varchar(200),
     hormoneType varchar(100),
     radioType varchar(100),
     carTType varchar(100),


### PR DESCRIPTION
Rename TumorUtil to TumorMetastasisEvaluator for clarity.
Use static EvaluationFunction references in tests as per feedback.
Use Boolean equals comparison to handle nulls and resolve IDE warning.
Restructure CurationModel lesion tests to align them with acceptance criteria.
Increase size of targetedType column to accommodate clinical data.
Replace explicit JSON deserialization with type adapters.