### PR TITLE
ACTIN-1287: Clarify last date of treatment

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/SecondPrimaryConfigFactory.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/SecondPrimaryConfigFactory.kt
@@ -9,7 +9,7 @@ import com.hartwig.actin.util.ResourceFile
 
 class SecondPrimaryConfigFactory(private val curationDoidValidator: CurationDoidValidator) : CurationConfigFactory<SecondPrimaryConfig> {
     override fun create(fields: Map<String, Int>, parts: Array<String>): ValidatedCurationConfig<SecondPrimaryConfig> {
-        val input = parts[fields["input (second primary | last treatment date)"]!!]
+        val input = parts[fields["input"]!!]
         val ignore = CurationUtil.isIgnoreString(parts[fields["name"]!!])
         if (!ignore) {
             val (validatedTumorStatus, tumorStatusValidationErrors) = validateMandatoryEnum<TumorStatus>(

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireCuration.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireCuration.kt
@@ -138,7 +138,7 @@ internal object QuestionnaireCuration {
     }
 
     fun toSecondaryPrimaries(secondaryPrimary: String, lastTreatmentInfo: String): List<String> {
-        return listOf(secondaryPrimary + if (lastTreatmentInfo.isEmpty()) "" else " | $lastTreatmentInfo")
+        return listOf(secondaryPrimary + if (lastTreatmentInfo.isEmpty()) "" else " | last treatment date: $lastTreatmentInfo")
     }
 
     fun toInfectionStatus(subject: String, significantCurrentInfection: String?): ValidatedQuestionnaireCuration<InfectionStatus> {

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireCurationTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireCurationTest.kt
@@ -82,7 +82,7 @@ class QuestionnaireCurationTest {
 
     @Test
     fun shouldExtractSecondaryPrimaryAndLastTreatmentDateWhenAvailable() {
-        Assert.assertEquals(listOf("sarcoma | Feb 2020"), toSecondaryPrimaries("sarcoma", "Feb 2020"))
+        Assert.assertEquals(listOf("sarcoma | last treatment date: Feb 2020"), toSecondaryPrimaries("sarcoma", "Feb 2020"))
     }
 
     @Test

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireExtractionTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/questionnaire/QuestionnaireExtractionTest.kt
@@ -250,7 +250,7 @@ class QuestionnaireExtractionTest {
 
             val secondaryPrimaries = questionnaire.secondaryPrimaries
             assertThat(secondaryPrimaries!!).hasSize(1)
-            assertThat(secondaryPrimaries).contains("sarcoma | Feb 2020")
+            assertThat(secondaryPrimaries).contains("sarcoma | last treatment date: Feb 2020")
 
             assertThat(questionnaire.hasMeasurableDisease!!).isTrue
             assertThat(questionnaire.hasBrainLesions!!).isTrue

--- a/clinical/src/test/resources/curation/second_primary.tsv
+++ b/clinical/src/test/resources/curation/second_primary.tsv
@@ -1,2 +1,2 @@
-input (second primary | last treatment date)	name	tumorLocation	tumorSubLocation	tumorType	tumorSubType	doids	diagnosedYear	diagnosedMonth	treatmentHistory	lastTreatmentYear	lastTreatmentMonth	status
-Prostate carconoma | 2019	Prostate carcinoma	Prostate		Carcinoma		10286	2019			2019		ACTIVE
+input	name	tumorLocation	tumorSubLocation	tumorType	tumorSubType	doids	diagnosedYear	diagnosedMonth	treatmentHistory	lastTreatmentYear	lastTreatmentMonth	status
+Prostate carconoma | last treatment date: 2019	Prostate carcinoma	Prostate		Carcinoma		10286	2019			2019		ACTIVE


### PR DESCRIPTION
The “Second primary” and “Last date of active treatment” fields of the questionnaire are currently mapped to the input “$secondary primary | $last date” in our curation sheet for example “bladder carcinoma | june 2024”. This has lead to incorrectly curations, since the last date of active treatment was incorrectly curated as diagnose date. We should clarify (for the people who do curation) that this is the “last date of active treatment”.

-> After merging this I will change the title in the curation sheet (from input -> input (second primary | last treatment date))
-> I would expect we also need to make a change in `actin-pipelines` but I can't find this in the code? Will merging this PR lead to problems?