### PR TITLE
ACTIN-446: improved warning message for ECG abnormalities and potenti…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasECGAberration.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasECGAberration.kt
@@ -9,21 +9,21 @@ class HasECGAberration internal constructor() : EvaluationFunction {
     override fun evaluate(record: PatientRecord): Evaluation {
         val ecg = record.clinical().clinicalStatus().ecg()
             ?: return EvaluationFactory.fail(
-                "ECG details are missing, it is assumed there are no abnormalities",
+                "ECG details are missing - it is assumed there are no abnormalities",
                 "Assumed no ECG abnormalities"
             )
         return when {
             ecg.hasSigAberrationLatestECG() && ecg.aberrationDescription() != null -> {
                 EvaluationFactory.pass(
                     "Patient has known ECG abnormalities: " + ecg.aberrationDescription(),
-                    "Present ECG abnormalities: " + ecg.aberrationDescription()
+                    "ECG abnormalities: " + ecg.aberrationDescription()
                 )
             }
 
             ecg.hasSigAberrationLatestECG() -> {
                 EvaluationFactory.pass(
-                    "Patient has present ECG abnormalities, but aberration details unknown",
-                    "Present ECG abnormalities (details unknown)"
+                    "Patient has ECG abnormalities (details unknown)",
+                    "ECG abnormalities present (details unknown)"
                 )
             }
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasPotentialSignificantHeartDisease.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/cardiacfunction/HasPotentialSignificantHeartDisease.kt
@@ -15,8 +15,8 @@ class HasPotentialSignificantHeartDisease internal constructor(private val doidM
         val ecg = record.clinical().clinicalStatus().ecg()
         if (ecg != null && ecg.hasSigAberrationLatestECG()) {
             return EvaluationFactory.pass(
-                "Patient has significant aberration on latest ECG and therefore potentially significant cardiac disease",
-                "Potentially significant cardiac disease: present ECG aberrations"
+                "Patient has an abnormality on latest ECG and therefore potentially significant cardiac disease",
+                "Potentially significant cardiac disease (ECG abnormalities present)"
             )
         }
         val heartConditions = OtherConditionSelector.selectClinicallyRelevant(record.clinical().priorOtherConditions())


### PR DESCRIPTION
…al heart disease

Changes:
- Better readable / messages more clear
- Although aberration is correct in English, abnormality would be a better term for the messages, since there's also a conduction disorder called "aberrant conduction". Hence, ECG aberration could be confused with this specific condition, in stead of a general abnormality on the ECG.
- Removed some commas in specific messages