### PR TITLE
ACTIN-1410: Only display WARN and UNDETERMINED in case of recoverable FAIL

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/interpretation/EvaluationInterpreter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/interpretation/EvaluationInterpreter.kt
@@ -67,10 +67,10 @@ object EvaluationInterpreter {
             EvaluationResult.FAIL -> {
                 listOfNotNull(
                     Pair(evaluation.result, generateEntry(evaluation, evaluation.failSpecificMessages)),
-                    evaluation.warnSpecificMessages.takeIf { it.isNotEmpty() }?.let {
+                    evaluation.warnSpecificMessages.takeIf { it.isNotEmpty() && evaluation.recoverable }?.let {
                         Pair(EvaluationResult.WARN, generateEntry(EvaluationResult.WARN, evaluation.warnSpecificMessages))
                     },
-                    evaluation.undeterminedSpecificMessages.takeIf { it.isNotEmpty() }?.let {
+                    evaluation.undeterminedSpecificMessages.takeIf { it.isNotEmpty() && evaluation.recoverable }?.let {
                         Pair(
                             EvaluationResult.UNDETERMINED,
                             generateEntry(EvaluationResult.UNDETERMINED, evaluation.undeterminedSpecificMessages)

--- a/report/src/test/kotlin/com/hartwig/actin/report/interpretation/EvaluationInterpreterTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/interpretation/EvaluationInterpreterTest.kt
@@ -30,8 +30,6 @@ class EvaluationInterpreterTest {
                     reference = FIRST_CRITERION.text,
                     entriesPerResult = mapOf(
                         Pair(EvaluationResult.FAIL, EvaluationEntry("FAIL", setOf("fail specific 1", "fail specific 2"))),
-                        Pair(EvaluationResult.WARN, EvaluationEntry("WARN", setOf("warn specific 1", "warn specific 2"))),
-                        Pair(EvaluationResult.UNDETERMINED, EvaluationEntry("UNDETERMINED", setOf("undetermined specific")))
                     )
                 )
             )
@@ -55,8 +53,6 @@ class EvaluationInterpreterTest {
                     reference = FIRST_CRITERION.text,
                     entriesPerResult = mapOf(
                         Pair(EvaluationResult.FAIL, EvaluationEntry("FAIL", setOf("fail specific 1", "fail specific 2"))),
-                        Pair(EvaluationResult.WARN, EvaluationEntry("WARN", setOf("warn specific 1", "warn specific 2"))),
-                        Pair(EvaluationResult.UNDETERMINED, EvaluationEntry("UNDETERMINED", setOf("undetermined specific")))
                     )
                 ),
                 EvaluationInterpretation(
@@ -113,7 +109,7 @@ class EvaluationInterpreterTest {
     }
 
     @Test
-    fun `Should clarify recoverable in header`() {
+    fun `Should clarify recoverable in header and add WARN and UNDETERMINED`() {
         val evaluations = mapOf(
             Pair(FIRST_CRITERION, createBaseEvaluation(result = EvaluationResult.FAIL).copy(recoverable = true)),
         )


### PR DESCRIPTION
An oversight that happened during refactoring of original solution (see also ACTIN-1372)