### PR TITLE
ACTIN-1150: fixed bug in WGSSummaryGenerator.tumorOriginPrediction in…

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/WGSSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/WGSSummaryGenerator.kt
@@ -99,7 +99,7 @@ class WGSSummaryGenerator(
 
     private fun tumorOriginPrediction(): String {
         val predictedTumorOrigin = molecular.characteristics.predictedTumorOrigin
-        return if (TumorOriginInterpreter.hasConfidentPrediction(predictedTumorOrigin) && wgsMolecular?.hasSufficientQualityButLowPurity() == true) {
+        return if (TumorOriginInterpreter.hasConfidentPrediction(predictedTumorOrigin) && wgsMolecular?.hasSufficientQualityAndPurity() == true) {
             TumorOriginInterpreter.interpret(predictedTumorOrigin)
         } else if (wgsMolecular?.hasSufficientQuality == true && predictedTumorOrigin != null) {
             val predictionsMeetingThreshold = TumorOriginInterpreter.predictionsToDisplay(predictedTumorOrigin)


### PR DESCRIPTION
…troduced in ACTIN-1111

In ACTIN-1111, `molecular.hasSufficientQualityAndPurity()` was changed to `wgsMolecular?.hasSufficientQualityButLowPurity() == true` -> this is a slightly different function however, resulting in `Inconclusive: ...` on the report even though quality = pass, purity is high and prediction is above 80%.

Works as expected on test report