### PR TITLE
ACTIN-1364 At least one table in ACTIN report is not properly filled

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularCharacteristicsGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularCharacteristicsGenerator.kt
@@ -33,8 +33,8 @@ class MolecularCharacteristicsGenerator(private val molecular: MolecularTest, pr
             createTMBStatusCell(),
             createMSStabilityCell(),
             createHRStatusCell(),
-            wgsMolecular?.let { Cells.createContent(createPeachSummaryForGene(it.pharmaco, PharmacoGene.DPYD)) },
-            wgsMolecular?.let { Cells.createContent(createPeachSummaryForGene(it.pharmaco, PharmacoGene.UGT1A1)) }
+            wgsMolecular?.let { Cells.createContent(createPeachSummaryForGene(it.pharmaco, PharmacoGene.DPYD)) } ?: Cells.createEmpty(),
+            wgsMolecular?.let { Cells.createContent(createPeachSummaryForGene(it.pharmaco, PharmacoGene.UGT1A1)) } ?: Cells.createEmpty()
         ).forEach { table.addCell(it) }
 
         return table


### PR DESCRIPTION
Added missing headers which were triggering a warning while generating the General table in the Molecular Details section of the report. 