### PR TITLE
ACTIN-1039: Remove one column from molecular characteristics table definition

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularCharacteristicsGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularCharacteristicsGenerator.kt
@@ -18,7 +18,7 @@ class MolecularCharacteristicsGenerator(private val molecular: MolecularRecord, 
 
     override fun contents(): Table {
         val colWidth = width / 10
-        val table = Tables.createFixedWidthCols(colWidth, colWidth, colWidth, colWidth, colWidth, colWidth, colWidth * 2, colWidth * 2)
+        val table = Tables.createFixedWidthCols(colWidth, colWidth, colWidth, colWidth, colWidth, colWidth * 2, colWidth * 2)
 
         listOf("Purity", "TML Status", "TMB Status", "MS Stability", "HR Status", "DPYD", "UGT1A1").forEach(
             Consumer { title: String -> table.addHeaderCell(Cells.createHeader(title)) })


### PR DESCRIPTION
Bugfix for a change introduced in ACTIN-143. @cbruel @jbartletthmf You could have spotted this from the warnings generated by iTextPDF library.