### PR TITLE
ACTIN-1264: Updated HLA inclusion event String for better readability

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasSpecificHLAType.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasSpecificHLAType.kt
@@ -24,7 +24,7 @@ class HasSpecificHLAType(private val hlaAlleleToFind: String) : MolecularEvaluat
                     "Patient has HLA type $hlaAlleleToFind which is equal to required allele type $hlaAlleleToFind,"
                             + " this allele is present and without somatic variants in tumor",
                     "Patient has required HLA type",
-                    inclusionEvents = setOf(hlaAlleleToFind)
+                    inclusionEvents = setOf("HLA-$hlaAlleleToFind")
                 )
             }
 
@@ -33,7 +33,7 @@ class HasSpecificHLAType(private val hlaAlleleToFind: String) : MolecularEvaluat
                     "Patient has HLA type $hlaAlleleToFind which is equal to required allele type $hlaAlleleToFind,"
                             + " however, somatic mutation found in allele in tumor.",
                     "Patient has required HLA type but somatic mutation present in this allele in tumor",
-                    inclusionEvents = setOf(hlaAlleleToFind)
+                    inclusionEvents = setOf("HLA-$hlaAlleleToFind")
                 )
             }
 


### PR DESCRIPTION
Changes e.g. `A*01:01` to `HLA-A*01:01` in column Molecular in trial table