### PR TITLE
 ACTIN-566: Configured HAS_MEASURED_CREATININE_CLEARANCE_OF_AT_LEAST_…

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/interpretation/EligibilityRuleUsageEvaluator.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/interpretation/EligibilityRuleUsageEvaluator.kt
@@ -83,7 +83,8 @@ object EligibilityRuleUsageEvaluator {
         EligibilityRule.HAS_HAD_LOCAL_HEPATIC_THERAPY_WITHIN_X_WEEKS,
         EligibilityRule.HAS_PHOSPHORUS_MMOL_PER_L_OF_AT_MOST_X,
         EligibilityRule.HAS_FAMILY_HISTORY_OF_LONG_QT_SYNDROME,
-        EligibilityRule.HAS_IRRADIATION_AMENABLE_LESION
+        EligibilityRule.HAS_IRRADIATION_AMENABLE_LESION,
+        EligibilityRule.HAS_MEASURED_CREATININE_CLEARANCE_OF_AT_LEAST_X
     )
 
     fun evaluate(trials: List<Trial>) {


### PR DESCRIPTION
…X as unused rule to keep