### PR TITLE
ACTIN-740 Filter the ignored config from the cross-sheet curation

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorOtherConditionsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorOtherConditionsExtractor.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.clinical.ExtractionResult
 import com.hartwig.actin.clinical.curation.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.CurationResponse
+import com.hartwig.actin.clinical.curation.config.CurationConfig
 import com.hartwig.actin.clinical.curation.config.NonOncologicalHistoryConfig
 import com.hartwig.actin.clinical.curation.config.TreatmentHistoryEntryConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
@@ -15,7 +16,7 @@ class EhrPriorOtherConditionsExtractor(
 ) :
     EhrExtractor<List<PriorOtherCondition>> {
     override fun extract(ehrPatientRecord: EhrPatientRecord): ExtractionResult<List<PriorOtherCondition>> {
-        return ehrPatientRecord.priorOtherConditions.filter { oncologicalHistoryCuration.find(it.name).isEmpty() }.map {
+        return ehrPatientRecord.priorOtherConditions.filter { oncologicalHistoryCuration.find(it.name).all(CurationConfig::ignore) }.map {
             val curatedPriorOtherCondition = CurationResponse.createFromConfigs(
                 priorOtherConditionsCuration.find(it.name),
                 ehrPatientRecord.patientDetails.hashedId,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTreatmentHistoryExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTreatmentHistoryExtractor.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.clinical.ExtractionResult
 import com.hartwig.actin.clinical.curation.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.CurationResponse
+import com.hartwig.actin.clinical.curation.config.CurationConfig
 import com.hartwig.actin.clinical.curation.config.NonOncologicalHistoryConfig
 import com.hartwig.actin.clinical.curation.config.TreatmentHistoryEntryConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
@@ -33,7 +34,7 @@ class EhrTreatmentHistoryExtractor(
 
     private fun getOncologicalPreviousConditions(ehrPatientRecord: EhrPatientRecord) =
         ehrPatientRecord.priorOtherConditions.mapNotNull { ehrPreviousCondition ->
-            if (nonOncologicalHistoryCuration.find(ehrPreviousCondition.name).isEmpty()) {
+            if (nonOncologicalHistoryCuration.find(ehrPreviousCondition.name).all(CurationConfig::ignore)) {
                 val treatment = CurationResponse.createFromConfigs(
                     treatmentCuration.find(ehrPreviousCondition.name),
                     ehrPatientRecord.patientDetails.hashedId,
@@ -41,27 +42,27 @@ class EhrTreatmentHistoryExtractor(
                     ehrPreviousCondition.name,
                     TREATMENT_HISTORY,
                 )
-                treatment.config()?.let { curatedTreatment ->
+                treatment.config()?.curated?.let { curatedTreatment ->
                     ExtractionResult(
                         listOf(
                             TreatmentHistoryEntry(
                                 startYear = ehrPreviousCondition.startDate.year,
                                 startMonth = ehrPreviousCondition.startDate.monthValue,
-                                treatments = curatedTreatment.curated!!.treatments,
-                                intents = curatedTreatment.curated.intents,
+                                treatments = curatedTreatment.treatments,
+                                intents = curatedTreatment.intents,
                                 treatmentHistoryDetails = TreatmentHistoryDetails(
                                     stopYear = ehrPreviousCondition.endDate?.year,
                                     stopMonth = ehrPreviousCondition.endDate?.monthValue,
-                                    stopReason = curatedTreatment.curated.treatmentHistoryDetails?.stopReason,
-                                    bestResponse = curatedTreatment.curated.treatmentHistoryDetails?.bestResponse,
-                                    switchToTreatments = curatedTreatment.curated.treatmentHistoryDetails?.switchToTreatments,
-                                    cycles = curatedTreatment.curated.treatmentHistoryDetails?.cycles,
-                                    bodyLocations = curatedTreatment.curated.treatmentHistoryDetails?.bodyLocations,
-                                    bodyLocationCategories = curatedTreatment.curated.treatmentHistoryDetails?.bodyLocationCategories,
-                                    maintenanceTreatment = curatedTreatment.curated.treatmentHistoryDetails?.maintenanceTreatment,
+                                    stopReason = curatedTreatment.treatmentHistoryDetails?.stopReason,
+                                    bestResponse = curatedTreatment.treatmentHistoryDetails?.bestResponse,
+                                    switchToTreatments = curatedTreatment.treatmentHistoryDetails?.switchToTreatments,
+                                    cycles = curatedTreatment.treatmentHistoryDetails?.cycles,
+                                    bodyLocations = curatedTreatment.treatmentHistoryDetails?.bodyLocations,
+                                    bodyLocationCategories = curatedTreatment.treatmentHistoryDetails?.bodyLocationCategories,
+                                    maintenanceTreatment = curatedTreatment.treatmentHistoryDetails?.maintenanceTreatment,
                                 ),
-                                isTrial = curatedTreatment.curated.isTrial,
-                                trialAcronym = curatedTreatment.curated.trialAcronym
+                                isTrial = curatedTreatment.isTrial,
+                                trialAcronym = curatedTreatment.trialAcronym
 
                             )
                         ), treatment.extractionEvaluation

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorOtherConditionsExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorOtherConditionsExtractorTest.kt
@@ -81,4 +81,19 @@ class EhrPriorOtherConditionsExtractorTest {
         )
     }
 
+    @Test
+    fun `Should include evaluated input when prior condition is ignored in both prior condition and oncological history curation`() {
+        every { priorOtherConditionsCuration.find(PRIOR_CONDITION_NAME) } returns setOf(
+            NonOncologicalHistoryConfig(
+                input = PRIOR_CONDITION_NAME,
+                ignore = true,
+                priorOtherCondition = PRIOR_OTHER_CONDITION
+            )
+        )
+        every { oncologicalHistoryCuration.find(PRIOR_CONDITION_NAME) } returns setOf(
+            TreatmentHistoryEntryConfig(PRIOR_CONDITION_NAME, true)
+        )
+        val result = extractor.extract(EHR_PATIENT_RECORD_WITH_PRIOR_CONDITIONS)
+        assertThat(result.evaluation.nonOncologicalHistoryEvaluatedInputs).containsExactly(PRIOR_CONDITION_NAME)
+    }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTreatmentHistoryExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTreatmentHistoryExtractorTest.kt
@@ -257,4 +257,26 @@ class EhrTreatmentHistoryExtractorTest {
         )
         assertThat(result.extracted).isEmpty()
     }
+
+    @Test
+    fun `Should include evaluated input when prior condition is ignored in both prior condition and oncological history curation`() {
+        every { nonOncologicalHistoryCuration.find(PREVIOUS_CONDITION) } returns setOf(
+            NonOncologicalHistoryConfig(
+                input = PREVIOUS_CONDITION,
+                ignore = true
+            )
+        )
+        every { treatmentCurationDatabase.find(PREVIOUS_CONDITION) } returns setOf(
+            TREATMENT_HISTORY_ENTRY_CONFIG.copy(
+                ignore = true,
+                input = PREVIOUS_CONDITION
+            )
+        )
+        val result = extractor.extract(
+            EHR_PATIENT_RECORD.copy(
+                treatmentHistory = listOf(TREATMENT_HISTORY.copy(treatmentName = PREVIOUS_CONDITION, modifications = null)),
+            )
+        )
+        assertThat(result.evaluation.treatmentHistoryEntryEvaluatedInputs).containsExactly(PREVIOUS_CONDITION)
+    }
 }


### PR DESCRIPTION
Allows for the evaluated inputs to be propagated when the entry is ignored in both sheets. 