### PR TITLE
ACTIN-1158: Prevent double identical treatment names in HasHadSomeTre…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
@@ -13,7 +13,7 @@ class HasHadSomeTreatmentsWithCategory(private val category: TreatmentCategory, 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(record.oncologicalHistory, category)
 
         return if (treatmentSummary.numSpecificMatches() >= minTreatmentLines) {
-            val treatmentDisplay = treatmentSummary.specificMatches.joinToString(", ") { it.treatmentDisplay() }
+            val treatmentDisplay = treatmentSummary.specificMatches.map { it.treatmentDisplay() }.toSet().joinToString(", ")
             EvaluationFactory.pass(
                 "Patient has received at least $minTreatmentLines line(s) of ${category.display()} ($treatmentDisplay)",
                 "Has received at least $minTreatmentLines line(s) of ${category.display()} ($treatmentDisplay)"


### PR DESCRIPTION
…atmentsWithCategory message

Prevents the following: `Has received at least 1 line(s) of targeted therapy (same treatment, same treatment, same treatment)` when there are multiple treatment instances (at different timepoints) of the same treatment in input data.