### PR TITLE
ACTIN-838: Improve congestive heart failure message

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/HasHistoryOfCongestiveHeartFailureWithNYHA.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/HasHistoryOfCongestiveHeartFailureWithNYHA.kt
@@ -8,7 +8,7 @@ import com.hartwig.actin.algo.evaluation.EvaluationFunction
 class HasHistoryOfCongestiveHeartFailureWithNYHA internal constructor() : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        return EvaluationFactory.undetermined(
+        return EvaluationFactory.recoverableUndetermined(
             "Currently undetermined if patient has history of congestive heart failure with NYHA class",
             "Undetermined congestive heart failure"
         )


### PR DESCRIPTION
I've got the intention to implement logic here based on history. For now just a change to recoverable, since this message is confusing when a patient doesn't have any cardiac history at all.