### PR TITLE
ACTIN-445: improved warning message for CNS metastases

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownActiveCnsMetastases.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownActiveCnsMetastases.kt
@@ -34,8 +34,8 @@ class HasKnownActiveCnsMetastases : EvaluationFunction {
 
             hasActiveBrainMetastases == true ->
                 EvaluationFactory.pass(
-                    "Active CNS metastases are present (Brain)",
-                    "Active CNS metastases (Brain)"
+                    "Active CNS (Brain) metastases are present",
+                    "Active CNS (Brain) metastases"
                 )
 
             else ->

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownCnsMetastases.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownCnsMetastases.kt
@@ -26,7 +26,7 @@ class HasKnownCnsMetastases : EvaluationFunction {
             EvaluationFactory.fail("No known CNS metastases present", "No known CNS metastases")
         } else {
             if (hasAtLeastActiveBrainMetastases) {
-                EvaluationFactory.pass("CNS metastases (Brain) are present", "CNS metastases (Brain)")
+                EvaluationFactory.pass("CNS (Brain) metastases are present", "CNS (Brain) metastases")
             } else {
                 EvaluationFactory.pass("CNS metastases are present", "CNS metastases")
             }


### PR DESCRIPTION
Logic: Brain is category of CNS, not the other way around. Thus, when a function checks for (active) CNS metastases, the warning should be `EvaluationFactory.pass("CNS metastases (Brain) are present", "CNS metastases (Brain)")` in case of brain metastases.