### PR TITLE
ACTIN-961 Read both versions of serve from a single parent directory

### DIFF
--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterApplication.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterApplication.kt
@@ -69,49 +69,54 @@ class MolecularInterpreterApplication(private val config: MolecularInterpreterCo
         clinical: ClinicalRecord, orangeRefGenomeVersion: OrangeRefGenomeVersion
     ): Pair<KnownEvents, EvidenceDatabase> {
         val serveRefGenomeVersion = toServeRefGenomeVersion(orangeRefGenomeVersion)
+        val serveDirectoryWithGenome = "${config.serveDirectory}/${serveRefGenomeVersion.name.lowercase().replace("v", "")}"
         val knownEvents = KnownEventsLoader.readFromDir(
-            "${config.serveDirectory}/${serveRefGenomeVersion.name.lowercase().replace("v", "")}",
+            serveDirectoryWithGenome,
             serveRefGenomeVersion
         )
-        val evidenceDatabase = loadEvidenceDatabase(config.serveDirectory, config.doidJson, serveRefGenomeVersion, knownEvents, clinical)
+        val evidenceDatabase = loadEvidenceDatabase(serveDirectoryWithGenome, config.doidJson, serveRefGenomeVersion, knownEvents, clinical)
         return Pair(knownEvents, evidenceDatabase)
+    }
+
+    private fun loadEvidenceDatabase(
+        serveDirectoryWithGenome: String,
+        doidJson: String,
+        serveRefGenomeVersion: RefGenome,
+        knownEvents: KnownEvents,
+        clinical: ClinicalRecord
+    ): EvidenceDatabase {
+        val actionableEvents = ActionableEventsLoader.readFromDir(serveDirectoryWithGenome, serveRefGenomeVersion)
+
+        val tumorDoids = clinical.tumor.doids.orEmpty().toSet()
+        if (tumorDoids.isEmpty()) {
+            LOGGER.warn(" No tumor DOIDs configured in ACTIN clinical data for {}!", clinical.patientId)
+        } else {
+            LOGGER.info(" Tumor DOIDs determined to be: {}", tumorDoids.joinToString(", "))
+        }
+
+        LOGGER.info("Loading DOID tree from {}", doidJson)
+        val doidEntry = DoidJson.readDoidOwlEntry(doidJson)
+
+        LOGGER.info(" Loaded {} nodes", doidEntry.nodes.size)
+        return EvidenceDatabaseFactory.create(knownEvents, actionableEvents, doidEntry, tumorDoids)
+    }
+
+    private fun toServeRefGenomeVersion(refGenomeVersion: OrangeRefGenomeVersion): RefGenome {
+        return when (refGenomeVersion) {
+            OrangeRefGenomeVersion.V37 -> {
+                RefGenome.V37
+            }
+
+            OrangeRefGenomeVersion.V38 -> {
+                RefGenome.V38
+            }
+        }
     }
 
     companion object {
         val LOGGER: Logger = LogManager.getLogger(MolecularInterpreterApplication::class.java)
         const val APPLICATION: String = "ACTIN ORANGE Interpreter"
         private val VERSION = MolecularInterpreterApplication::class.java.getPackage().implementationVersion
-
-        private fun loadEvidenceDatabase(
-            serveDirectory: String, doidJson: String, serveRefGenomeVersion: RefGenome, knownEvents: KnownEvents, clinical: ClinicalRecord
-        ): EvidenceDatabase {
-            val actionableEvents = ActionableEventsLoader.readFromDir(serveDirectory, serveRefGenomeVersion)
-
-            val tumorDoids = clinical.tumor.doids.orEmpty().toSet()
-            if (tumorDoids.isEmpty()) {
-                LOGGER.warn(" No tumor DOIDs configured in ACTIN clinical data for {}!", clinical.patientId)
-            } else {
-                LOGGER.info(" Tumor DOIDs determined to be: {}", tumorDoids.joinToString(", "))
-            }
-
-            LOGGER.info("Loading DOID tree from {}", doidJson)
-            val doidEntry = DoidJson.readDoidOwlEntry(doidJson)
-
-            LOGGER.info(" Loaded {} nodes", doidEntry.nodes.size)
-            return EvidenceDatabaseFactory.create(knownEvents, actionableEvents, doidEntry, tumorDoids)
-        }
-
-        private fun toServeRefGenomeVersion(refGenomeVersion: OrangeRefGenomeVersion): RefGenome {
-            return when (refGenomeVersion) {
-                OrangeRefGenomeVersion.V37 -> {
-                    RefGenome.V37
-                }
-
-                OrangeRefGenomeVersion.V38 -> {
-                    RefGenome.V38
-                }
-            }
-        }
     }
 }
 


### PR DESCRIPTION
Adds 38 or 37 to the serve path based on reference genome specified.

Might be nice to add the path defaulting to serves ref genome class, but doing so in a backwards compatible way is messy given the structure of the code there.