### PR TITLE
ACTIN-1068: Add new drug type ImmTAC

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/clinical/datamodel/treatment/DrugType.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/datamodel/treatment/DrugType.kt
@@ -112,6 +112,7 @@ enum class DrugType(override val category: TreatmentCategory, private val displa
     IDO1_INHIBITOR(TreatmentCategory.TARGETED_THERAPY, "IDO1 inhibitor"),
     IL_15_CYTOKINE(TreatmentCategory.IMMUNOTHERAPY, "IL-15 cytokine"),
     IL_2_CYTOKINE(TreatmentCategory.IMMUNOTHERAPY, "IL-2 cytokine"),
+    IMMTAC(TreatmentCategory.TARGETED_THERAPY, "ImmTAC"),
     IMMUNE_AGONIST(TreatmentCategory.IMMUNOTHERAPY),
     IMMUNE_CHECKPOINT_INHIBITOR(TreatmentCategory.IMMUNOTHERAPY),
     IMMUNOMODULATOR(TreatmentCategory.IMMUNOTHERAPY),


### PR DESCRIPTION
Examples of this new drug type include "tebentafusp", "IMCnyeso", "IMC-C103C" and "IMC-F106C". All these drugs have no drug types in CKB