### PR TITLE
ACTIN-677: No "with switch to" displayed in treatment history on repo…

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -142,9 +142,8 @@ class PatientClinicalHistoryGenerator(private val record: ClinicalRecord, privat
                 treatmentHistoryEntry.treatmentDisplay() + if (annotation.isEmpty()) "" else " ($annotation)",
                 treatmentHistoryEntry.treatmentHistoryDetails?.let { details ->
                     if (details.switchToTreatments.isNullOrEmpty()) "" else {
-                        " with switch to " + details.switchToTreatments!!.joinToString(" then ") {
-                            it.treatment.display() + it.cycles?.let { cycles -> " (${cycles} cycles)"
-                            }
+                        details.switchToTreatments!!.joinToString(prefix = "with switch to ", separator = " then ") {
+                            it.treatment.display() + it.cycles?.let { cycles -> " (${cycles} cycles)" }
                         }
                     }
                 },


### PR DESCRIPTION
…rt, if switchToTreatments is an empty list

In the report from the new hospital we are currently working with (not sure if I can mention the name here), "with switch to" is mentioned in every treatment in clinical summary. This is due to the fact that switchToTreatments is an empty list instead of null. I've changed the code, so that with an empty list this message won't appear anymore.
It works as expected when I use `TestClinicalFactory` + `TestReportWriterApplication`