### PR TITLE
ACTIN-1180: Fix first letter capitalization

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -15,7 +15,6 @@ import com.hartwig.actin.report.pdf.util.Cells.createKey
 import com.hartwig.actin.report.pdf.util.Cells.createSpanningValue
 import com.hartwig.actin.report.pdf.util.Cells.createValue
 import com.hartwig.actin.report.pdf.util.Formats.DATE_UNKNOWN
-import com.hartwig.actin.report.pdf.util.Styles.enforceFirstLetterCapitalization
 import com.hartwig.actin.report.pdf.util.Tables.createFixedWidthCols
 import com.hartwig.actin.report.pdf.util.Tables.createSingleColWithWidth
 import com.itextpdf.layout.element.BlockElement
@@ -215,7 +214,7 @@ class PatientClinicalHistoryGenerator(
 
         private fun toPriorOtherConditionString(priorOtherCondition: PriorOtherCondition): String {
             val note = if (!priorOtherCondition.isContraindicationForTherapy) " (no contraindication for therapy)" else ""
-            return enforceFirstLetterCapitalization(priorOtherCondition.name) + note
+            return (priorOtherCondition.name.replaceFirstChar { it.uppercase() }) + note
         }
 
         private fun toDateString(maybeYear: Int?, maybeMonth: Int?): String? {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/util/Styles.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/util/Styles.kt
@@ -118,12 +118,6 @@ object Styles {
         return fontBold
     }
 
-    fun enforceFirstLetterCapitalization(string: String): String {
-        return if (string.isEmpty()) {
-            string
-        } else string.substring(0, 1).uppercase() + string.substring(1)
-    }
-
     private fun createFont(fontPath: String): PdfFont {
         return PdfFontFactory.createFont(loadFontProgram(fontPath), PdfEncodings.IDENTITY_H)
     }


### PR DESCRIPTION
Should fix the problem that first letters in Non-oncological history were not always capitalized.

I'm not sure if 'Styles' is the right place for the function?