### PR TITLE
ACTIN-1337: FAIL in case ASAT or ALAT is too high and other value missing (instead of UNDETERMINED)

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedAsatAndAlatDependingOnLiverMetastases.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedAsatAndAlatDependingOnLiverMetastases.kt
@@ -44,12 +44,9 @@ class HasLimitedAsatAndAlatDependingOnLiverMetastases(
         val alatReferenceString = createReferenceString(mostRecentAlat, hasLiverMetastases)
 
         return when {
-            !checkValidity(mostRecentAsat, ASPARTATE_AMINOTRANSFERASE) -> {
-                evaluateInvalidLabValue(ASPARTATE_AMINOTRANSFERASE, mostRecentAsat, minValidLabDate)
-            }
-
-            !checkValidity(mostRecentAlat, ALANINE_AMINOTRANSFERASE) -> {
-                evaluateInvalidLabValue(ALANINE_AMINOTRANSFERASE, mostRecentAlat, minValidLabDate)
+            !checkValidity(mostRecentAsat, ASPARTATE_AMINOTRANSFERASE) && !checkValidity(mostRecentAlat, ALANINE_AMINOTRANSFERASE) -> {
+                val message = "ASAT and ALAT are not present or cannot be evaluated"
+                EvaluationFactory.recoverableUndetermined(message, message)
             }
 
             asatLimitEvaluation == EXCEEDS_THRESHOLD_AND_OUTSIDE_MARGIN && alatLimitEvaluation == EXCEEDS_THRESHOLD_AND_OUTSIDE_MARGIN -> {
@@ -67,6 +64,14 @@ class HasLimitedAsatAndAlatDependingOnLiverMetastases(
             alatLimitEvaluation == EXCEEDS_THRESHOLD_AND_OUTSIDE_MARGIN -> {
                 val message = "$alatLabValueString exceeds maximum of $alatReferenceString"
                 evaluateOutsideMargin(alatWithinLiverMetastasisLimit == true, hasLiverMetastases, message)
+            }
+
+            !checkValidity(mostRecentAsat, ASPARTATE_AMINOTRANSFERASE) -> {
+                evaluateInvalidLabValue(ASPARTATE_AMINOTRANSFERASE, mostRecentAsat, minValidLabDate)
+            }
+
+            !checkValidity(mostRecentAlat, ALANINE_AMINOTRANSFERASE) -> {
+                evaluateInvalidLabValue(ALANINE_AMINOTRANSFERASE, mostRecentAlat, minValidLabDate)
             }
 
             asatLimitEvaluation == EXCEEDS_THRESHOLD_BUT_WITHIN_MARGIN && alatLimitEvaluation == EXCEEDS_THRESHOLD_BUT_WITHIN_MARGIN -> {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedAsatAndAlatDependingOnLiverMetastasesTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedAsatAndAlatDependingOnLiverMetastasesTest.kt
@@ -36,6 +36,21 @@ class HasLimitedAsatAndAlatDependingOnLiverMetastasesTest {
     }
 
     @Test
+    fun `Should be undetermined when both lab measures are missing`() {
+        evaluateForAllLiverLesionStates(EvaluationResult.UNDETERMINED, emptyList())
+    }
+
+    @Test
+    fun `Should be undetermined when one lab measure is missing and the other one is within margin`() {
+        evaluateForAllLiverLesionStates(EvaluationResult.UNDETERMINED, listOf(ALAT_1_ULN))
+    }
+
+    @Test
+    fun `Should fail when one lab measure is missing but the other one is outside margin`() {
+        evaluateForAllLiverLesionStates(EvaluationResult.FAIL, listOf(ASAT_6_ULN))
+    }
+
+    @Test
     fun `Should fail when both lab values are above requested fold of ULN for both with or without liver metastases`() {
         evaluateForAllLiverLesionStates(EvaluationResult.FAIL, listOf(ASAT_6_ULN, ALAT_6_ULN))
     }


### PR DESCRIPTION
Currently; if we have a patient for who ASAT but not ALAT is measured, we resolve to UNDETERMINED (missing data), even when ASAT is known too high (and vice versa). We should resolve to recoverable fail instead.