### PR TITLE
ACTIN-1298: Handle deleted genes from Panels

### DIFF
--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
@@ -91,7 +91,7 @@ class PanelAnnotator(
         isAssociatedWithDrugResistance = null,
         isReportable = true,
         event = sequencedDeletedGene.gene,
-        driverLikelihood = null,
+        driverLikelihood = DriverLikelihood.HIGH,
         evidence = ClinicalEvidenceFactory.createNoEvidence(),
         type = CopyNumberType.LOSS,
         minCopies = 0,

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotatorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotatorTest.kt
@@ -144,7 +144,7 @@ class PanelAnnotatorTest {
                     maxCopies = 0,
                     isReportable = true,
                     event = GENE,
-                    driverLikelihood = null,
+                    driverLikelihood = DriverLikelihood.HIGH,
                     evidence = ClinicalEvidenceFactory.create(ACTIONABILITY_MATCH),
                     gene = GENE,
                     geneRole = GeneRole.ONCO,


### PR DESCRIPTION
Wired theses in similar to amplifications, currently they're just dropped.