### PR TITLE
ACTIN-1000 Enable special floating point numbers on GSON builder

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/datamodel/orange/PatientRecordJson.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/datamodel/orange/PatientRecordJson.kt
@@ -51,6 +51,7 @@ object PatientRecordJson {
         val gsonBuilder = GsonBuilder()
         return gsonBuilder.serializeNulls()
             .enableComplexMapKeySerialization()
+            .serializeSpecialFloatingPointValues()
             .registerTypeAdapter(object : TypeToken<LocalDate?>() {}.type, GsonLocalDateAdapter())
             .registerTypeAdapter(LocalDateTime::class.java, GsonLocalDateTimeAdapter())
             .registerTypeAdapter(Treatment::class.java, TreatmentAdapter(gsonBuilder.create()))


### PR DESCRIPTION
When running ACTIN on historic patients, serialization of the molecular test history can fail on NaN values (seen in ACTN01020134). From there it is not possible to deduce what field is NaN, as it's not in the stack trace and the json is not persisted.

This change will allow the NaN to be persisted and followed up. Annoyingly, in the case of ACTN01020134, there is no NaN in the output json after enabling this flag.