### PR TITLE
ACTIN-871: Remove empty parentheses when prior primary does not have …

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -183,7 +183,8 @@ class PatientClinicalHistoryGenerator(
         }
 
         private fun toSecondPrimaryString(priorSecondPrimary: PriorSecondPrimary): String {
-            val tumorLocation = priorSecondPrimary.tumorLocation + priorSecondPrimary.tumorSubLocation.let { " ($it)" }
+            val tumorSubLocation = priorSecondPrimary.tumorSubLocation
+            val tumorLocation = priorSecondPrimary.tumorLocation + if (tumorSubLocation.isNotEmpty()) " ($tumorSubLocation)" else ""
             val tumorDetails = when {
                 priorSecondPrimary.tumorSubType.isNotEmpty() -> {
                     tumorLocation + " " + priorSecondPrimary.tumorSubType.lowercase()


### PR DESCRIPTION
…a sublocation

Changed showed below using the test report application (i.e. not real patient data)

Test report before: `Lung () adenocarcinoma (diagnosed 4/2021, considered non-active)`
Test report after:` Lung adenocarcinoma (diagnosed 4/2021, considered non-active)`
And with sublocation: `Lung (left upper lobe) adenocarcinoma (diagnosed 4/2021, considered non-active)`