### PR TITLE
ACTIN-1487: Turn off automatic flush in report writer

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportWriter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportWriter.kt
@@ -78,7 +78,7 @@ class ReportWriter(private val writeToDisk: Boolean, private val outputDirectory
         pdf.defaultPageSize = PageSize.A4
         pdf.documentInfo.title = Constants.METADATA_TITLE
         pdf.documentInfo.author = Constants.METADATA_AUTHOR
-        val document = Document(pdf)
+        val document = Document(pdf, pdf.defaultPageSize, false)
         document.setMargins(
             Constants.PAGE_MARGIN_TOP,
             Constants.PAGE_MARGIN_RIGHT,


### PR DESCRIPTION
Report writing is currently failing with message:
> Exception in thread "main" com.itextpdf.kernel.exceptions.PdfException: Cannot draw elements on already flushed pages.

Since this is the first deployment since merging https://github.com/hartwigmedical/actin/pull/867, I think it relates to larger elements being kept together. I haven't been able to reproduce the issue locally, but this simple change seems like a likely fix.