### PR TITLE
ACTIN-1059 Add log4j xml for mysql

### DIFF
--- a/database/src/main/resources/log4j.xml
+++ b/database/src/main/resources/log4j.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
+<!--This config exists because mysql connector uses an older version of log4j -->
 <!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
 <log4j:configuration debug="false"
                      xmlns:log4j='http://jakarta.apache.org/log4j/'>


### PR DESCRIPTION
The mysql connector uses an older version of log4j, but we only include a log4j2.xml. 

This PR adds a log4j 1.2 compatible xml with the same config. 