### PR TITLE
ACTIN-332 Build the clinical docker image

### DIFF
--- a/clinical/Dockerfile
+++ b/clinical/Dockerfile
@@ -1,14 +1,12 @@
 FROM eclipse-temurin:11-jre
 
 COPY --from=eu.gcr.io/hmf-build/common-resources-public:0.1 /data/resources/public/disease_ontology /data/resources/public/disease_ontology
-COPY --from=europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-resources:0.2 /data/resources/actin/clinical_curation /data/resources/actin/clinical_curation
 COPY --from=europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-resources:0.2 /data/resources/actin/atc_config /data/resources/actin/atc_config
 COPY --from=europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-resources:0.2 /data/resources/actin/treatment_db /data/resources/actin/treatment_db
 
 COPY target/clinical-local-SNAPSHOT-jar-with-dependencies.jar /usr/local/actin.jar
 
 ENTRYPOINT ["java", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.clinical.ClinicalIngestionApplicationKt", \
-    "-curation_directory", "/data/resources/actin/clinical_curation", \
     "-doid_json", "/data/resources/public/disease_ontology/doid.json", \
     "-atc_tsv", "/data/resources/actin/atc_config/atc_tree.tsv", \
     "-treatment_directory", "/data/resources/actin/treatment_db" \

--- a/cloudbuild-images.yaml
+++ b/cloudbuild-images.yaml
@@ -29,6 +29,11 @@ steps:
     dir: 'report'
     args: [ 'europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-evaluation', '$TAG_NAME', 'evaluation.Dockerfile' ]
 
+  - id: 'Build and push the clinical image with tag'
+    name: 'eu.gcr.io/hmf-build/docker-tag'
+    dir: 'clinical'
+    args: [ 'europe-west4-docker.pkg.dev/actin-build/build-registry-docker/actin-clinical', '$TAG_NAME', 'clinical.Dockerfile' ]
+
 options:
   machineType: 'E2_HIGHCPU_8'
 images:


### PR DESCRIPTION
Adds the build step and removes the defaulting of the curation dir, which will now be passed in as an argument at runtime (comes down from a bucket)