### PR TITLE
ACTIN-106: Make GENAYA subjectno optional in questionnaire v1.6

### DIFF
--- a/clinical/src/main/java/com/hartwig/actin/clinical/feed/questionnaire/QuestionnaireExtraction.java
+++ b/clinical/src/main/java/com/hartwig/actin/clinical/feed/questionnaire/QuestionnaireExtraction.java
@@ -83,7 +83,7 @@ public final class QuestionnaireExtraction {
                 .infectionStatus(toInfectionStatus(value(entry, mapping.get(QuestionnaireKey.SIGNIFICANT_CURRENT_INFECTION))))
                 .ecg(toECG(value(entry, mapping.get(QuestionnaireKey.SIGNIFICANT_ABERRATION_LATEST_ECG))))
                 .complications(toList(value(entry, mapping.get(QuestionnaireKey.COMPLICATIONS))))
-                .genayaSubjectNumber(value(entry, mapping.get(QuestionnaireKey.GENAYA_SUBJECT_NUMBER), true))
+                .genayaSubjectNumber(optionalValue(entry, mapping.get(QuestionnaireKey.GENAYA_SUBJECT_NUMBER)))
                 .build();
     }
 
@@ -196,17 +196,17 @@ public final class QuestionnaireExtraction {
 
     @Nullable
     private static String value(@NotNull QuestionnaireEntry entry, @Nullable String key) {
-        return value(entry, key, false);
-    }
-
-    @Nullable
-    private static String value(@NotNull QuestionnaireEntry entry, @Nullable String key, boolean isOptional) {
-        return value(entry, key, isOptional, 0);
+        return value(entry, key, false, 0);
     }
 
     @Nullable
     private static String value(@NotNull QuestionnaireEntry entry, @Nullable String key, int lineOffset) {
         return value(entry, key, false, lineOffset);
+    }
+
+    @Nullable
+    private static String optionalValue(@NotNull QuestionnaireEntry entry, @Nullable String key) {
+        return value(entry, key, true, 0);
     }
 
     @Nullable

--- a/clinical/src/test/java/com/hartwig/actin/clinical/feed/questionnaire/QuestionnaireExtractionTest.java
+++ b/clinical/src/test/java/com/hartwig/actin/clinical/feed/questionnaire/QuestionnaireExtractionTest.java
@@ -19,7 +19,7 @@ import org.junit.Test;
 public class QuestionnaireExtractionTest {
 
     @Test
-    public void canDetermineIsActualQuestionnaire() {
+    public void shouldBeAbleToDetermineThatQuestionnaireEntryIsAQuestionnaire() {
         assertTrue(QuestionnaireExtraction.isActualQuestionnaire(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_5())));
         assertTrue(QuestionnaireExtraction.isActualQuestionnaire(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_4())));
         assertTrue(QuestionnaireExtraction.isActualQuestionnaire(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_3())));
@@ -33,7 +33,86 @@ public class QuestionnaireExtractionTest {
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_5() {
+    public void shouldBeAbleToHandleMissingGENAYASubjectNumberFromQuestionnaire() {
+        QuestionnaireEntry entryWithMissingSubjectNumber =
+                entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_6().replace("GENAYA subjectno: GAYA-01-02-9999", ""));
+
+        Questionnaire questionnaire = QuestionnaireExtraction.extract(entryWithMissingSubjectNumber);
+
+        assertNull(questionnaire.genayaSubjectNumber());
+    }
+
+    @Test
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_6() {
+        Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_6()));
+
+        assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
+        assertEquals("ovary", questionnaire.tumorLocation());
+        assertEquals("serous", questionnaire.tumorType());
+        assertEquals("lymph node", questionnaire.biopsyLocation());
+
+        List<String> treatmentHistory = questionnaire.treatmentHistoryCurrentTumor();
+        assertEquals(2, treatmentHistory.size());
+        assertTrue(treatmentHistory.contains("cisplatin"));
+        assertTrue(treatmentHistory.contains("nivolumab"));
+
+        List<String> otherOncologicalHistory = questionnaire.otherOncologicalHistory();
+        assertEquals(1, otherOncologicalHistory.size());
+        assertTrue(otherOncologicalHistory.contains("surgery"));
+
+        List<String> secondaryPrimaries = questionnaire.secondaryPrimaries();
+        assertEquals(1, secondaryPrimaries.size());
+        assertTrue(secondaryPrimaries.contains("sarcoma | Feb 2020"));
+
+        List<String> nonOncologicalHistory = questionnaire.nonOncologicalHistory();
+        assertEquals(1, nonOncologicalHistory.size());
+        assertTrue(nonOncologicalHistory.contains("diabetes"));
+
+        assertEquals(TumorStage.IV, questionnaire.stage());
+        assertTrue(questionnaire.hasMeasurableDisease());
+        assertTrue(questionnaire.hasBrainLesions());
+        assertTrue(questionnaire.hasActiveBrainLesions());
+        assertNull(questionnaire.hasCnsLesions());
+        assertNull(questionnaire.hasActiveCnsLesions());
+        assertFalse(questionnaire.hasBoneLesions());
+        assertFalse(questionnaire.hasLiverLesions());
+
+        List<String> otherLesions = questionnaire.otherLesions();
+        assertEquals(2, otherLesions.size());
+        assertTrue(otherLesions.contains("pulmonal"));
+        assertTrue(otherLesions.contains("abdominal"));
+
+        List<String> ihcTestResults = questionnaire.ihcTestResults();
+        assertEquals(1, ihcTestResults.size());
+        assertTrue(ihcTestResults.contains("ERBB2 3+"));
+
+        List<String> pdl1TestResults = questionnaire.pdl1TestResults();
+        assertEquals(1, pdl1TestResults.size());
+        assertTrue(pdl1TestResults.contains("Positive"));
+
+        assertEquals(0, (int) questionnaire.whoStatus());
+        List<String> unresolvedToxicities = questionnaire.unresolvedToxicities();
+        assertEquals(1, unresolvedToxicities.size());
+        assertTrue(unresolvedToxicities.contains("toxic"));
+
+        InfectionStatus infectionStatus = questionnaire.infectionStatus();
+        assertNotNull(infectionStatus);
+        assertFalse(infectionStatus.hasActiveInfection());
+
+        ECG ecg = questionnaire.ecg();
+        assertNotNull(ecg);
+        assertTrue(ecg.hasSigAberrationLatestECG());
+        assertEquals("Sinus", ecg.aberrationDescription());
+
+        List<String> complications = questionnaire.complications();
+        assertEquals(1, complications.size());
+        assertTrue(complications.contains("vomit"));
+
+        assertEquals("GAYA-01-02-9999", questionnaire.genayaSubjectNumber());
+    }
+
+    @Test
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_5() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_5()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -97,10 +176,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("vomit"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_4() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_4() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_4()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -156,10 +237,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("nausea"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_3() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_3() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_3()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -213,10 +296,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("nausea"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_2() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_2() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_2()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -270,10 +355,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("nausea"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_1() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_1() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_1()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -327,10 +414,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("nausea"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV1_0() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV1_0() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV1_0()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -385,10 +474,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("ascites"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV0_2() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV0_2() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV0_2()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -436,10 +527,12 @@ public class QuestionnaireExtractionTest {
         List<String> complications = questionnaire.complications();
         assertEquals(1, complications.size());
         assertTrue(complications.contains("pleural effusion"));
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test
-    public void canExtractFromQuestionnaireV0_1() {
+    public void shouldBeAbleToExtractDataFromQuestionnaireV0_1() {
         Questionnaire questionnaire = QuestionnaireExtraction.extract(entry(TestQuestionnaireFactory.createTestQuestionnaireValueV0_1()));
 
         assertEquals(LocalDate.of(2020, 8, 28), questionnaire.date());
@@ -487,6 +580,8 @@ public class QuestionnaireExtractionTest {
         assertEquals("No", ecg.aberrationDescription());
 
         assertTrue(questionnaire.complications().isEmpty());
+
+        assertNull(questionnaire.genayaSubjectNumber());
     }
 
     @Test

--- a/clinical/src/test/java/com/hartwig/actin/clinical/feed/questionnaire/TestQuestionnaireFactory.java
+++ b/clinical/src/test/java/com/hartwig/actin/clinical/feed/questionnaire/TestQuestionnaireFactory.java
@@ -36,7 +36,7 @@ public final class TestQuestionnaireFactory {
                 + "\n"
                 + "Tumor details\n"
                 + "Primary tumor location: ovary\n"
-                + "Primary tumor type serous:\n"
+                + "Primary tumor type: serous\n"
                 + "Biopsy location: lymph node\n"
                 + "Stage: 4\n"
                 + "CNS lesions:\n"


### PR DESCRIPTION
Have already merged the actual fix into master to address the immediate issue. 

With hindsight it does not relate so much to John's initial comments on v1.6 support which was to make keys optional. This fix involves making values optional, for a key that we expect to be there in a questionnaire.