### PR TITLE
ACTIN-27: Filter reported drivers by actionability

### DIFF
--- a/common/src/main/java/com/hartwig/actin/molecular/datamodel/driver/DriverLikelihood.java
+++ b/common/src/main/java/com/hartwig/actin/molecular/datamodel/driver/DriverLikelihood.java
@@ -3,5 +3,9 @@ package com.hartwig.actin.molecular.datamodel.driver;
 public enum DriverLikelihood {
     HIGH,
     MEDIUM,
-    LOW
+    LOW;
+
+    public String toString() {
+        return name().substring(0, 1).toUpperCase() + name().substring(1).toLowerCase();
+    }
 }

--- a/common/src/test/java/com/hartwig/actin/molecular/datamodel/TestMolecularFactory.java
+++ b/common/src/test/java/com/hartwig/actin/molecular/datamodel/TestMolecularFactory.java
@@ -29,6 +29,7 @@ import com.hartwig.actin.molecular.datamodel.driver.TestVirusFactory;
 import com.hartwig.actin.molecular.datamodel.driver.VariantEffect;
 import com.hartwig.actin.molecular.datamodel.driver.VariantType;
 import com.hartwig.actin.molecular.datamodel.driver.VirusType;
+import com.hartwig.actin.molecular.datamodel.evidence.ActionableEvidence;
 import com.hartwig.actin.molecular.datamodel.evidence.TestActionableEvidenceFactory;
 import com.hartwig.actin.molecular.datamodel.immunology.ImmutableMolecularImmunology;
 import com.hartwig.actin.molecular.datamodel.immunology.MolecularImmunology;
@@ -63,6 +64,14 @@ public final class TestMolecularFactory {
                 .characteristics(ImmutableMolecularCharacteristics.builder().build())
                 .drivers(ImmutableMolecularDrivers.builder().build())
                 .immunology(ImmutableMolecularImmunology.builder().isReliable(false).build())
+                .build();
+    }
+
+    @NotNull
+    public static MolecularRecord createTestMolecularRecordWithDriverEvidenceAndNullLikelihood(ActionableEvidence evidence) {
+        return ImmutableMolecularRecord.builder()
+                .from(createMinimalTestMolecularRecord())
+                .drivers(createDriversWithEvidenceAndNullLikelihood(evidence))
                 .build();
     }
 
@@ -113,6 +122,22 @@ public final class TestMolecularFactory {
                 .homologousRepairEvidence(TestActionableEvidenceFactory.createExhaustive())
                 .tumorMutationalBurdenEvidence(TestActionableEvidenceFactory.createExhaustive())
                 .tumorMutationalLoadEvidence(TestActionableEvidenceFactory.createExhaustive())
+                .build();
+    }
+
+    @NotNull
+    private static MolecularDrivers createDriversWithEvidenceAndNullLikelihood(ActionableEvidence evidence) {
+        return ImmutableMolecularDrivers.builder()
+                .addViruses(TestVirusFactory.builder()
+                        .isReportable(true)
+                        .event("HPV positive")
+                        .driverLikelihood(null)
+                        .evidence(evidence)
+                        .name("Human papillomavirus type 16")
+                        .type(VirusType.HUMAN_PAPILLOMA_VIRUS)
+                        .integrations(3)
+                        .isReliable(true)
+                        .build())
                 .build();
     }
 

--- a/molecular/src/main/java/com/hartwig/actin/molecular/orange/interpretation/VirusExtractor.java
+++ b/molecular/src/main/java/com/hartwig/actin/molecular/orange/interpretation/VirusExtractor.java
@@ -48,16 +48,18 @@ class VirusExtractor {
         return viruses;
     }
 
-    @NotNull
+    @Nullable
     @VisibleForTesting
     static DriverLikelihood determineDriverLikelihood(@NotNull VirusDriverLikelihood driverLikelihood) {
         switch (driverLikelihood) {
             case HIGH: {
                 return DriverLikelihood.HIGH;
             }
-            case LOW:
-            case UNKNOWN: {
+            case LOW: {
                 return DriverLikelihood.LOW;
+            }
+            case UNKNOWN: {
+                return null;
             }
             default: {
                 throw new IllegalStateException(

--- a/molecular/src/test/java/com/hartwig/actin/molecular/orange/interpretation/VirusExtractorTest.java
+++ b/molecular/src/test/java/com/hartwig/actin/molecular/orange/interpretation/VirusExtractorTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import com.hartwig.actin.molecular.datamodel.driver.DriverLikelihood;
@@ -72,8 +74,14 @@ public class VirusExtractorTest {
 
     @Test
     public void canDetermineDriverLikelihoodForAllVirusDriverLikelihoods() {
+        Map<VirusDriverLikelihood, DriverLikelihood> expectedDriverLikelihoodLookup = new HashMap<>();
+        expectedDriverLikelihoodLookup.put(VirusDriverLikelihood.LOW, DriverLikelihood.LOW);
+        expectedDriverLikelihoodLookup.put(VirusDriverLikelihood.HIGH, DriverLikelihood.HIGH);
+        expectedDriverLikelihoodLookup.put(VirusDriverLikelihood.UNKNOWN, null);
+
         for (VirusDriverLikelihood virusDriverLikelihood : VirusDriverLikelihood.values()) {
-            assertNotNull(VirusExtractor.determineDriverLikelihood(virusDriverLikelihood));
+            assertEquals(expectedDriverLikelihoodLookup.get(virusDriverLikelihood),
+                    VirusExtractor.determineDriverLikelihood(virusDriverLikelihood));
         }
     }
 

--- a/report/src/main/java/com/hartwig/actin/report/interpretation/MolecularDriverEntry.java
+++ b/report/src/main/java/com/hartwig/actin/report/interpretation/MolecularDriverEntry.java
@@ -18,7 +18,7 @@ public abstract class MolecularDriverEntry {
     @NotNull
     public abstract String driver();
 
-    @NotNull
+    @Nullable
     public abstract DriverLikelihood driverLikelihood();
 
     @NotNull

--- a/report/src/main/java/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactory.java
+++ b/report/src/main/java/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactory.java
@@ -60,8 +60,8 @@ public class MolecularDriverEntryFactory {
                         fromFusions(drivers.fusions()),
                         fromViruses(drivers.viruses()))
                 .flatMap(Function.identity())
-                .filter(driver -> driver.driverLikelihood() != null || !driver.externalTrials().isEmpty() || !driver.actinTrials().isEmpty()
-                        || Objects.equals(driver.bestResponsiveEvidence(), RESPONSIVE_EVIDENCE_APPROVED_TREATMENTS))
+                .filter(entry -> entry.driverLikelihood() != null || !entry.externalTrials().isEmpty() || !entry.actinTrials().isEmpty()
+                        || Objects.equals(entry.bestResponsiveEvidence(), RESPONSIVE_EVIDENCE_APPROVED_TREATMENTS))
                 .sorted(new MolecularDriverEntryComparator());
     }
 

--- a/report/src/main/java/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.java
+++ b/report/src/main/java/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.java
@@ -1,14 +1,15 @@
 package com.hartwig.actin.report.pdf.tables.molecular;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 
 import com.hartwig.actin.molecular.datamodel.MolecularRecord;
 import com.hartwig.actin.molecular.datamodel.driver.Driver;
+import com.hartwig.actin.molecular.datamodel.driver.DriverLikelihood;
 import com.hartwig.actin.report.interpretation.ClonalityInterpreter;
 import com.hartwig.actin.report.interpretation.EvaluatedCohort;
-import com.hartwig.actin.report.interpretation.MolecularDriverEntry;
 import com.hartwig.actin.report.interpretation.MolecularDriverEntryFactory;
 import com.hartwig.actin.report.pdf.tables.TableGenerator;
 import com.hartwig.actin.report.pdf.util.Cells;
@@ -57,17 +58,15 @@ public class MolecularDriversGenerator implements TableGenerator {
         table.addHeaderCell(Cells.createHeader("Resistance in " + molecular.evidenceSource()));
 
         MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(cohorts);
-        Set<MolecularDriverEntry> entries = factory.create(molecular);
-
-        for (MolecularDriverEntry entry : entries) {
+        factory.create(molecular).forEach(entry -> {
             table.addCell(Cells.createContent(entry.driverType()));
             table.addCell(Cells.createContent(entry.driver()));
-            table.addCell(Cells.createContent(formatDriverLikelihood(entry.driverLikelihood().toString())));
+            table.addCell(Cells.createContent(formatDriverLikelihood(entry.driverLikelihood())));
             table.addCell(Cells.createContent(concat(entry.actinTrials())));
             table.addCell(Cells.createContent(concat(entry.externalTrials())));
             table.addCell(Cells.createContent(nullToEmpty(entry.bestResponsiveEvidence())));
             table.addCell(Cells.createContent(nullToEmpty(entry.bestResistanceEvidence())));
-        }
+        });
 
         boolean hasPotentiallySubClonalVariants = molecular.drivers().variants().stream()
                 .filter(Driver::isReportable)
@@ -82,8 +81,8 @@ public class MolecularDriversGenerator implements TableGenerator {
     }
 
     @NotNull
-    private static String formatDriverLikelihood(@NotNull String driverLikelihood) {
-        return driverLikelihood.substring(0, 1).toUpperCase() + driverLikelihood.substring(1).toLowerCase();
+    private static String formatDriverLikelihood(@Nullable DriverLikelihood driverLikelihood) {
+        return Optional.ofNullable(driverLikelihood).map(DriverLikelihood::toString).orElse(Formats.VALUE_UNKNOWN);
     }
 
     @NotNull

--- a/report/src/main/java/com/hartwig/actin/report/pdf/tables/molecular/RecentMolecularSummaryGenerator.java
+++ b/report/src/main/java/com/hartwig/actin/report/pdf/tables/molecular/RecentMolecularSummaryGenerator.java
@@ -88,7 +88,7 @@ public class RecentMolecularSummaryGenerator implements TableGenerator {
                             Maps.immutableEntry("Virus detection", highDriverVirusDetectionsStringOption()),
                             Maps.immutableEntry("", Optional.of("")),
                             Maps.immutableEntry("Potentially actionable events with medium/low driver:",
-                                    actionableEventsWithoutHighDriverMutation()))
+                                    actionableEventsWithoutHighDriverLikelihood()))
                     .flatMap(entry -> Stream.of(Cells.createKey(entry.getKey()),
                             Cells.createValue(entry.getValue().orElse(Formats.VALUE_UNKNOWN))))
                     .forEach(table::addCell);
@@ -175,7 +175,7 @@ public class RecentMolecularSummaryGenerator implements TableGenerator {
     }
 
     @NotNull
-    private Optional<String> actionableEventsWithoutHighDriverMutation() {
+    private Optional<String> actionableEventsWithoutHighDriverLikelihood() {
         Set<String> eventsWithActinTrials = cohorts.stream()
                 .filter(EvaluatedCohort::isPotentiallyEligible)
                 .filter(EvaluatedCohort::isOpen)

--- a/report/src/test/java/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactoryTest.java
+++ b/report/src/test/java/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactoryTest.java
@@ -4,14 +4,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Set;
+import java.util.Collections;
+import java.util.stream.Stream;
 
 import com.google.common.collect.Lists;
 import com.hartwig.actin.molecular.datamodel.MolecularRecord;
 import com.hartwig.actin.molecular.datamodel.TestMolecularFactory;
 import com.hartwig.actin.molecular.datamodel.driver.Variant;
+import com.hartwig.actin.molecular.datamodel.evidence.TestActionableEvidenceFactory;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.Test;
 
 public class MolecularDriverEntryFactoryTest {
@@ -20,10 +21,49 @@ public class MolecularDriverEntryFactoryTest {
     public void canCreateMolecularDriverEntries() {
         MolecularRecord record = TestMolecularFactory.createExhaustiveTestMolecularRecord();
 
-        MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(Lists.newArrayList());
-        Set<MolecularDriverEntry> entries = factory.create(record);
+        MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(Collections.emptyList());
+        Stream<MolecularDriverEntry> entries = factory.create(record);
 
-        assertEquals(7, entries.size());
+        assertEquals(7, entries.count());
+    }
+
+    @Test
+    public void shouldSkipNonActionableDriversWithNullLikelihood() {
+        MolecularRecord record = TestMolecularFactory.createTestMolecularRecordWithDriverEvidenceAndNullLikelihood(
+                TestActionableEvidenceFactory.createEmpty());
+
+        MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(Collections.emptyList());
+
+        assertEquals(0, factory.create(record).count());
+    }
+
+    @Test
+    public void shouldIncludeDriversWithNullLikelihoodAndActinTrialMatches() {
+        MolecularRecord record = TestMolecularFactory.createTestMolecularRecordWithDriverEvidenceAndNullLikelihood(
+                TestActionableEvidenceFactory.createEmpty());
+        String driverToFind = record.drivers().viruses().iterator().next().event();
+
+        assertEquals(1, createFactoryWithCohortsForEvent(driverToFind).create(record).count());
+    }
+
+    @Test
+    public void shouldIncludeDriversWithNullLikelihoodAndApprovedTreatmentMatches() {
+        MolecularRecord record = TestMolecularFactory.createTestMolecularRecordWithDriverEvidenceAndNullLikelihood(
+                TestActionableEvidenceFactory.withApprovedTreatment("treatment"));
+
+        MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(Collections.emptyList());
+
+        assertEquals(1, factory.create(record).count());
+    }
+
+    @Test
+    public void shouldIncludeDriversWithNullLikelihoodAndExternalTrialMatches() {
+        MolecularRecord record = TestMolecularFactory.createTestMolecularRecordWithDriverEvidenceAndNullLikelihood(
+                TestActionableEvidenceFactory.withExternalEligibleTrial("trial 1"));
+
+        MolecularDriverEntryFactory factory = MolecularDriverEntryFactory.fromEvaluatedCohorts(Collections.emptyList());
+
+        assertEquals(1, factory.create(record).count());
     }
 
     @Test
@@ -32,37 +72,33 @@ public class MolecularDriverEntryFactoryTest {
         assertFalse(record.drivers().variants().isEmpty());
 
         Variant firstVariant = record.drivers().variants().iterator().next();
+
+        String driverToFind = firstVariant.event();
+
+        MolecularDriverEntry entry = createFactoryWithCohortsForEvent(driverToFind).create(record)
+                .filter(molecularDriverEntry -> molecularDriverEntry.driver().startsWith(driverToFind))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Could not find molecular driver entry starting with driver: " + driverToFind));
+        assertEquals(1, entry.actinTrials().size());
+        assertTrue(entry.actinTrials().contains("trial 1"));
+    }
+
+    private MolecularDriverEntryFactory createFactoryWithCohortsForEvent(String event) {
         EvaluatedCohort openCohortForVariant = EvaluatedCohortTestFactory.builder()
                 .acronym("trial 1")
-                .addMolecularEvents(firstVariant.event())
+                .addMolecularEvents(event)
                 .isPotentiallyEligible(true)
                 .isOpen(true)
                 .build();
 
         EvaluatedCohort closedCohortForVariant = EvaluatedCohortTestFactory.builder()
                 .acronym("trial 2")
-                .addMolecularEvents(firstVariant.event())
+                .addMolecularEvents(event)
                 .isPotentiallyEligible(true)
                 .isOpen(false)
                 .build();
 
-        MolecularDriverEntryFactory factory =
-                MolecularDriverEntryFactory.fromEvaluatedCohorts(Lists.newArrayList(openCohortForVariant, closedCohortForVariant));
-        Set<MolecularDriverEntry> entries = factory.create(record);
-
-        MolecularDriverEntry entry = startsWithDriver(entries, firstVariant.event());
-        assertEquals(1, entry.actinTrials().size());
-        assertTrue(entry.actinTrials().contains("trial 1"));
-    }
-
-    @NotNull
-    private static MolecularDriverEntry startsWithDriver(@NotNull Set<MolecularDriverEntry> entries, @NotNull String driverToFind) {
-        for (MolecularDriverEntry entry : entries) {
-            if (entry.driver().startsWith(driverToFind)) {
-                return entry;
-            }
-        }
-
-        throw new IllegalStateException("Could not find molecular driver entry starting with driver: " + driverToFind);
+        return MolecularDriverEntryFactory.fromEvaluatedCohorts(Lists.newArrayList(openCohortForVariant, closedCohortForVariant));
     }
 }


### PR DESCRIPTION
In molecular details, reported drivers must have known driver
likelihood or be actionable. Additionally:
- Extract VirusDriverLikelihood UNKNOWN as null.
- Use streams to facilitate filtering and concatenation.
- Add toString method to DriverLikelihood.