### PR TITLE
ACTIN-677: Do not build string for empty switch to treatments

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -147,10 +147,10 @@ class PatientClinicalHistoryGenerator(private val record: ClinicalRecord, privat
 
             val treatmentWithAnnotation = listOfNotNull(
                 treatmentHistoryEntry.treatmentDisplay() + if (annotation.isEmpty()) "" else " ($annotation)",
-                treatmentHistoryEntry.treatmentHistoryDetails?.switchToTreatments?.let { switchToTreatments ->
+                treatmentHistoryEntry.treatmentHistoryDetails?.switchToTreatments?.ifEmpty { null }?.let { switchToTreatments ->
                     switchToTreatments.joinToString(prefix = "with switch to ", separator = " then ") {
                         it.treatment.display() + it.cycles?.let { cycles -> " (${cycles} cycles)" }
-                    }.ifEmpty { null }
+                    }
                 },
                 treatmentHistoryEntry.treatmentHistoryDetails?.maintenanceTreatment?.let { maintenanceTreatment ->
                     "continued with ${maintenanceTreatment.treatment.display()} maintenance"


### PR DESCRIPTION
The original fix from https://github.com/hartwigmedical/actin/pull/395 was broken by https://github.com/hartwigmedical/actin/pull/403.