### PR TITLE
ACTIN-411 Expose uncaught exceptions to the log in a predictable way

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionApplication.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionApplication.kt
@@ -96,5 +96,10 @@ fun main(args: Array<String>) {
         exitProcess(1)
     }
 
-    ClinicalIngestionApplication(config).run()
+    try {
+        ClinicalIngestionApplication(config).run()
+    } catch (e: Exception) {
+        ClinicalIngestionApplication.LOGGER.error("${ClinicalIngestionApplication.APPLICATION} failed on an unrecoverable error [${e.message}]", e)
+        exitProcess(1)
+    }
 }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/TreatmentHistoryEntryConfigFactory.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/TreatmentHistoryEntryConfigFactory.kt
@@ -8,7 +8,6 @@ import com.hartwig.actin.clinical.datamodel.ObservedToxicity
 import com.hartwig.actin.clinical.datamodel.treatment.ImmutableDrugTreatment
 import com.hartwig.actin.clinical.datamodel.treatment.ImmutableOtherTreatment
 import com.hartwig.actin.clinical.datamodel.treatment.ImmutableRadiotherapy
-import com.hartwig.actin.clinical.datamodel.treatment.Treatment
 import com.hartwig.actin.clinical.datamodel.treatment.history.ImmutableTreatmentHistoryDetails
 import com.hartwig.actin.clinical.datamodel.treatment.history.ImmutableTreatmentHistoryEntry
 import com.hartwig.actin.clinical.datamodel.treatment.history.Intent
@@ -17,14 +16,12 @@ import com.hartwig.actin.clinical.datamodel.treatment.history.TreatmentHistoryEn
 import com.hartwig.actin.clinical.datamodel.treatment.history.TreatmentResponse
 import com.hartwig.actin.util.ResourceFile
 import com.hartwig.actin.util.json.GsonSerializer
-import org.apache.logging.log4j.LogManager
 import java.util.*
 
 class TreatmentHistoryEntryConfigFactory(
     private val treatmentDatabase: TreatmentDatabase
 ) : CurationConfigFactory<TreatmentHistoryEntryConfig> {
 
-    private val logger = LogManager.getLogger(TreatmentHistoryEntryConfigFactory::class.java)
     private val gson = GsonSerializer.create()
 
     override fun create(fields: Map<String, Int>, parts: Array<String>): TreatmentHistoryEntryConfig {
@@ -46,8 +43,7 @@ class TreatmentHistoryEntryConfigFactory(
             val treatmentsByName = CurationUtil.toSet(treatmentName).associateWith(treatmentDatabase::findTreatmentByName)
             val unknownTreatmentNames = treatmentsByName.filterValues(Objects::isNull).keys
             if (unknownTreatmentNames.isNotEmpty()) {
-                unknownTreatmentNames.forEach(::logMissingTreatmentMessage)
-                throw IllegalStateException("Unable to resolve the following treatment(s): ${unknownTreatmentNames.joinToString(", ")}.")
+                throw missingTreatmentException(unknownTreatmentNames)
             }
             treatmentsByName.values
         }
@@ -91,24 +87,6 @@ class TreatmentHistoryEntryConfigFactory(
             .build()
     }
 
-    private fun logMissingTreatmentMessage(treatmentName: String): Treatment? {
-        val formattedTreatmentName = treatmentName.replace(" ", "_").uppercase()
-        logger.warn("  Treatment with name $formattedTreatmentName does not exist in database. Please add with one of the following templates:")
-
-        listOf(
-            ImmutableDrugTreatment.builder().name(formattedTreatmentName).synonyms(emptySet()).isSystemic(false).drugs(emptySet()).build(),
-            ImmutableRadiotherapy.builder().name(formattedTreatmentName).synonyms(emptySet()).isSystemic(false).build(),
-            ImmutableOtherTreatment.builder().name(formattedTreatmentName).synonyms(emptySet()).isSystemic(false).categories(emptySet())
-                .build()
-        ).forEach {
-            val treatmentProposal = gson.toJson(it).replace("isSystemic\":false", "isSystemic\":?")
-                .replace("\"displayOverride\":null,", "")
-                .replace("\"maxCycles\":null,", "")
-            logger.warn("    $treatmentProposal,")
-        }
-        return null
-    }
-
     private fun optionalIntegerFromColumn(parts: List<String>, fields: Map<String, Int>, colName: String): Int? {
         return optionalObjectFromColumn(parts, fields, colName, ResourceFile::optionalInteger)
     }
@@ -132,5 +110,22 @@ class TreatmentHistoryEntryConfigFactory(
 
     private fun <T> stringToEnum(input: String, enumCreator: (String) -> T): T {
         return enumCreator(input.uppercase().replace(" ", "_"))
+    }
+
+    private fun missingTreatmentException(treatments: Set<String>): IllegalStateException {
+        return IllegalStateException(treatments.map { it.replace(" ", "_").uppercase() }.map {
+            "Treatment with name $it does not exist in database. Please add with one of the following templates: \n" + listOf(
+                ImmutableDrugTreatment.builder().name(it).synonyms(emptySet()).isSystemic(false).drugs(emptySet())
+                    .build(),
+                ImmutableRadiotherapy.builder().name(it).synonyms(emptySet()).isSystemic(false).build(),
+                ImmutableOtherTreatment.builder().name(it).synonyms(emptySet()).isSystemic(false)
+                    .categories(emptySet())
+                    .build()
+            ).map { templates ->
+                gson.toJson(templates).replace("isSystemic\":false", "isSystemic\":?")
+                    .replace("\"displayOverride\":null,", "")
+                    .replace("\"maxCycles\":null,", "")
+            }
+        }.joinToString(","))
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/config/TreatmentHistoryEntryConfigFactoryTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/config/TreatmentHistoryEntryConfigFactoryTest.kt
@@ -5,6 +5,7 @@ import com.hartwig.actin.clinical.datamodel.treatment.history.ImmutableTreatment
 import com.hartwig.actin.clinical.datamodel.treatment.history.ImmutableTreatmentHistoryEntry
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatExceptionOfType
+import org.junit.Assert.assertThrows
 import org.junit.Test
 
 class TreatmentHistoryEntryConfigFactoryTest {
@@ -20,7 +21,12 @@ class TreatmentHistoryEntryConfigFactoryTest {
                 "startYear" to "2022"
             )
         )
-        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { factory.create(fields, parts) }
+        assertThat(assertThrows(IllegalStateException::class.java) {
+            factory.create(fields, parts)
+        }.message).isEqualTo("Treatment with name UNKNOWN_THERAPY does not exist in database. Please add with one of the following templates: \n" +
+                "[{\"name\":\"UNKNOWN_THERAPY\",\"synonyms\":[],\"isSystemic\":?,\"drugs\":[],\"treatmentClass\":\"DRUG_TREATMENT\"}, {\"name\":\"UNKNOWN_THERAPY\"," +
+                "\"synonyms\":[],\"isSystemic\":?,\"radioType\":null,\"isInternal\":null,\"treatmentClass\":\"RADIOTHERAPY\"}, {\"name\":\"UNKNOWN_THERAPY\",\"categories\":[]," +
+                "\"synonyms\":[],\"isSystemic\":?,\"types\":[],\"treatmentClass\":\"OTHER_TREATMENT\"}]")
     }
 
     @Test
@@ -82,7 +88,12 @@ class TreatmentHistoryEntryConfigFactoryTest {
                 "isTrial" to "1"
             )
         )
-        assertThatExceptionOfType(IllegalStateException::class.java).isThrownBy { factory.create(fields, parts) }
+        assertThat(assertThrows(IllegalStateException::class.java) {
+            factory.create(fields, parts)
+        }.message).isEqualTo("Treatment with name TRIAL_NAME does not exist in database. Please add with one of the following templates: \n" +
+                "[{\"name\":\"TRIAL_NAME\",\"synonyms\":[],\"isSystemic\":?,\"drugs\":[],\"treatmentClass\":\"DRUG_TREATMENT\"}, {\"name\":\"TRIAL_NAME\"," +
+                "\"synonyms\":[],\"isSystemic\":?,\"radioType\":null,\"isInternal\":null,\"treatmentClass\":\"RADIOTHERAPY\"}, {\"name\":\"TRIAL_NAME\"," +
+                "\"categories\":[],\"synonyms\":[],\"isSystemic\":?,\"types\":[],\"treatmentClass\":\"OTHER_TREATMENT\"}]")
     }
 
     @Test


### PR DESCRIPTION
Tried first to expand the results.json to include more failure modes, but the ways things can fail are spread out between the parsing of inputs, construction of models, and the execution of models themselves.

So to be comprehensive instead ensured that we actually catch all exceptions and predictably log the error message (and exit 1). Pipelines can then properly handle the failure by presenting the unexpected ERROR to the user.