### PR TITLE
ACTIN-919 Allow nulls in atc_code in medications

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrMedicationExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/EhrMedicationExtractor.kt
@@ -19,7 +19,14 @@ class EhrMedicationExtractor(
 
     override fun extract(ehrPatientRecord: EhrPatientRecord): ExtractionResult<List<Medication>?> {
         return ExtractionResult(ehrPatientRecord.medications?.map {
-            val atcClassification = if (!it.isTrial && !it.isSelfCare) atcModel.resolveByCode(it.atcCode, "") else null
+            val atcClassification = if (!it.isTrial && !it.isSelfCare) atcModel.resolveByCode(
+                it.atcCode
+                    ?: throw IllegalStateException(
+                        "Patient '${ehrPatientRecord.patientDetails.hashedId}' had medication '${it.name}' with null atc code, " +
+                                "but is not a trial or self care"
+                    ),
+                ""
+            ) else null
             val atcNameOrInput = atcClassification?.chemicalSubstance?.name ?: it.name
             Medication(
                 name = atcNameOrInput,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardEhrFeedDatamodel.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardEhrFeedDatamodel.kt
@@ -106,7 +106,7 @@ data class EhrLabValue(
 @JacksonSerializable
 data class EhrMedication(
     val name: String,
-    val atcCode: String,
+    val atcCode: String?,
     val startDate: LocalDate?,
     val endDate: LocalDate?,
     val administrationRoute: String?,


### PR DESCRIPTION
If not self-care or trial throw exception, otherwise it is ignored.