### PR TITLE
ACTIN-957: Change header in StudiesNotInTrialStatusDatabase

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/CohortStatusInterpreter.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/CohortStatusInterpreter.kt
@@ -17,8 +17,8 @@ internal object CohortStatusInterpreter {
         entries: List<TrialStatusEntry>,
         cohortConfig: CohortDefinitionConfig
     ): CohortStatusInterpretation {
-        val ctcCohortIds = cohortConfig.externalCohortIds
-        if (isNotAvailableOrIncorrect(ctcCohortIds)) {
+        val externalCohortIds = cohortConfig.externalCohortIds
+        if (isNotAvailableOrIncorrect(externalCohortIds)) {
             LOGGER.debug(
                 " Trial status entry for cohort '{}' of trial '{}' explicitly configured to be unavailable or incorrect in trial status database. "
                         + "Ingesting cohort status as configured",
@@ -26,7 +26,7 @@ internal object CohortStatusInterpreter {
                 cohortConfig.trialId
             )
             return CohortStatusInterpretation(null, emptyList(), emptyList())
-        } else if (isMissingBecauseClosedOrUnavailable(ctcCohortIds)) {
+        } else if (isMissingBecauseClosedOrUnavailable(externalCohortIds)) {
             LOGGER.debug(
                 " Trial status entry missing for cohort '{}' of trial '{}' because it's assumed closed or not available. "
                         + "Setting cohort to closed without slots", cohortConfig.cohortId, cohortConfig.trialId
@@ -37,21 +37,21 @@ internal object CohortStatusInterpreter {
         return CohortStatusResolver.resolve(entries, cohortConfig)
     }
 
-    private fun isNotAvailableOrIncorrect(ctcCohortIds: Set<String>): Boolean {
+    private fun isNotAvailableOrIncorrect(externalCohortIds: Set<String>): Boolean {
         return isSingleEntryWithValue(
-            ctcCohortIds,
+            externalCohortIds,
             NOT_AVAILABLE,
             NOT_IN_TRIAL_STATUS_DATABASE_OVERVIEW_UNKNOWN_WHY,
             OVERRULED_BECAUSE_INCORRECT_IN_TRIAL_STATUS_DATABASE
         )
     }
 
-    private fun isMissingBecauseClosedOrUnavailable(ctcCohortIds: Set<String>): Boolean {
-        return isSingleEntryWithValue(ctcCohortIds, WONT_BE_MAPPED_BECAUSE_CLOSED, WONT_BE_MAPPED_BECAUSE_NOT_AVAILABLE)
+    private fun isMissingBecauseClosedOrUnavailable(externalCohortIds: Set<String>): Boolean {
+        return isSingleEntryWithValue(externalCohortIds, WONT_BE_MAPPED_BECAUSE_CLOSED, WONT_BE_MAPPED_BECAUSE_NOT_AVAILABLE)
     }
 
-    private fun isSingleEntryWithValue(ctcCohortIds: Set<String>, vararg valuesToFind: String): Boolean {
-        return ctcCohortIds.size == 1 && ctcCohortIds.first() in valuesToFind
+    private fun isSingleEntryWithValue(externalCohortIds: Set<String>, vararg valuesToFind: String): Boolean {
+        return externalCohortIds.size == 1 && externalCohortIds.first() in valuesToFind
     }
 
     private fun closedWithoutSlots(): InterpretedCohortStatus {

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/StudiesNotInTrialStatusDatabase.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/StudiesNotInTrialStatusDatabase.kt
@@ -8,5 +8,12 @@ object StudiesNotInTrialStatusDatabase {
         return FileUtil.createObjectsFromTsv(tsv, ::create).toSet()
     }
 
-    private fun create(fields: Map<String, Int>, parts: List<String>): String = parts[fields["StudyNotInTrialStatusDatabase"]!!]
+    private fun create(fields: Map<String, Int>, parts: List<String>): String {
+        // TODO (KD): Remove support for "StudyNotInTrialStatusDatabase" once resorces have been updated.
+        return if (fields.containsKey("studyNotInTrialStatusDatabase")) {
+            parts[fields["studyNotInTrialStatusDatabase"]!!]
+        } else {
+            parts[fields["StudyNotInTrialStatusDatabase"]!!]
+        }
+    }
 }

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseEvaluator.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseEvaluator.kt
@@ -14,7 +14,7 @@ class TrialStatusDatabaseEvaluator(private val trialStatusDatabase: TrialStatusD
             unusedStudyMETCsToIgnore.map {
                 IgnoreValidationError(
                     it,
-                    "Study that is configured to be ignored is not actually referenced in CTC database"
+                    "Study that is configured to be ignored is not actually referenced in trial status database"
                 )
             }
         }
@@ -28,7 +28,7 @@ class TrialStatusDatabaseEvaluator(private val trialStatusDatabase: TrialStatusD
             unusedUnmappedCohortIds.map {
                 TrialStatusUnmappedValidationError(
                     it,
-                    "Cohort ID that is configured to be unmapped is not actually referenced in CTC database"
+                    "Cohort ID that is configured to be unmapped is not actually referenced in trial status database"
                 )
             }
         }

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseReader.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseReader.kt
@@ -40,9 +40,9 @@ class TrialStatusDatabaseReader(private val trialStatusEntryReader: TrialStatusE
     }
 
     private fun readStudiesNotInTrialStatusDatabaseStudies(tsv: String): Set<String> {
-        val notInCTCStudies = StudiesNotInTrialStatusDatabase.read(tsv)
-        LOGGER.info(" Read {} studies not in trial status database from {}", notInCTCStudies.size, tsv)
-        return notInCTCStudies
+        val notInTrialStatusDatabaseStudies = StudiesNotInTrialStatusDatabase.read(tsv)
+        LOGGER.info(" Read {} studies not in trial status database from {}", notInTrialStatusDatabaseStudies.size, tsv)
+        return notInTrialStatusDatabaseStudies
     }
 
     companion object {

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/TestTrialData.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/TestTrialData.kt
@@ -7,5 +7,5 @@ object TestTrialData {
 
     const val TEST_TRIAL_METC_IGNORE = "Ignore-Study"
     const val TEST_UNMAPPED_COHORT_ID = 3
-    const val TEST_MEC_NOT_IN_CTC = "ACTN 2021"
+    const val TEST_MEC_NOT_IN_TRIAL_STATUS_DATABASE = "ACTN 2021"
 }

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/CohortStatusInterpreterTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/CohortStatusInterpreterTest.kt
@@ -9,26 +9,27 @@ class CohortStatusInterpreterTest {
 
     @Test
     fun `Should ignore cohorts that are configured as not available`() {
-        val notAvailable = createWithCTCCohortIDs(CohortStatusInterpreter.NOT_AVAILABLE)
+        val notAvailable = createWithExternalCohortIDs(CohortStatusInterpreter.NOT_AVAILABLE)
         assertThat(evaluate(notAvailable)).isNull()
     }
 
     @Test
-    fun `Should ignore cohorts that are configured as not in CTC overview unknown why`() {
-        val notInCTCOverviewUnknownWhy = createWithCTCCohortIDs(CohortStatusInterpreter.NOT_IN_TRIAL_STATUS_DATABASE_OVERVIEW_UNKNOWN_WHY)
-        assertThat(evaluate(notInCTCOverviewUnknownWhy)).isNull()
+    fun `Should ignore cohorts that are configured as not in trial status database unknown why`() {
+        val notInTrialStatusDatabaseUnknownWhy =
+            createWithExternalCohortIDs(CohortStatusInterpreter.NOT_IN_TRIAL_STATUS_DATABASE_OVERVIEW_UNKNOWN_WHY)
+        assertThat(evaluate(notInTrialStatusDatabaseUnknownWhy)).isNull()
     }
 
     @Test
-    fun `Should ignore cohorts that are configured as overruled because incorrect in CTC`() {
-        val overruledBecauseIncorrectInCTC =
-            createWithCTCCohortIDs(CohortStatusInterpreter.OVERRULED_BECAUSE_INCORRECT_IN_TRIAL_STATUS_DATABASE)
-        assertThat(evaluate(overruledBecauseIncorrectInCTC)).isNull()
+    fun `Should ignore cohorts that are configured as overruled because incorrect in trial status database`() {
+        val overruledBecauseIncorrectInTrialStatusDatabase =
+            createWithExternalCohortIDs(CohortStatusInterpreter.OVERRULED_BECAUSE_INCORRECT_IN_TRIAL_STATUS_DATABASE)
+        assertThat(evaluate(overruledBecauseIncorrectInTrialStatusDatabase)).isNull()
     }
 
     @Test
     fun `Should assume unmapped closed cohorts are closed`() {
-        val notMappedClosed = createWithCTCCohortIDs(CohortStatusInterpreter.WONT_BE_MAPPED_BECAUSE_CLOSED)
+        val notMappedClosed = createWithExternalCohortIDs(CohortStatusInterpreter.WONT_BE_MAPPED_BECAUSE_CLOSED)
         val status = evaluate(notMappedClosed)
         assertThat(status!!.open).isFalse
         assertThat(status.slotsAvailable).isFalse
@@ -36,7 +37,7 @@ class CohortStatusInterpreterTest {
 
     @Test
     fun `Should assume unmapped unavailable cohorts are closed`() {
-        val notMappedNotAvailable = createWithCTCCohortIDs(CohortStatusInterpreter.WONT_BE_MAPPED_BECAUSE_NOT_AVAILABLE)
+        val notMappedNotAvailable = createWithExternalCohortIDs(CohortStatusInterpreter.WONT_BE_MAPPED_BECAUSE_NOT_AVAILABLE)
         val status = evaluate(notMappedNotAvailable)
         assertThat(status!!.open).isFalse
         assertThat(status.slotsAvailable).isFalse
@@ -44,7 +45,7 @@ class CohortStatusInterpreterTest {
 
     @Test(expected = NumberFormatException::class)
     fun `Should throw exception on unexpected non integer cohort id`() {
-        val unexpected = createWithCTCCohortIDs("this is unexpected")
+        val unexpected = createWithExternalCohortIDs("this is unexpected")
         evaluate(unexpected)
     }
 
@@ -53,8 +54,8 @@ class CohortStatusInterpreterTest {
             return CohortStatusInterpreter.interpret(listOf(), cohortConfig).status
         }
 
-        private fun createWithCTCCohortIDs(vararg ctcCohortIDs: String): CohortDefinitionConfig {
-            return TestCohortDefinitionConfigFactory.MINIMAL.copy(externalCohortIds = setOf(*ctcCohortIDs))
+        private fun createWithExternalCohortIDs(vararg externalCohortIDs: String): CohortDefinitionConfig {
+            return TestCohortDefinitionConfigFactory.MINIMAL.copy(externalCohortIds = setOf(*externalCohortIDs))
         }
     }
 }

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/TrialStatusConfigInterpreterTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/TrialStatusConfigInterpreterTest.kt
@@ -200,7 +200,7 @@ class TrialStatusConfigInterpreterTest {
     fun `Should find no unused MEC trial ids not in trial status database when all these trials are configured`() {
         val trialConfigs: List<TrialDefinitionConfig> = listOf(
             TestTrialDefinitionConfigFactory.MINIMAL.copy(
-                trialId = TestTrialData.TEST_MEC_NOT_IN_CTC
+                trialId = TestTrialData.TEST_MEC_NOT_IN_TRIAL_STATUS_DATABASE
             )
         )
 
@@ -219,7 +219,7 @@ class TrialStatusConfigInterpreterTest {
 
         assertThat(trialStatusConfigInterpreter.extractUnusedStudiesNotInTrialStatusDatabase(trialConfigs)).isEqualTo(
             listOf(
-                TestTrialData.TEST_MEC_NOT_IN_CTC
+                TestTrialData.TEST_MEC_NOT_IN_TRIAL_STATUS_DATABASE
             )
         )
 
@@ -234,5 +234,4 @@ class TrialStatusConfigInterpreterTest {
         trialStatusConfigInterpreterIgnoringNewTrials.checkModelForNewTrials(trialConfigs)
         assertThat(trialStatusConfigInterpreterIgnoringNewTrials.validation().trialStatusDatabaseValidationErrors).isEmpty()
     }
-
 }

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/TrialStatusInterpreterTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/TrialStatusInterpreterTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class TrialStatusInterpreterTest {
 
     @Test
-    fun `Should return null for empty CTC Database`() {
+    fun `Should return null for empty trial status Database`() {
         assertThat(
             TrialStatusInterpreter.isOpen(
                 listOf(),

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseFactory.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseFactory.kt
@@ -16,7 +16,7 @@ object TestTrialStatusDatabaseFactory {
             entries = createTestTrialStatusEntries(),
             studyMETCsToIgnore = setOf(TestTrialData.TEST_TRIAL_METC_IGNORE),
             unmappedCohortIds = setOf(TestTrialData.TEST_UNMAPPED_COHORT_ID),
-            studiesNotInTrialStatusDatabase = setOf(TestTrialData.TEST_MEC_NOT_IN_CTC)
+            studiesNotInTrialStatusDatabase = setOf(TestTrialData.TEST_MEC_NOT_IN_TRIAL_STATUS_DATABASE)
         )
     }
 

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TrialStatusDatabaseReaderTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TrialStatusDatabaseReaderTest.kt
@@ -17,7 +17,7 @@ class TrialStatusDatabaseReaderTest {
         assertEntries(database.entries)
         assertStudyMETCsToIgnore(database.studyMETCsToIgnore)
         assertUnmappedCohortIds(database.unmappedCohortIds)
-        assertStudyNotInCTC(database.studiesNotInTrialStatusDatabase)
+        assertStudiesNotInTrialStatusDatabase(database.studiesNotInTrialStatusDatabase)
     }
 
     companion object {
@@ -64,9 +64,9 @@ class TrialStatusDatabaseReaderTest {
             assertThat(unmappedCohortIds.contains(1)).isTrue
         }
 
-        private fun assertStudyNotInCTC(studyWithMECIdNotInCTC: Set<String>) {
-            assertThat(studyWithMECIdNotInCTC).hasSize(1)
-            assertThat(studyWithMECIdNotInCTC.contains("ACTN 2021")).isTrue
+        private fun assertStudiesNotInTrialStatusDatabase(studiesNotInTrialStatusDatabase: Set<String>) {
+            assertThat(studiesNotInTrialStatusDatabase).hasSize(1)
+            assertThat(studiesNotInTrialStatusDatabase.contains("ACTN 2021")).isTrue
         }
     }
 }

--- a/trial/src/test/resources/ctc_config/studies_not_in_trial_status_database.tsv
+++ b/trial/src/test/resources/ctc_config/studies_not_in_trial_status_database.tsv
@@ -1,2 +1,2 @@
-StudyNotInTrialStatusDatabase
+studyNotInTrialStatusDatabase
 ACTN 2021


### PR DESCRIPTION
Have also renamed various other old references to "CTC" where "status database" is more applicable.

Only remaining "incorrect" references to CTC are in tests, due to our proper trial test database depending on CTC trial states. 