### PR TITLE
ACTIN-1270 Add a configurable cutoff for molecular test age

### DIFF
--- a/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
@@ -26,9 +26,9 @@ import com.hartwig.serve.datamodel.ActionableEvents
 import com.hartwig.serve.datamodel.ImmutableActionableEvents
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.time.LocalDate
 
 class TreatmentMatcherTest {
     private val patient = TestPatientFactory.createMinimalTestWGSPatientRecord()
@@ -56,7 +56,8 @@ class TreatmentMatcherTest {
         trials,
         CurrentDateProvider(),
         EvaluatedTreatmentAnnotator.create(evidenceEntries, resistanceEvidenceMatcher),
-        EMC_TRIAL_SOURCE
+        EMC_TRIAL_SOURCE,
+        null
     )
     private val expectedTreatmentMatch = TreatmentMatch(
         patientId = patient.patientId,
@@ -107,7 +108,8 @@ class TreatmentMatcherTest {
             trials,
             CurrentDateProvider(),
             EvaluatedTreatmentAnnotator.create(evidenceEntries, resistanceEvidenceMatcher),
-            EMC_TRIAL_SOURCE
+            EMC_TRIAL_SOURCE,
+            null
         )
         every { recommendationEngine.standardOfCareCanBeEvaluatedForPatient(patientWithoutMolecular) } returns false
         val expectedTreatmentMatchWithoutMolecular = expectedTreatmentMatch.copy(sampleId = "N/A")

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -47,7 +47,8 @@ const val EMC_TRIAL_SOURCE = "EMC"
 
 data class AlgoConfiguration(
     val trialSource: String = EMC_TRIAL_SOURCE,
-    val warnIfToxicitiesNotFromQuestionnaire: Boolean = true
+    val warnIfToxicitiesNotFromQuestionnaire: Boolean = true,
+    val maxMolecularTestAgeForTrialMatchingInDays: Long? = null
 )
 
 data class TrialConfiguration(

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/MolecularHistory.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/MolecularHistory.kt
@@ -3,7 +3,8 @@ package com.hartwig.actin.datamodel.molecular
 import java.time.LocalDate
 
 data class MolecularHistory(
-    val molecularTests: List<MolecularTest>
+    val molecularTests: List<MolecularTest>,
+    val maxTestAge: LocalDate? = null
 ) {
     fun allOrangeMolecularRecords(): List<MolecularRecord> {
         return molecularTests.filterIsInstance<MolecularRecord>()
@@ -21,6 +22,9 @@ data class MolecularHistory(
     fun hasMolecularData(): Boolean {
         return molecularTests.isNotEmpty()
     }
+
+    fun molecularTestsForTrialMatching() =
+        molecularTests.filter { it.date?.let { date -> maxTestAge == null || date >= maxTestAge } ?: true }
 
     companion object {
         fun empty(): MolecularHistory {


### PR DESCRIPTION
A different approach. The age can be added to the molecular history as a nullable parameter.

The only controversial bit is that we only do this for trial matching, which is maybe logical as that is the only place we want to use it currently... but maybe a big tricky?