### PR TITLE
ACTIN-780: Show only start date if start/end date are equal for '(oth…

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -121,7 +121,7 @@ class PatientClinicalHistoryGenerator(private val record: ClinicalRecord, privat
             val stopString = treatmentHistoryEntry.treatmentHistoryDetails?.let { toDateString(it.stopYear, it.stopMonth) }
 
             return when {
-                startString != null && stopString != null -> "$startString-$stopString"
+                startString != null && stopString != null -> if (startString != stopString) "$startString-$stopString" else startString
                 startString != null -> startString
                 stopString != null -> "?-$stopString"
                 else -> DATE_UNKNOWN


### PR DESCRIPTION
…er) oncological history' table

Intended logic: if history entry contains exact same start and stop date (year + month, or year+year if no months provided) -> only display start date

Works when I modify `unknownDetailsHistoryEntry` in `TestClinicalFactory`