### PR TITLE
ACTIN-737: Fix `Body weights not measured in kilogram` warning message

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrBodyWeightExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrBodyWeightExtractor.kt
@@ -17,7 +17,7 @@ class EhrBodyWeightExtractor : EhrExtractor<List<BodyWeight>> {
                     unit = if (enumeratedInput<EhrMeasurementUnit>(it.unit) == EhrMeasurementUnit.KILOGRAMS) "Kilograms" else throw IllegalArgumentException(
                         "Unit of body weight is not Kilograms"
                     ),
-                    valid = true
+                    valid = it.value in 20.0..250.0
                 )
             }, CurationExtractionEvaluation()
         )

--- a/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
+++ b/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
@@ -263,6 +263,13 @@
       "subcategory": null,
       "value": 3.5,
       "unit": "kilograms"
+    },
+    {
+      "date": "2020-02-01T10:10:00",
+      "category": "Body Weight",
+      "subcategory": null,
+      "value": 53,
+      "unit": "kilograms"
     }
   ],
   "who_evaluations": [

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -262,6 +262,12 @@
       "date": "2020-01-01T00:00:00",
       "value": 3.5,
       "unit": "Kilograms",
+      "valid": false
+    },
+    {
+      "date": "2020-02-01T00:00:00",
+      "value": 53,
+      "unit": "Kilograms",
       "valid": true
     }
   ],


### PR DESCRIPTION
Hey @pauldwolfe, could you take a look? I think:
- We were missing a filter before and were evaluating all BodyWeights, even if they were in a different unit.
- We were setting the unit in EhrBodyWeightExtractor to "KG" while in the rest of the code we have EXPECTED_UNIT: String = "kilogram".
I'm kind of at a loss why we weren't getting the same issues at EMC, so I'm hoping you can enlighten me. 