### PR TITLE
ACTIN-1398: First evaluate oncological history before returning MEDICATION_NOT_PROVIDED

### DIFF
--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedCancerTherapyOfCategoryTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedCancerTherapyOfCategoryTest.kt
@@ -142,11 +142,33 @@ class HasRecentlyReceivedCancerTherapyOfCategoryTest {
     }
 
     @Test
-    fun `Should be undetermined if medication is not provided`() {
+    fun `Should be undetermined if medication is not provided and no matching treatment history entry`() {
         val result = function.evaluate(
             TestPatientFactory.createMinimalTestWGSPatientRecord().copy(medications = null)
         )
         assertEvaluation(EvaluationResult.UNDETERMINED, result)
         Assertions.assertThat(result.recoverable).isTrue()
+    }
+
+    @Test
+    fun `Should pass if medication is not provided but matching treatment history entry`() {
+        val treatments = TreatmentTestFactory.drugTreatment(
+            "PARP inhibitor",
+            category = TreatmentCategory.IMMUNOTHERAPY,
+            types = setOf(DrugType.MONOCLONAL_ANTIBODY_IMMUNOTHERAPY)
+        )
+        val treatmentHistory = listOf(
+            TreatmentTestFactory.treatmentHistoryEntry(
+                setOf(treatments),
+                startYear = REFERENCE_DATE.year,
+                startMonth = REFERENCE_DATE.plusMonths(1).monthValue,
+                stopYear = REFERENCE_DATE.year,
+                stopMonth = REFERENCE_DATE.plusMonths(2).monthValue
+            )
+        )
+        assertEvaluation(
+            EvaluationResult.PASS,
+            function.evaluate(TreatmentTestFactory.withTreatmentsAndMedications(treatmentHistory, null))
+        )
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedTrialMedicationTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedTrialMedicationTest.kt
@@ -76,12 +76,29 @@ class HasRecentlyReceivedTrialMedicationTest {
     }
 
     @Test
-    fun `Should evaluate to undetermined if medication is not provided`() {
+    fun `Should evaluate to undetermined if medication is not provided and no trial in treatment history entry`() {
         val result = functionActive.evaluate(
             TestPatientFactory.createMinimalTestWGSPatientRecord().copy(medications = null)
         )
         assertEvaluation(EvaluationResult.UNDETERMINED, result)
         Assertions.assertThat(result.recoverable).isTrue()
+    }
+
+    @Test
+    fun `Should pass if medication is not provided but trial in treatment history entry`() {
+        val treatments = TreatmentTestFactory.treatment("Chemotherapy", true, setOf(TreatmentCategory.CHEMOTHERAPY))
+        val treatmentHistory = listOf(
+            TreatmentTestFactory.treatmentHistoryEntry(
+                setOf(treatments),
+                isTrial = true,
+                stopYear = evaluationDate.year,
+                stopMonth = evaluationDate.plusMonths(2).monthValue
+            )
+        )
+        assertEvaluation(
+            EvaluationResult.PASS,
+            functionActive.evaluate(TreatmentTestFactory.withTreatmentsAndMedications(treatmentHistory, null))
+        )
     }
 
     @Test

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TreatmentTestFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TreatmentTestFactory.kt
@@ -112,7 +112,7 @@ object TreatmentTestFactory {
         return base.copy(oncologicalHistory = treatmentHistory)
     }
 
-    fun withTreatmentsAndMedications(treatmentHistory: List<TreatmentHistoryEntry>, medications: List<Medication>): PatientRecord {
+    fun withTreatmentsAndMedications(treatmentHistory: List<TreatmentHistoryEntry>, medications: List<Medication>?): PatientRecord {
         return base.copy(oncologicalHistory = treatmentHistory, medications = medications)
     }
 }


### PR DESCRIPTION
In case medication = null (which is the case for all NKI patients) medication rules currently evaluate to `MEDICATION_NOT_PROVIDED`.
In [ACTIN-533](https://github.com/hartwigmedical/actin/pull/751) I added evaluation of treatment history to the medication rules, making it now possible to first check if a matching treatment is found in the treatment history before returning `MEDICATION_NOT_PROVIDED` if `medication == null`.

So the implemented logic:
* If `medication == null`, and no matching treatment found -> `MEDICATION_NOT_PROVIDED`
* If `medication == null`, but a matching treatment is found -> pass / undetermined
* If medication is provided -> just evaluate as before


[ACTIN-533]: https://hartwigmedical.atlassian.net/browse/ACTIN-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ