### PR TITLE
ACTIN-338: update experiment-type display in report

### DIFF
--- a/common/src/main/java/com/hartwig/actin/molecular/datamodel/ExperimentType.java
+++ b/common/src/main/java/com/hartwig/actin/molecular/datamodel/ExperimentType.java
@@ -1,16 +1,19 @@
 package com.hartwig.actin.molecular.datamodel;
 
-public enum ExperimentType {
-    TARGETED {
-        @Override
-        public String toString() {
-            return "Panel analysis";
-        }
-    },
-    WHOLE_GENOME {
-        @Override
-        public String toString() {
-            return "WGS";
-        }
-    }
+import com.hartwig.actin.Displayable;
+
+import org.jetbrains.annotations.NotNull;
+
+public enum ExperimentType implements Displayable {
+    TARGETED("Panel analysis"),
+    WHOLE_GENOME("WGS");
+
+    @NotNull
+    private final String display;
+
+    ExperimentType(@NotNull final String display) { this.display = display; }
+
+    @Override
+    @NotNull
+    public String display() { return display; }
 }

--- a/common/src/main/java/com/hartwig/actin/molecular/util/MolecularPrinter.java
+++ b/common/src/main/java/com/hartwig/actin/molecular/util/MolecularPrinter.java
@@ -36,7 +36,7 @@ public class MolecularPrinter {
 
     public void print(@NotNull MolecularRecord record) {
         printer.print("Sample: " + record.sampleId());
-        printer.print(" Experiment type '" + record.type() + "' on " + formatDate(record.date()));
+        printer.print(" Experiment type '" + record.type().display() + "' on " + formatDate(record.date()));
         printer.print(" Contains tumor cells: " + toYesNoUnknown(record.containsTumorCells()));
         printer.print(" Has sufficient quality and purity: " + toYesNoUnknown(record.hasSufficientQualityAndPurity()));
         printer.print(" Purity: " + formatPercentage(record.characteristics().purity()));

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
@@ -44,7 +44,7 @@ class MolecularDetailsChapter(private val report: Report) : ReportChapter {
         val table = Tables.createSingleColWithWidth(contentWidth())
         table.addCell(Cells.createEmpty())
         table.addCell(
-            Cells.createTitle("${report.molecular.type()} (${report.molecular.sampleId()}, ${date(report.molecular.date())})")
+            Cells.createTitle("${report.molecular.type().display()} (${report.molecular.sampleId()}, ${date(report.molecular.date())})")
         )
 
         val cohorts = EvaluatedCohortFactory.create(report.treatmentMatch)

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
@@ -29,7 +29,7 @@ class MolecularSummaryGenerator(
             table.addCell(Cells.create(wgsGenerator.contents()))
         } else {
             val noRecent = Tables.createFixedWidthCols(keyWidth, valueWidth)
-            noRecent.addCell(Cells.createKey(molecular.type().toString() + " results"))
+            noRecent.addCell(Cells.createKey(molecular.type().display() + " results"))
             noRecent.addCell(Cells.createValue("No successful WGS could be performed on the submitted biopsy"))
             table.addCell(Cells.create(noRecent))
         }

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/WGSSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/WGSSummaryGenerator.kt
@@ -31,7 +31,7 @@ class WGSSummaryGenerator(
         return String.format(
             ApplicationConfig.LOCALE,
             "%s of %s (%s)",
-            molecular.type(),
+            molecular.type().display(),
             clinical.patientId(),
             date(molecular.date())
         )


### PR DESCRIPTION
When swapping in the orange-datamodel from hmftools into ACTIN, Actin's own enum for ExperimentType was changed to use consistent terminology with upstream. So previously Actin used PANEL, WGS and now uses  TARGETED, WHOLE_GENOME. However these enum's appear directly in the report as text, and the new forms are not preferred there.

Rather than revert to the old enum values, and since the recommended text for PANEL is now "Panel analysis", this change just override's toString() for these enums to the desired display values. Not sure if this is the best way.