### PR TITLE
ACTIN-517: Clarify validation warning

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/ctc/CTCModel.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/ctc/CTCModel.kt
@@ -53,7 +53,7 @@ class CTCModel(private val ctcDatabase: CTCDatabase) {
         trialDefinitionValidationErrors.add(
             TrialDefinitionValidationError(
                 trialConfig,
-                "No study status found in CTC for trial"
+                "No study status found in CTC overview, using manually configured status for study status"
             )
         )
         return null


### PR DESCRIPTION
"No study status found in CTC for trial" is a vague warning. We use manually configured status in these cases (if configured), which is best we can do. This is now clarified in the warning.