### PR TITLE
ACTIN-678: always put trial acronym on next row, after trialID

### DIFF
--- a/common/src/test/kotlin/com/hartwig/actin/algo/datamodel/TestTreatmentMatchFactory.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/algo/datamodel/TestTreatmentMatchFactory.kt
@@ -32,7 +32,7 @@ object TestTreatmentMatchFactory {
         return listOf(
             TrialMatch(
                 identification = TrialIdentification(
-                    trialId = "Test 1",
+                    trialId = "Test Trial 1",
                     open = true,
                     acronym = "TEST-1",
                     title = "Example test trial 1"


### PR DESCRIPTION
This implementation works on the test report, when changing `Test Trial 1` to `Test 1` in TestTreatmentMatchFactory (changed it back to prevent failure of some unrelated tests) -> before this change it would result to `Test 1TEST-1` on the report, after the change:
```
Test 1
TEST-1
```