### PR TITLE
ACTIN-1168: Improved "None" message in molecular summary chapter when…

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/PriorMolecularResultGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/PriorMolecularResultGenerator.kt
@@ -16,7 +16,7 @@ class PriorMolecularResultGenerator(
     fun contents(): Table {
         val table = Tables.createFixedWidthCols(keyWidth, valueWidth)
         if (patientRecord.priorIHCTests.isEmpty()) {
-            table.addCell(Cells.createValue("None"))
+            table.addCell(Cells.createValue("No prior non-Hartwig molecular tests"))
         } else {
             val sortedInterpretation = interpreter.interpret(patientRecord)
             for (priorMolecularTestInterpretation in sortedInterpretation) {


### PR DESCRIPTION
… priorMolecularTests is empty

@pauldwolfe let me know if you think another message is more appropriate. I chose non-Hartwig, since `PriorMolecularResultGenerator` (currently) handles other tests than IHC as well. Right now, if there are no non-Hartwig tests, it just displays **None** on the bottom of the molecular summary table (you can try it out with `TestReportWriterApplication` by returning an emptyList in `TestClinicalFactory.createTestPriorMolecularTests()`).