### PR TITLE
ACTIN-481 Fix issues with reporting of unused configs

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabase.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabase.kt
@@ -18,10 +18,10 @@ class CurationDatabase<T : CurationConfig>(
 
     fun reportUnusedConfig(evaluations: List<ExtractionEvaluation>): List<UnusedCurationConfig> {
         val evaluatedInputs = evaluations.flatMap(evaluatedInputFunction)
-        return configs.values.flatten()
-            .filter { !evaluatedInputs.contains(it.input) }
+        return configs.keys
+            .filter { !evaluatedInputs.contains(it) }
             .map {
-                UnusedCurationConfig(category.categoryName, it.input)
+                UnusedCurationConfig(category.categoryName, it)
             }
     }
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabaseContext.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabaseContext.kt
@@ -82,13 +82,10 @@ data class CurationDatabaseContext(
             molecularTestCuration,
             medicationNameCuration,
             medicationDosageCuration,
-            intoleranceCuration,
-            cypInteractionCuration,
-            qtProlongingCuration
+            intoleranceCuration
         ).flatMap { it.reportUnusedConfig(extractionEvaluations) }.toSet() + listOf(
             laboratoryTranslation,
             administrationRouteTranslation,
-            bloodTransfusionTranslation,
             toxicityTranslation,
             dosageUnitTranslation
         ).flatMap { it.reportUnusedTranslations(extractionEvaluations) }
@@ -136,7 +133,7 @@ data class CurationDatabaseContext(
                 curationDir,
                 CurationDatabaseReader.COMPLICATION_TSV,
                 ComplicationConfigFactory(),
-                CurationCategory.NON_ONCOLOGICAL_HISTORY
+                CurationCategory.COMPLICATION
             ) { it.nonOncologicalHistoryEvaluatedInputs },
             intoleranceCuration = CurationDatabaseReader.read(
                 curationDir,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/translation/TranslationDatabase.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/translation/TranslationDatabase.kt
@@ -13,9 +13,9 @@ class TranslationDatabase<T>(
 
     fun reportUnusedTranslations(evaluations: List<ExtractionEvaluation>): List<UnusedCurationConfig> {
         val evaluatedInputs = evaluations.flatMap(evaluatedInputFunction).map { it.input }
-        return translations.values.filter { !evaluatedInputs.contains(it.input) }
+        return translations.keys.filter { !evaluatedInputs.contains(it) }
             .map {
-                UnusedCurationConfig(category.categoryName, it.input.toString())
+                UnusedCurationConfig(category.categoryName, it.toString())
             }
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionTest.kt
@@ -52,5 +52,10 @@ class ClinicalIngestionTest {
         assertThat(patientResults[0].patientId).isEqualTo("ACTN01029999")
         assertThat(patientResults[0].curationResults).isEmpty()
         assertThat(patientResults[0].clinicalRecord).isEqualTo(ClinicalRecordJson.read(EXPECTED_CLINICAL_RECORD))
+
+        assertThat(ingestionResult.unusedConfigs).containsExactly(
+            UnusedCurationConfig(categoryName = "Molecular Test", input = "ihc erbb2 3+"),
+            UnusedCurationConfig(categoryName = "Dosage Unit Translation", input = "stuk")
+        )
     }
 }

--- a/clinical/src/test/resources/curation/complication.tsv
+++ b/clinical/src/test/resources/curation/complication.tsv
@@ -1,2 +1,1 @@
-input	impliesUnknownComplicationState	name	categories	year	month
-something	0	curated something	category1; category2	2000	1			
+input	impliesUnknownComplicationState	name	categories	year	month	

--- a/clinical/src/test/resources/curation/infection.tsv
+++ b/clinical/src/test/resources/curation/infection.tsv
@@ -1,2 +1,1 @@
 input	interpretation
-YES lung abces	Lung abscess

--- a/clinical/src/test/resources/curation/lesion_location.tsv
+++ b/clinical/src/test/resources/curation/lesion_location.tsv
@@ -1,2 +1,1 @@
 input	location	category
-Lever	Liver	Liver

--- a/clinical/src/test/resources/curation/oncological_history.tsv
+++ b/clinical/src/test/resources/curation/oncological_history.tsv
@@ -1,2 +1,1 @@
-input	name	treatmentName	bodyLocations	bodyLocationCategories	intents	startYear	startMonth	stopYear	stopMonth	cycles	bestResponse	stopReason	category	isSystemic	chemoType	immunoType	targetedType	hormoneType	radioType	carTType	transplantType	supportiveType	trialAcronym	ablationType
-Capecitabine/Oxaliplatin 2020-2021	Capecitabine+Oxaliplatin	Capecitabine+Oxaliplatin			PALLIATIVE	2020		2021		6	PR	toxicity	Chemotherapy	1	antimetabolite,platinum									
+input	name	treatmentName	bodyLocations	bodyLocationCategories	intents	startYear	startMonth	stopYear	stopMonth	cycles	bestResponse	stopReason	category	isSystemic	chemoType	immunoType	targetedType	hormoneType	radioType	carTType	transplantType	supportiveType	trialAcronym	ablationType								

--- a/clinical/src/test/resources/curation/period_between_unit_interpretation.tsv
+++ b/clinical/src/test/resources/curation/period_between_unit_interpretation.tsv
@@ -1,2 +1,1 @@
 input	interpretation
-mo	months

--- a/clinical/src/test/resources/curation/second_primary.tsv
+++ b/clinical/src/test/resources/curation/second_primary.tsv
@@ -1,2 +1,1 @@
 input	name	tumorLocation	tumorSubLocation	tumorType	tumorSubType	doids	diagnosedYear	diagnosedMonth	treatmentHistory	lastTreatmentYear	lastTreatmentMonth	status
-basaalcelcarcinoom (2014) | 2014	Basal cell carcinoma			Carcinoma	Basal cell carcinoma	2513	2014	1	None	2014	2	INACTIVE


### PR DESCRIPTION
Compare against the keys of the maps (which have been lowercased) instead of the input in the config/translation.

Added an example unused warning to ClinicalIngestionTest for each of curation databases and translations. All other unused configs are removed from the test curation files, for now. May add them again to make the test more comprehensive but that is not in scope of this change. The curation loading is now fully unit tested. 