### PR TITLE
ACTIN-1236: Bump version of ACTIN-Tools to fix number parsing bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <serve.version>5.0.0</serve.version>
         <actin-personalization.version>0.4.0</actin-personalization.version>
         <orange-datamodel.version>2.6.0</orange-datamodel.version>
-        <actin-transvar.version>0.3.3-beta.2</actin-transvar.version>
-        <actin-pave-lite.version>0.3.3-beta.2</actin-pave-lite.version>
+        <actin-transvar.version>0.3.3</actin-transvar.version>
+        <actin-pave-lite.version>0.3.3</actin-pave-lite.version>
         <pave.version>1.6</pave.version>
 
         <!-- KD: Even though all code is in kotlin, the jooq code generator generates java code that needs to be compiled -->


### PR DESCRIPTION
Due to different localization settings in docker containers