### PR TITLE
ACTIN-363: fixed upper-/lowercase issues in pass/warning messages

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasPotentialSignificantHeartDisease.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasPotentialSignificantHeartDisease.kt
@@ -5,7 +5,7 @@ import com.hartwig.actin.algo.datamodel.Evaluation
 import com.hartwig.actin.algo.doid.DoidConstants
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.util.Format.concatLowercaseWithAndAbbreviationsInCapital
+import com.hartwig.actin.algo.evaluation.util.Format.concatStringsWithAnd
 import com.hartwig.actin.algo.evaluation.util.ValueComparison.stringCaseInsensitivelyMatchesQueryCollection
 import com.hartwig.actin.algo.othercondition.OtherConditionSelector
 import com.hartwig.actin.doid.DoidModel
@@ -25,8 +25,8 @@ class HasPotentialSignificantHeartDisease internal constructor(private val doidM
 
         return if (heartConditions.isNotEmpty()) {
             EvaluationFactory.pass(
-                "Patient has " + concatLowercaseWithAndAbbreviationsInCapital(heartConditions) + " and therefore potentially significant cardiac disease",
-                "Potentially significant cardiac disease: history of " + concatLowercaseWithAndAbbreviationsInCapital(heartConditions)
+                "Patient has " + concatStringsWithAnd(heartConditions) + " and therefore potentially significant cardiac disease",
+                "Potentially significant cardiac disease: history of " + concatStringsWithAnd(heartConditions)
             )
         } else EvaluationFactory.fail(
             "Patient has no potential significant cardiac disease", "No potential significant cardiac disease"

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/PriorConditionMessages.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/PriorConditionMessages.kt
@@ -14,7 +14,7 @@ internal object PriorConditionMessages {
     }
 
     fun passGeneral(matches: Iterable<String>): String {
-        return "Patient has ${Format.concatLowercaseWithAndAbbreviationsInCapital(matches)}"
+        return "Patient has ${Format.concatStringsWithAnd(matches)}"
     }
 
     fun passSpecific(characteristic: Characteristic, matches: Iterable<String>, doidTerm: String?): String {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
@@ -26,9 +26,8 @@ object Format {
         return concatStrings(strings.map(String::lowercase), SEPARATOR_AND)
     }
 
-    fun concatLowercaseWithAndAbbreviationsInCapital(strings: Iterable<String>): String {
-        val text = concatStrings(strings.map(String::lowercase), SEPARATOR_AND)
-        return Regex("\\([^() ]*\\)").replace(text) { it.value.uppercase() }
+    fun concatStringsWithAnd(strings: Iterable<String>): String {
+        return concatStrings(strings, SEPARATOR_AND)
     }
 
     fun concatItemsWithAnd(items: Iterable<Displayable>): String {


### PR DESCRIPTION
I've added a new format function to fix the lower case abbreviations in priorConditionMessages.kt HasPotentialSignificantHeartDisease.kt  
Using regex, it now looks for a single pair of parentheses with consecutive characters and turns these into uppercase. 
I think this will cover all abbreviations, though it may lead to unintentional uppercase sometimes. 
An alternative would be to sum up all medical abbreviations we can think of somewhere, and change to uppercase when these are recognized, but this would not be exhaustive I think.

Looking forward to your feedback!