### PR TITLE
ACTIN-274: Support SERVE v2.4.0 datamodel in ACTIN

### DIFF
--- a/molecular/src/test/java/com/hartwig/actin/molecular/orange/evidence/actionability/ActionableEventMatcherFactoryTest.java
+++ b/molecular/src/test/java/com/hartwig/actin/molecular/orange/evidence/actionability/ActionableEventMatcherFactoryTest.java
@@ -47,7 +47,8 @@ public class ActionableEventMatcherFactoryTest {
                 .addHotspots(hotspot("gene 1", "external", Knowledgebase.ICLUSION))
                 .addHotspots(hotspot("gene 2", "internal", Knowledgebase.ICLUSION))
                 .addHotspots(hotspot("gene 3", "external", Knowledgebase.CKB))
-                .addRanges(TestServeActionabilityFactory.rangeBuilder().from(base).build())
+                .addCodons(TestServeActionabilityFactory.rangeBuilder().from(base).build())
+                .addExons(TestServeActionabilityFactory.rangeBuilder().from(base).build())
                 .addGenes(TestServeActionabilityFactory.geneBuilder().from(base).build())
                 .addCharacteristics(TestServeActionabilityFactory.characteristicBuilder().from(base).build())
                 .addFusions(TestServeActionabilityFactory.fusionBuilder().from(base).build())
@@ -68,7 +69,8 @@ public class ActionableEventMatcherFactoryTest {
         assertEquals("internal", findByGene(curated.hotspots(), "gene 2"));
         assertEquals("external", findByGene(curated.hotspots(), "gene 3"));
 
-        assertEquals("actin", curated.ranges().iterator().next().treatment().name());
+        assertEquals("actin", curated.codons().iterator().next().treatment().name());
+        assertEquals("actin", curated.exons().iterator().next().treatment().name());
         assertEquals("actin", curated.genes().iterator().next().treatment().name());
         assertEquals("actin", curated.fusions().iterator().next().treatment().name());
         assertEquals("actin", curated.characteristics().iterator().next().treatment().name());

--- a/molecular/src/test/java/com/hartwig/actin/molecular/orange/evidence/actionability/TestActionableEventMatcherFactory.java
+++ b/molecular/src/test/java/com/hartwig/actin/molecular/orange/evidence/actionability/TestActionableEventMatcherFactory.java
@@ -44,7 +44,8 @@ public final class TestActionableEventMatcherFactory {
 
         ActionableEvents actionableEvents = ImmutableActionableEvents.builder()
                 .addHotspots(TestServeActionabilityFactory.hotspotBuilder().build())
-                .addRanges(TestServeActionabilityFactory.rangeBuilder().build())
+                .addCodons(TestServeActionabilityFactory.rangeBuilder().build())
+                .addExons(TestServeActionabilityFactory.rangeBuilder().build())
                 .addGenes(TestServeActionabilityFactory.geneBuilder().event(GeneEvent.DELETION).build())
                 .addGenes(TestServeActionabilityFactory.geneBuilder().event(GeneEvent.AMPLIFICATION).build())
                 .addGenes(TestServeActionabilityFactory.geneBuilder().event(GeneEvent.ANY_MUTATION).build())

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <serve.version>2.2.0</serve.version>
+        <serve.version>2.4.0</serve.version>
 
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
Refactor to reduce code duplication and mutability.

This change is not backwards-compatible with SERVE v2.2.0 so it should only be merged when v2.4.0 is released.