### PR TITLE
ACTIN-1424: NKI-config: drop "eligible but no slots" table if empty

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -33,7 +33,7 @@ data class ReportConfiguration(
     val includeRelevantNonOncologicalHistoryInSummary: Boolean = true,
     val includeApprovedTreatmentsInSummary: Boolean = true,
     val includeTrialMatchingInSummary: Boolean = true,
-    val dropNoSlotsTableIfEmpty: Boolean = false,
+    val includeEligibleButNoSlotsTableIfEmpty: Boolean = true,
     val includeExternalTrialsInSummary: Boolean = true,
     val filterOnSOCExhaustionAndTumorType: Boolean = false,
     val includeClinicalDetailsChapter: Boolean = true,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
@@ -143,7 +143,7 @@ class ReportContentProvider(private val report: Report, private val enableExtend
                 report.config.includeTrialMatchingInSummary
             },
             openCohortsWithoutSlotsGenerator.takeIf {
-                report.config.includeTrialMatchingInSummary && (it.getCohortSize() > 0 || !report.config.dropNoSlotsTableIfEmpty)
+                report.config.includeTrialMatchingInSummary && (it.getCohortSize() > 0 || report.config.includeEligibleButNoSlotsTableIfEmpty)
             },
             cohortsWithMissingGenesGenerator.takeIf {
                 report.config.includeTrialMatchingInSummary


### PR DESCRIPTION
Intended logic: 
- Drop table "eligible but no slots available" if it doesn't contain any cohort/trial. 
- Make this option configurable -> should currently only be active for NKI