### PR TITLE
ACTIN-879: Make treatment retries optional for SOC exhaustion

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/CrcDecisionTree.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/CrcDecisionTree.kt
@@ -41,14 +41,9 @@ class CrcDecisionTree(treatmentCandidateDatabase: TreatmentCandidateDatabase) : 
     )
 
     private val socExhaustedTree = DecisionTree(
-        decision = EligibilityFunction(
-            EligibilityRule.AND, listOf(
-                EligibilityFunction(EligibilityRule.HAS_EXHAUSTED_SOC_TREATMENTS, emptyList()),
-                EligibilityFunction(EligibilityRule.OR, listOf("NTRK1", "NTRK2", "NTRK3").map {
-                    EligibilityFunction(EligibilityRule.FUSION_IN_GENE_X, listOf(it))
-                })
-            )
-        ),
+        decision = EligibilityFunction(EligibilityRule.OR, listOf("NTRK1", "NTRK2", "NTRK3").map {
+            EligibilityFunction(EligibilityRule.FUSION_IN_GENE_X, listOf(it))
+        }),
         trueBranch = DecisionTreeLeaf(listOf(ENTRECTINIB, LAROTRECTINIB).map(treatmentCandidateDatabase::treatmentCandidate)),
         falseBranch = DecisionTreeLeaf(emptyList())
     )

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentInterpreter.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentInterpreter.kt
@@ -8,9 +8,7 @@ class EvaluatedTreatmentInterpreter(private val recommendedTreatments: List<Eval
         return if (recommendedTreatments.isEmpty()) {
             "No treatments available"
         } else {
-            "Recommended treatment(s): " + recommendedTreatments.map { it.treatmentCandidate.treatment.display() }
-                .distinct()
-                .joinToString(", ")
+            "Available treatment(s): " + recommendedTreatments.map(EvaluatedTreatment::treatmentCandidate).distinct().joinToString("\n")
         }
     }
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/RecommendationEngine.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/RecommendationEngine.kt
@@ -27,7 +27,7 @@ class RecommendationEngine(
         return DoidConstants.COLORECTAL_CANCER_DOID in tumorDoids && (EXCLUDED_TUMOR_DOIDS intersect tumorDoids).isEmpty()
     }
 
-    private fun determineRequiredTreatments(patientRecord: PatientRecord): List<EvaluatedTreatment> {
+    fun determineRequiredTreatments(patientRecord: PatientRecord): List<EvaluatedTreatment> {
         return treatmentCandidates().asSequence()
             .filterNot(TreatmentCandidate::optional)
             .map { evaluateTreatmentRequirementForPatient(it, patientRecord) }
@@ -56,7 +56,7 @@ class RecommendationEngine(
         treatmentCandidate: TreatmentCandidate,
         patientRecord: PatientRecord
     ): EvaluatedTreatment {
-        return evaluateTreatmentCandidate(treatmentCandidate.eligibilityFunctions, patientRecord, treatmentCandidate)
+        return evaluateTreatmentCandidate(treatmentCandidate.eligibilityFunctionsForRequirement(), patientRecord, treatmentCandidate)
     }
 
     private fun evaluateTreatmentCandidate(

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
@@ -60,8 +60,16 @@ class StandardOfCareApplication(private val config: StandardOfCareConfig) {
         val recommendationEngine = RecommendationEngineFactory(resources).create()
 
         LOGGER.info(recommendationEngine.provideRecommendations(patient))
-        val patientHasExhaustedStandardOfCare = recommendationEngine.patientHasExhaustedStandardOfCare(patient)
-        LOGGER.info("Standard of care has${if (patientHasExhaustedStandardOfCare) "" else " not"} been exhausted")
+        val requiredTreatments = recommendationEngine.determineRequiredTreatments(patient)
+        requiredTreatments.forEach {
+            val allMessages = it.evaluations.flatMap { evaluation ->
+                with(evaluation) {
+                    passGeneralMessages + warnGeneralMessages + undeterminedGeneralMessages
+                }
+            }
+            LOGGER.debug("${it.treatmentCandidate.treatment.display()}: ${allMessages.joinToString(", ")}")
+        }
+        LOGGER.info("Standard of care has${if (requiredTreatments.isEmpty()) "" else " not"} been exhausted")
     }
 
     companion object {

--- a/common/src/main/kotlin/com/hartwig/actin/algo/datamodel/TreatmentCandidate.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/algo/datamodel/TreatmentCandidate.kt
@@ -6,13 +6,24 @@ import com.hartwig.actin.trial.datamodel.EligibilityFunction
 data class TreatmentCandidate(
     val treatment: Treatment,
     val optional: Boolean,
-    val eligibilityFunctions: Set<EligibilityFunction>
+    val eligibilityFunctions: Set<EligibilityFunction>,
+    val additionalCriteriaForRequirement: Set<EligibilityFunction> = emptySet()
 ) {
 
     override fun toString(): String {
+        val requiredFunctionsString = if (additionalCriteriaForRequirement.isEmpty()) "" else {
+            " when:\n${functionString(additionalCriteriaForRequirement)}"
+        }
         return "${treatment.display()} eligible if:\n${functionString(eligibilityFunctions)}" +
-                if (!optional) "\n   Treatment is required" else ""
+                if (!optional) "\n   Treatment is required$requiredFunctionsString" else ""
     }
 
     private fun functionString(functions: Set<EligibilityFunction>) = functions.joinToString("\n") { "    $it" }
+
+    fun eligibilityFunctionsForRequirement(): Set<EligibilityFunction> {
+        if (optional) {
+            throw IllegalStateException("Requirement criteria undefined for optional treatment")
+        }
+        return eligibilityFunctions union additionalCriteriaForRequirement
+    }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/algo/serialization/TreatmentMatchJsonTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/algo/serialization/TreatmentMatchJsonTest.kt
@@ -9,9 +9,9 @@ import com.hartwig.actin.algo.serialization.TreatmentMatchJson.fromJson
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson.read
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson.toJson
 import com.hartwig.actin.testutil.ResourceLocator.resourceOnClasspath
-import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.io.File
 
 class TreatmentMatchJsonTest {
 
@@ -60,7 +60,7 @@ class TreatmentMatchJsonTest {
                 + "\"failSpecificMessages\":[],\"failGeneralMessages\":[]}]],\"cohorts\":[]}],"
                 + "\"standardOfCareMatches\":[{\"treatmentCandidate\":{\"treatment\":{\"name\":\"Pembrolizumab\",\"isSystemic\":true,"
                 + "\"synonyms\":[],\"displayOverride\":null,\"categories\":[],\"types\":[],\"treatmentClass\":\"OTHER_TREATMENT\"},"
-                + "\"optional\":true,\"eligibilityFunctions\":[{\"rule\":\"HAS_KNOWN_ACTIVE_CNS_METASTASES\",\"parameters\":[]}]},"
+                + "\"optional\":true,\"eligibilityFunctions\":[{\"rule\":\"HAS_KNOWN_ACTIVE_CNS_METASTASES\",\"parameters\":[]}],\"additionalCriteriaForRequirement\":[]},"
                 + "\"evaluations\":[{\"result\":\"PASS\",\"recoverable\":false,\"inclusionMolecularEvents\":[],"
                 + "\"exclusionMolecularEvents\":[],\"passSpecificMessages\":[\"Patient has active CNS metastases\"],"
                 + "\"passGeneralMessages\":[\"Active CNS metastases\"],\"warnSpecificMessages\":[],\"warnGeneralMessages\":[],"


### PR DESCRIPTION
Add `additionalCriteriaForRequirement` to `TreatmentCandidate` so the criteria for requirement can be stricter than the eligibility criteria.

A treatment may be eligible if it or some of its components were previously administered over 6 months ago, but it will only be required if the excluded components don't appear in the patient's oncological history at all.