### PR TITLE
ACTIN-1138: pin docker base version

### DIFF
--- a/molecular/Dockerfile
+++ b/molecular/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:11-jre
+# Pin to base version of eclipse-temurin that supports python2, needed for TransVar
+FROM eclipse-temurin:11-jre@sha256:7e474f2d1d3d1291c152d97ee3b9b6689b81e0d535326d8bfc680db35de0969b
 
 ARG VERSION=local-SNAPSHOT
 


### PR DESCRIPTION
Does it make sense to leave the other images on the latest base and only pin molecular?

Test in CI on a throw-away branch seemed to work.