### PR TITLE
ACTIN-478 Subjects sanitised on the way in

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionConfig.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionConfig.kt
@@ -50,7 +50,7 @@ data class ClinicalIngestionConfig(
             options.addOption(
                 FEED_FORMAT,
                 true,
-                "The format of the feed. Accepted values [${FeedFormat.values().joinToString()}]. Default is EMC_TSV"
+                "The format of the feed. Accepted values [${FeedFormat.values().joinToString()}]. Default is ${FeedFormat.EMC_TSV.name}."
             )
             return options
         }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -59,13 +59,12 @@ class EmcClinicalFeedIngestor(
         val processedPatientIds: MutableSet<String> = HashSet()
 
         LOGGER.info("Creating clinical model")
-        return feed.subjects().map { subject ->
-            val patientId = subject.replace("-".toRegex(), "")
+        return feed.subjects().map { patientId ->
             check(!processedPatientIds.contains(patientId)) { "Cannot create clinical records. Duplicate patientId: $patientId" }
             processedPatientIds.add(patientId)
             LOGGER.info(" Extracting and curating data for patient {}", patientId)
 
-            val (questionnaire, questionnaireCurationErrors) = QuestionnaireExtraction.extract(feed.latestQuestionnaireEntry(subject))
+            val (questionnaire, questionnaireCurationErrors) = QuestionnaireExtraction.extract(feed.latestQuestionnaireEntry(patientId))
             val tumorExtraction = tumorDetailsExtractor.extract(patientId, questionnaire)
             val complicationsExtraction = complicationsExtractor.extract(patientId, questionnaire)
             val clinicalStatusExtraction =
@@ -74,15 +73,15 @@ class EmcClinicalFeedIngestor(
             val priorSecondPrimaryExtraction = priorSecondPrimaryExtractor.extract(patientId, questionnaire)
             val priorOtherConditionsExtraction = priorOtherConditionExtractor.extract(patientId, questionnaire)
             val priorMolecularTestsExtraction = priorMolecularTestsExtractor.extract(patientId, questionnaire)
-            val labValuesExtraction = labValueExtractor.extract(patientId, feed.labEntries(subject).map { LabExtraction.extract(it) })
-            val toxicityExtraction = toxicityExtractor.extract(patientId, feed.toxicityEntries(subject), questionnaire)
-            val intoleranceExtraction = intoleranceExtractor.extract(patientId, feed.intoleranceEntries(subject))
-            val bloodTransfusionsExtraction = bloodTransfusionsExtractor.extract(patientId, feed.bloodTransfusionEntries(subject))
-            val medicationExtraction = medicationExtractor.extract(patientId, feed.medicationEntries(subject))
+            val labValuesExtraction = labValueExtractor.extract(patientId, feed.labEntries(patientId).map { LabExtraction.extract(it) })
+            val toxicityExtraction = toxicityExtractor.extract(patientId, feed.toxicityEntries(patientId), questionnaire)
+            val intoleranceExtraction = intoleranceExtractor.extract(patientId, feed.intoleranceEntries(patientId))
+            val bloodTransfusionsExtraction = bloodTransfusionsExtractor.extract(patientId, feed.bloodTransfusionEntries(patientId))
+            val medicationExtraction = medicationExtractor.extract(patientId, feed.medicationEntries(patientId))
 
             val record = ClinicalRecord(
                 patientId = patientId,
-                patient = extractPatientDetails(subject, questionnaire),
+                patient = extractPatientDetails(patientId, questionnaire),
                 tumor = tumorExtraction.extracted,
                 complications = complicationsExtraction.extracted,
                 clinicalStatus = clinicalStatusExtraction.extracted,
@@ -93,9 +92,9 @@ class EmcClinicalFeedIngestor(
                 labValues = labValuesExtraction.extracted,
                 toxicities = toxicityExtraction.extracted,
                 intolerances = intoleranceExtraction.extracted,
-                surgeries = extractSurgeries(subject),
-                bodyWeights = extractBodyWeights(subject),
-                vitalFunctions = extractVitalFunctions(subject),
+                surgeries = extractSurgeries(patientId),
+                bodyWeights = extractBodyWeights(patientId),
+                vitalFunctions = extractVitalFunctions(patientId),
                 bloodTransfusions = bloodTransfusionsExtraction.extracted,
                 medications = medicationExtraction.extracted
             )
@@ -123,7 +122,7 @@ class EmcClinicalFeedIngestor(
                     record,
                     patientEvaluation.warnings.toList(),
                     questionnaireCurationErrors.toSet(),
-                    feed.validationWarnings(subject)
+                    feed.validationWarnings(patientId)
                 ), patientEvaluation
             )
         }
@@ -157,7 +156,7 @@ class EmcClinicalFeedIngestor(
     }
 
     private fun bodyWeightIsValid(entry: BodyWeightEntry): Boolean {
-        return entry.valueQuantityUnit.lowercase() == "kilogram" && entry.valueQuantityValue in BODY_WEIGHT_MIN..BODY_WEIGHT_MAX
+        return entry.valueQuantityUnit.lowercase() == BODY_WEIGHT_EXPECTED_UNIT && entry.valueQuantityValue in BODY_WEIGHT_MIN..BODY_WEIGHT_MAX
     }
 
     private fun extractVitalFunctions(subject: String): List<VitalFunction> {
@@ -240,6 +239,7 @@ class EmcClinicalFeedIngestor(
 
         const val BODY_WEIGHT_MIN = 20.0
         const val BODY_WEIGHT_MAX = 300.0
+        const val BODY_WEIGHT_EXPECTED_UNIT = "kilogram"
         const val HEART_RATE_MIN = 10.0
         const val HEART_RATE_MAX = 300.0
         const val HEART_RATE_EXPECTED_UNIT = "bpm"

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/FeedFileReader.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/FeedFileReader.kt
@@ -11,12 +11,12 @@ import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvParser
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import org.apache.logging.log4j.LogManager
 import java.io.File
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.Temporal
+import org.apache.logging.log4j.LogManager
 
 class FeedTemporalDeserializer<T : Temporal>(private val parser: (String, DateTimeFormatter) -> T?) : JsonDeserializer<T?>() {
     companion object {
@@ -54,6 +54,12 @@ class FeedStringDeserializer : JsonDeserializer<String>() {
         } else {
             cleanInput
         }
+    }
+}
+
+class FeedSubjectDeserializer : JsonDeserializer<String>() {
+    override fun deserialize(p: JsonParser, ctxt: DeserializationContext): String {
+        return p.text.replace("-".toRegex(), "")
     }
 }
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/bodyweight/BodyWeightEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/bodyweight/BodyWeightEntry.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.EuropeanDecimalDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedValidation
 import com.hartwig.actin.clinical.feed.emc.FeedValidator
 import java.time.LocalDateTime
@@ -12,6 +13,7 @@ import java.time.LocalDateTime
 @JacksonSerializable
 data class BodyWeightEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
 
     @JsonProperty("valueQuantity_value")

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/digitalfile/DigitalFileEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/digitalfile/DigitalFileEntry.kt
@@ -1,13 +1,16 @@
 package com.hartwig.actin.clinical.feed.emc.digitalfile
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import java.time.LocalDate
 
 @JacksonSerializable
 data class DigitalFileEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
     @JsonProperty("authored")
     val authored: LocalDate,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/intolerance/IntoleranceEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/intolerance/IntoleranceEntry.kt
@@ -1,13 +1,16 @@
 package com.hartwig.actin.clinical.feed.emc.intolerance
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import java.time.LocalDate
 
 @JacksonSerializable
 data class IntoleranceEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
     @JsonProperty("assertedDate")
     val assertedDate: LocalDate,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/lab/LabEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/lab/LabEntry.kt
@@ -5,11 +5,13 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.EuropeanDecimalDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import java.time.LocalDate
 
 @JacksonSerializable
 data class LabEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
 
     @JsonProperty("code_code_original")

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/medication/MedicationEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/medication/MedicationEntry.kt
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.EuropeanDecimalDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import java.time.LocalDate
 
 class ActiveDeserializer : JsonDeserializer<Boolean>() {
@@ -26,6 +27,7 @@ class ActiveDeserializer : JsonDeserializer<Boolean>() {
 @JacksonSerializable
 data class MedicationEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
 
     @JsonProperty("code_text")

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/patient/PatientEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/patient/PatientEntry.kt
@@ -1,15 +1,24 @@
 package com.hartwig.actin.clinical.feed.emc.patient
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.datamodel.Gender
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import java.time.LocalDate
 
 @JacksonSerializable
 data class PatientEntry(
+    @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
+    @JsonProperty("birth_year")
     val birthYear: Int,
+    @JsonProperty("gender")
     val gender: Gender,
+    @JsonProperty("period_start")
     val periodStart: LocalDate,
+    @JsonProperty("period_end")
     val periodEnd: LocalDate?
 ) : FeedEntry

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireEntry.kt
@@ -1,17 +1,26 @@
 package com.hartwig.actin.clinical.feed.emc.questionnaire
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedValidation
 import com.hartwig.actin.clinical.feed.emc.FeedValidator
 import java.time.LocalDate
 
 @JacksonSerializable
 data class QuestionnaireEntry(
+    @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
+    @JsonProperty("authored")
     val authored: LocalDate,
+    @JsonProperty("description")
     val description: String,
+    @JsonProperty("item_text")
     val itemText: String,
+    @JsonProperty("text")
     val text: String
 ) : FeedEntry
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/surgery/SurgeryEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/surgery/SurgeryEntry.kt
@@ -1,7 +1,10 @@
 package com.hartwig.actin.clinical.feed.emc.surgery
 
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedValidation
 import com.hartwig.actin.clinical.feed.emc.FeedValidator
 import java.time.LocalDate
@@ -10,12 +13,20 @@ private const val BIOPSY_PROCEDURE_DISPLAY = "Procedurele sedatie analgesie ANE 
 
 @JacksonSerializable
 data class SurgeryEntry(
+    @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
+    @JsonProperty("class_display")
     val classDisplay: String,
+    @JsonProperty("period_start")
     val periodStart: LocalDate,
+    @JsonProperty("period_end")
     val periodEnd: LocalDate,
+    @JsonProperty("code_coding_display_original")
     val codeCodingDisplayOriginal: String,
+    @JsonProperty("encounter_status")
     val encounterStatus: String,
+    @JsonProperty("procedure_status")
     val procedureStatus: String
 ) : FeedEntry
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/vitalfunction/VitalFunctionEntry.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/vitalfunction/VitalFunctionEntry.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.hartwig.actin.clinical.feed.JacksonSerializable
 import com.hartwig.actin.clinical.feed.emc.EuropeanDecimalDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedEntry
+import com.hartwig.actin.clinical.feed.emc.FeedSubjectDeserializer
 import com.hartwig.actin.clinical.feed.emc.FeedValidation
 import com.hartwig.actin.clinical.feed.emc.FeedValidationWarning
 import com.hartwig.actin.clinical.feed.emc.FeedValidator
@@ -13,6 +14,7 @@ import java.time.LocalDateTime
 @JacksonSerializable
 data class VitalFunctionEntry(
     @JsonProperty("subject")
+    @JsonDeserialize(using = FeedSubjectDeserializer::class)
     override val subject: String,
 
     @JsonProperty("effectiveDateTime")

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
@@ -18,8 +18,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.tuple
 import org.junit.Test
 
+private const val PATIENT = "ACTN01029999"
 val EXPECTED_CLINICAL_RECORD: String =
-    "${Resources.getResource("clinical_record").path}/ACTN01029999.clinical.json"
+    "${Resources.getResource("clinical_record").path}/$PATIENT.clinical.json"
 
 class ClinicalIngestionFeedAdapterTest {
 
@@ -62,14 +63,14 @@ class ClinicalIngestionFeedAdapterTest {
         val patientResults = ingestionResult.patientResults
         assertThat(patientResults[0].status).isEqualTo(PatientIngestionStatus.PASS)
         assertThat(patientResults).hasSize(1)
-        assertThat(patientResults[0].patientId).isEqualTo("ACTN01029999")
+        assertThat(patientResults[0].patientId).isEqualTo(PATIENT)
         assertThat(patientResults[0].curationResults).isEmpty()
         assertThat(patientResults[0].clinicalRecord).isEqualTo(ClinicalRecordJson.read(EXPECTED_CLINICAL_RECORD))
         assertThat(patientResults[0].questionnaireCurationErrors)
-            .containsExactly(QuestionnaireCurationError("ACTN-01-02-9999", "Unrecognized questionnaire option: 'Probably'"))
+            .containsExactly(QuestionnaireCurationError(PATIENT, "Unrecognized questionnaire option: 'Probably'"))
         assertThat(patientResults[0].feedValidationWarnings).containsExactly(
             FeedValidationWarning(
-                "ACTN-01-02-9999",
+                PATIENT,
                 "Empty vital function value"
             )
         )

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedReaderTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedReaderTest.kt
@@ -11,15 +11,16 @@ import com.hartwig.actin.clinical.feed.emc.patient.PatientEntry
 import com.hartwig.actin.clinical.feed.emc.questionnaire.QuestionnaireEntry
 import com.hartwig.actin.clinical.feed.emc.surgery.SurgeryEntry
 import com.hartwig.actin.clinical.feed.emc.vitalfunction.VitalFunctionEntry
+import java.io.IOException
+import java.time.LocalDate
+import java.time.LocalDateTime
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
 import org.apache.logging.log4j.util.Strings
 import org.junit.Test
-import java.io.IOException
-import java.time.LocalDate
-import java.time.LocalDateTime
+
 
 class EmcClinicalFeedReaderTest {
     @Test
@@ -39,11 +40,12 @@ class EmcClinicalFeedReaderTest {
     companion object {
         private val CLINICAL_FEED_DIRECTORY = Resources.getResource("feed/emc").path
         private const val EPSILON = 1.0E-10
+        private const val PATIENT = "ACTN01029999"
 
         private fun assertPatients(entries: List<PatientEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = entries[0]
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals(1953, entry.birthYear.toLong())
             assertEquals(Gender.MALE, entry.gender)
             assertEquals(LocalDate.of(2020, 7, 13), entry.periodStart)
@@ -53,7 +55,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertQuestionnaires(entries: List<QuestionnaireEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = findByAuthoredDate(entries, LocalDate.of(2021, 8, 16))
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals("INT Consult", entry.description)
             assertEquals("Beloop", entry.itemText)
             assertEquals(26, entry.text.split("\\n").dropLastWhile { it.isEmpty() }.toTypedArray().size.toLong())
@@ -74,7 +76,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertSurgeries(entries: List<SurgeryEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = entries[0]
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals("surgery", entry.classDisplay)
             assertEquals(LocalDate.of(2020, 8, 28), entry.periodStart)
             assertEquals(LocalDate.of(2020, 8, 28), entry.periodEnd)
@@ -86,7 +88,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertMedication(entries: List<MedicationEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = entries[0]
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals("19-0716 PEMBROLIZUMAB V/P INFOPL 25MG/ML FL 4ML", entry.codeText)
             assertTrue(entry.code5ATCDisplay.isEmpty())
             assertEquals("MILLIGRAM", entry.dosageInstructionDoseQuantityUnit)
@@ -117,7 +119,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertLab(entries: List<LabEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry1 = findByCodeCodeOriginal(entries, "AC")
-            assertEquals("ACTN-01-02-9999", entry1.subject)
+            assertEquals(PATIENT, entry1.subject)
             assertEquals("ACTH", entry1.codeDisplayOriginal)
             assertEquals(Strings.EMPTY, entry1.valueQuantityComparator)
             assertEquals(5.5, entry1.valueQuantityValue, EPSILON)
@@ -134,7 +136,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertVitalFunctions(entries: List<VitalFunctionEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = entries[0]
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals(LocalDateTime.of(2019, 4, 28, 13, 45), entry.effectiveDateTime)
             assertEquals("NIBP", entry.codeDisplayOriginal)
             assertEquals("Systolic blood pressure", entry.componentCodeDisplay)
@@ -145,7 +147,7 @@ class EmcClinicalFeedReaderTest {
         private fun assertIntolerances(entries: List<IntoleranceEntry>) {
             assertEquals(1, entries.size.toLong())
             val entry = entries[0]
-            assertEquals("ACTN-01-02-9999", entry.subject)
+            assertEquals(PATIENT, entry.subject)
             assertEquals(LocalDate.of(2014, 4, 21), entry.assertedDate)
             assertEquals("medication", entry.category)
             assertEquals("Propensity to adverse reactions to drug", entry.categoryAllergyCategoryDisplay)
@@ -159,11 +161,11 @@ class EmcClinicalFeedReaderTest {
         private fun assertBodyWeights(entries: List<BodyWeightEntry>) {
             assertEquals(2, entries.size.toLong())
             val entry1 = findByDate(entries, LocalDateTime.of(2020, 8, 11, 0, 0, 0, 0))
-            assertEquals("ACTN-01-02-9999", entry1.subject)
+            assertEquals(PATIENT, entry1.subject)
             assertEquals(61.1, entry1.valueQuantityValue, EPSILON)
             assertEquals("kilogram", entry1.valueQuantityUnit)
             val entry2 = findByDate(entries, LocalDateTime.of(2020, 8, 20, 8, 43, 0, 0))
-            assertEquals("ACTN-01-02-9999", entry2.subject)
+            assertEquals(PATIENT, entry2.subject)
             assertEquals(58.9, entry2.valueQuantityValue, EPSILON)
             assertEquals("kilogram", entry2.valueQuantityUnit)
         }


### PR DESCRIPTION
Don't store the unsanitised subjects from the feed, strip the hyphens out before processing, in the CSV parsing layer.

While I did add annotations to a number of classes that did not previously have them I do not think this is such a big problem as some `Entry` implementations had each field annotated for Jackson while others didn't.

Add a custom deserialiser for the subject fields and attach it to every `Entry`. A `JsonProperty` annotation must be added so that Jackson will pick up the custom deserialiser, when that has happened all the fields must be annotated or Jackson will throw when it is run.

Related but not strictly part of the ticket: constant for body weight unit.