### PR TITLE
ACTIN-1376 VAF not correctly used in molecular history

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
@@ -12,5 +12,8 @@ object DriverTableFunctions {
     }
 
     fun allDrivers(molecularHistory: MolecularHistory): List<Pair<MolecularTest, Set<Driver>>> =
-        molecularHistory.molecularTests.map { it to with(it.drivers) { variants + fusions + viruses + copyNumbers + disruptions } }
+        molecularHistory.molecularTests.map { it to allDrivers(it) }
+
+    fun allDrivers(molecularTest: MolecularTest): Set<Driver> =
+        with(molecularTest.drivers) { variants + fusions + viruses + copyNumbers + disruptions }
 }


### PR DESCRIPTION
Two issues, the way we were structuring the test results meant we always used the VAF of the driver which we were currently looping over for all tests.

Second, since VAF is part of the equality of a variant, we end up with rows drivers * tests and each test row has 3 times the same VAF.

For now, fixed by a little presentation filtering and transforming. But we should revisit and probably move VAF out of the variant interface.