### PR TITLE
ACTIN-852 Add support for multiple curation rows per input

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorPrimariesExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrPriorPrimariesExtractor.kt
@@ -40,13 +40,12 @@ class EhrPriorPrimariesExtractor(private val priorPrimaryCuration: CurationDatab
         return sourceList.map {
             curate(ehrPatientRecord.patientDetails.hashedId, inputAccessor.invoke(it))
         }
-            .mapNotNull {
-                it.config()?.curated?.let { priorSecondPrimary ->
-                    ExtractionResult(
-                        listOf(priorSecondPrimary),
-                        it.extractionEvaluation
-                    )
-                }
+            .filter { it.configs.isNotEmpty() }
+            .map {
+                ExtractionResult(
+                    it.configs.mapNotNull { c -> c.curated },
+                    it.extractionEvaluation
+                )
             }
     }
 
@@ -71,6 +70,7 @@ class EhrPriorPrimariesExtractor(private val priorPrimaryCuration: CurationDatab
         patientId,
         CurationCategory.SECOND_PRIMARY,
         input,
-        "prior primary"
+        "prior primary",
+        false
     )
 }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTumorDetailsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTumorDetailsExtractor.kt
@@ -27,7 +27,7 @@ class EhrTumorDetailsExtractor(
         )
         val lesionCurationResponse =
             extractLesions(ehrPatientRecord)
-        val curatedLesions = lesionCurationResponse.mapNotNull { it.config() }
+        val curatedLesions = lesionCurationResponse.flatMap { it.configs }
         val tumorDetailsFromEhr = tumorDetails(ehrPatientRecord, curatedLesions)
         return curatedTumorResponse.config()?.let {
             ExtractionResult(
@@ -92,7 +92,7 @@ class EhrTumorDetailsExtractor(
     ): List<CurationResponse<LesionLocationConfig>> {
         return sourceList.map {
             lesionCurationResponse(patientId, inputAccessor.invoke(it))
-        }.filter { it.config() != null }
+        }.filter { it.configs.isNotEmpty() }
     }
 
     private fun fromRadiologyReport(
@@ -117,6 +117,6 @@ class EhrTumorDetailsExtractor(
         CurationCategory.LESION_LOCATION,
         input,
         "lesion",
-        true
+        false
     )
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTumorDetailsExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/EhrTumorDetailsExtractorTest.kt
@@ -86,7 +86,22 @@ private val EHR_PRIOR_OTHER_CONDITION = EhrPriorOtherCondition(
     startDate = UNUSED_DATE
 )
 
-class EhrTumorDetailsExtractorTest {
+private val BRAIN_LESION_LOCATION_CONFIG = LesionLocationConfig(
+    input = PRIOR_CONDITION_INPUT,
+    location = "brain",
+    category = LesionLocationCategory.BRAIN
+)
+
+private val LUNG_LESION_LOCATION_CONFIG = BRAIN_LESION_LOCATION_CONFIG.copy(location = "lung", category = LesionLocationCategory.LUNG)
+
+private val BRAIN_AND_LUNG_LESION_TUMOR_DETAILS = TUMOR_DETAILS.copy(
+    hasBrainLesions = true,
+    brainLesionsCount = 1,
+    hasLungLesions = true,
+    lungLesionsCount = 1
+)
+
+class EhrTumorDetafilsExtractorTest {
 
     private val tumorCuration = mockk<CurationDatabase<PrimaryTumorConfig>>()
     private val lesionCuration = mockk<CurationDatabase<LesionLocationConfig>> {
@@ -124,7 +139,9 @@ class EhrTumorDetailsExtractorTest {
 
     @Test
     fun `Should curate lesions from the radiology report in lesion site`() {
-        setupLesionCuration(CONCLUSION_1)
+        setupLesionCuration(
+            CONCLUSION_1, BRAIN_LESION_LOCATION_CONFIG
+        )
         every { lesionCuration.find(CONCLUSION_2) } returns setOf(
             LesionLocationConfig(
                 input = CONCLUSION_2,
@@ -161,8 +178,10 @@ class EhrTumorDetailsExtractorTest {
     }
 
     @Test
-    fun `Should curate lesions from prior conditions but ignore any curation warnings`() {
-        setupLesionCuration(PRIOR_CONDITION_INPUT)
+    fun `Should curate lesions from prior conditions, supporting multiple configs per input, but ignore any curation warnings`() {
+        setupLesionCuration(
+            PRIOR_CONDITION_INPUT, BRAIN_LESION_LOCATION_CONFIG, LUNG_LESION_LOCATION_CONFIG
+        )
         val result =
             extractor.extract(
                 EHR_PATIENT_RECORD.copy(
@@ -172,19 +191,18 @@ class EhrTumorDetailsExtractorTest {
                     )
                 )
             )
-        assertThat(result.extracted).isEqualTo(
-            TUMOR_DETAILS.copy(
-                hasBrainLesions = true,
-                brainLesionsCount = 1
-            )
-        )
+        assertThat(result.extracted).isEqualTo(BRAIN_AND_LUNG_LESION_TUMOR_DETAILS)
         assertThat(result.evaluation.warnings).isEmpty()
         assertThat(result.evaluation.lesionLocationEvaluatedInputs).containsExactly(PRIOR_CONDITION_INPUT)
     }
 
     @Test
-    fun `Should curate lesions from treatment history but ignore any curation warnings`() {
-        setupLesionCuration(TREATMENT_HISTORY_INPUT)
+    fun `Should curate lesions from treatment history, supporting multiple configs per input, but ignore any curation warnings`() {
+        setupLesionCuration(
+            TREATMENT_HISTORY_INPUT,
+            BRAIN_LESION_LOCATION_CONFIG,
+            LUNG_LESION_LOCATION_CONFIG
+        )
         val result =
             extractor.extract(
                 EHR_PATIENT_RECORD.copy(
@@ -194,24 +212,13 @@ class EhrTumorDetailsExtractorTest {
                     )
                 )
             )
-        assertThat(result.extracted).isEqualTo(
-            TUMOR_DETAILS.copy(
-                hasBrainLesions = true,
-                brainLesionsCount = 1
-            )
-        )
+        assertThat(result.extracted).isEqualTo(BRAIN_AND_LUNG_LESION_TUMOR_DETAILS)
         assertThat(result.evaluation.warnings).isEmpty()
         assertThat(result.evaluation.lesionLocationEvaluatedInputs).containsExactly(TREATMENT_HISTORY_INPUT)
     }
 
-    private fun setupLesionCuration(input: String) {
+    private fun setupLesionCuration(input: String, vararg lesionLocationConfig: LesionLocationConfig) {
         every { tumorCuration.find("tumorLocation | tumorType") } returns setOf(CURATION_CONFIG)
-        every { lesionCuration.find(input) } returns setOf(
-            LesionLocationConfig(
-                input = PRIOR_CONDITION_INPUT,
-                location = "brain",
-                category = LesionLocationCategory.BRAIN
-            )
-        )
+        every { lesionCuration.find(input) } returns lesionLocationConfig.toSet()
     }
 }


### PR DESCRIPTION
To lesion and prior primary curation, when cross curating with onco and non-onco history.