### PR TITLE
ACTIN-464: change COVID-19 evaluation to recoverable undetermined to …

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/infection/MeetsCovid19InfectionRequirements.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/infection/MeetsCovid19InfectionRequirements.kt
@@ -7,7 +7,7 @@ import com.hartwig.actin.algo.evaluation.EvaluationFunction
 
 class MeetsCovid19InfectionRequirements internal constructor() : EvaluationFunction {
     override fun evaluate(record: PatientRecord): Evaluation {
-        return EvaluationFactory.undetermined(
+        return EvaluationFactory.recoverableUndetermined(
             "Currently COVID-19 infection status cannot be determined",
             "COVID-19 infection status unknown"
         )


### PR DESCRIPTION
…prevent the warning from showing on report