### PR TITLE
ACTIN-1091: Consider SOC as exhausted when tumor type is NSCLC and pl…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatments.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatments.kt
@@ -34,7 +34,9 @@ class HasExhaustedSOCTreatments(
 
             isNSCLC -> {
                 if (hasReceivedPlatinumBasedDoubletOrMore) {
-                    EvaluationFactory.undetermined("Undetermined exhaustion of SOC", "Undetermined exhaustion of SOC")
+                    EvaluationFactory.pass(
+                        "SOC considered exhausted since platinum doublet in treatment history", "SOC considered exhausted"
+                    )
                 } else EvaluationFactory.fail(
                     "Patient has not exhausted SOC (at least platinum doublet remaining)",
                     "SOC not exhausted: at least platinum doublet remaining"

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatmentsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatmentsTest.kt
@@ -39,7 +39,7 @@ class HasExhaustedSOCTreatmentsTest {
     )
 
     @Test
-    fun `Should return undetermined for patient with NSCLC and platinum doublet chemotherapy in treatment history`() {
+    fun `Should pass for patient with NSCLC and platinum doublet chemotherapy in treatment history`() {
         every { recommendationEngine.standardOfCareCanBeEvaluatedForPatient(any()) } returns false
         val platinumDoublet =
             DrugTreatment(
@@ -50,7 +50,7 @@ class HasExhaustedSOCTreatmentsTest {
                 )
             )
         val record = createHistoryWithNSCLCAndTreatment(platinumDoublet)
-        assertEvaluation(EvaluationResult.UNDETERMINED, function.evaluate(record))
+        assertEvaluation(EvaluationResult.PASS, function.evaluate(record))
     }
 
     @Test


### PR DESCRIPTION
…atinum doublet in history

Small change to pre-existing logic: Joop has given the feedback that for NSCLC, regardless the drivers, SOC can be considered exhausted for 99.99% of cases if the patient has received a platinum doublet. Platinum doublet is always, regardless the drivers, the last choice within SOC. The undetermined message was therefore not adding anything (except noise and possibly annoyed users). 