### PR TITLE
ACTIN-928 Match derived stages to sub-stages

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasTumorStage.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasTumorStage.kt
@@ -51,8 +51,6 @@ class HasTumorStage(private val stagesToMatch: Set<TumorStage>) : EvaluationFunc
     }
 
     private fun evaluateCategoryMatchForDerivedStage(derivedStage: TumorStage): Boolean {
-        val stagesInCategory =
-            derivedStage.category?.let { TumorStage.values().filter { it.category != null && it.category == it } } ?: emptySet()
-        return derivedStage in stagesInCategory
+        return stagesToMatch.any { it.category == derivedStage }
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasTumorStageTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasTumorStageTest.kt
@@ -62,9 +62,15 @@ class HasTumorStageTest {
     }
 
     @Test
-    fun `Should pass when derived stage is part of same category`() {
-        val patientRecord = TumorTestFactory.withTumorStageAndDerivedStages(null, setOf(TumorStage.IIIB, TumorStage.IIIC))
-        assertEvaluation(EvaluationResult.PASS, HasTumorStage(setOf(TumorStage.III)).evaluate(patientRecord))
+    fun `Should pass when derived stage is equal to the category of the stage to match`() {
+        val patientRecord = TumorTestFactory.withTumorStageAndDerivedStages(null, setOf(TumorStage.III))
+        assertEvaluation(EvaluationResult.PASS, HasTumorStage(setOf(TumorStage.IIIB)).evaluate(patientRecord))
+    }
+
+    @Test
+    fun `Should fail when derived stage is not equal to the category of the stage to match`() {
+        val patientRecord = TumorTestFactory.withTumorStageAndDerivedStages(null, setOf(TumorStage.III))
+        assertEvaluation(EvaluationResult.FAIL, HasTumorStage(setOf(TumorStage.IIB)).evaluate(patientRecord))
     }
 
     @Test


### PR DESCRIPTION
If a derived stage has matching sub-stages (defined as a stage with the derived as category), then return pass, as we have no logic to derive the sub-stage. For example, a derived stage of III will match IIIa.

This does not apply to non-derived stages, so if we know the stage is III we do not match it to IIIa.