### PR TITLE
ACTIN-1386 Assume availability for NKI cohorts

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReader.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReader.kt
@@ -14,6 +14,7 @@ import java.io.File
 private const val TRIALS_JSON = "trial_cohort_status.json"
 private const val NKI_OPEN_STATUS = "OPEN"
 private val STATUSES_TO_INCLUDE = setOf(NKI_OPEN_STATUS, "CLOSED", "SUSPENDED")
+private const val ALWAYS_ASSUME_OPEN_SLOTS_FOR_NKI = 1
 
 class NKITrialStatusEntryReader : TrialStatusEntryReader {
 
@@ -22,7 +23,6 @@ class NKITrialStatusEntryReader : TrialStatusEntryReader {
         registerModule(JavaTimeModule())
         registerModule(KotlinModule.Builder().build())
     }
-
 
     override fun read(inputPath: String): List<TrialStatusEntry> {
         return mapper.readValue(File("$inputPath/$TRIALS_JSON"), object : TypeReference<List<NKITrialStatus>>() {})
@@ -37,7 +37,7 @@ class NKITrialStatusEntryReader : TrialStatusEntryReader {
                     studyStatus = if (it.studyStatus == NKI_OPEN_STATUS) OPEN else CLOSED,
                     cohortId = it.cohortId,
                     cohortStatus = if (it.cohortOpen == true) OPEN else CLOSED,
-                    cohortSlotsNumberAvailable = it.studySlotsNumberAvailable ?: 0
+                    cohortSlotsNumberAvailable = ALWAYS_ASSUME_OPEN_SLOTS_FOR_NKI
                 )
             }
     }

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReaderTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReaderTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 class NKITrialStatusEntryReaderTest {
 
     @Test
-    fun `Should read all trial status from JSON and only include open, closed and suspended trials`() {
+    fun `Should read all trial status from JSON and only include open, closed and suspended trials but always set slots available to 1`() {
         val status = NKITrialStatusEntryReader().read(resourceOnClasspath("nki_config"))
         assertThat(status).containsExactly(
             TrialStatusEntry(
@@ -30,7 +30,7 @@ class NKITrialStatusEntryReaderTest {
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcde",
                 cohortStatus = TrialStatus.OPEN,
-                cohortSlotsNumberAvailable = 2
+                cohortSlotsNumberAvailable = 1
             ),
             TrialStatusEntry(
                 studyId = 1,
@@ -40,7 +40,7 @@ class NKITrialStatusEntryReaderTest {
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcdef",
                 cohortStatus = TrialStatus.CLOSED,
-                cohortSlotsNumberAvailable = 3
+                cohortSlotsNumberAvailable = 1
             ), TrialStatusEntry(
                 studyId = 1,
                 metcStudyID = "MEC-001",
@@ -49,7 +49,7 @@ class NKITrialStatusEntryReaderTest {
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcdeg",
                 cohortStatus = TrialStatus.CLOSED,
-                cohortSlotsNumberAvailable = 4
+                cohortSlotsNumberAvailable = 1
             ), TrialStatusEntry(
                 studyId = 2,
                 metcStudyID = "MEC-002",
@@ -58,7 +58,7 @@ class NKITrialStatusEntryReaderTest {
                 studyStatus = TrialStatus.CLOSED,
                 cohortId = "cdef",
                 cohortStatus = TrialStatus.OPEN,
-                cohortSlotsNumberAvailable = 5
+                cohortSlotsNumberAvailable = 1
             ),
             TrialStatusEntry(
                 studyId = 5,
@@ -68,7 +68,7 @@ class NKITrialStatusEntryReaderTest {
                 studyStatus = TrialStatus.CLOSED,
                 cohortId = "ghij",
                 cohortStatus = TrialStatus.OPEN,
-                cohortSlotsNumberAvailable = 7
+                cohortSlotsNumberAvailable = 1
             )
         )
     }

--- a/trial/src/test/resources/nki_config/trial_cohort_status.json
+++ b/trial/src/test/resources/nki_config/trial_cohort_status.json
@@ -82,7 +82,7 @@
     "studyAcronym": "CLS-001",
     "studyTitle": "Suspended trial",
     "studyStatus": "SUSPENDED",
-    "studySlotsNumberAvailable": 7,
+    "studySlotsNumberAvailable": 0,
     "studySlotsDateUpdate": "2024-03-12T00:00:00",
     "cohortId": "ghij",
     "cohortOpen": true


### PR DESCRIPTION
Essentially no matter what happens on the feed side, ignore it because we don't trust the data anyway and we've already had these discussions with NKI and agreed that they would rather see cohorts than not in the report.