### PR TITLE
ACTIN-1505 Remove all unused fields from trial status entry

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusConfigInterpreter.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusConfigInterpreter.kt
@@ -9,7 +9,7 @@ import com.hartwig.actin.trial.config.TrialDefinitionValidationError
 
 class TrialStatusConfigInterpreter(
     private val trialStatusDatabase: TrialStatusDatabase,
-    private val trialPrefix: String? = null,
+    trialPrefix: String? = null,
     private val ignoreNewTrials: Boolean = false
 ) {
 
@@ -110,7 +110,7 @@ class TrialStatusConfigInterpreter(
             LOGGER.info(" No new studies found in trial status database that are not explicitly ignored.")
         } else {
             if (!ignoreNewTrials) {
-                trialStatusDatabaseValidationErrors.addAll(newTrialsInTrialStatusDatabase.distinctBy { it.studyId }.map {
+                trialStatusDatabaseValidationErrors.addAll(newTrialsInTrialStatusDatabase.distinctBy { it.metcStudyID }.map {
                     TrialStatusDatabaseValidationError(
                         it,
                         " New trial detected in trial status database that is not configured to be ignored"

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseValidation.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusDatabaseValidation.kt
@@ -21,6 +21,6 @@ data class TrialStatusDatabaseValidationError(
     override val config: TrialStatusEntry, override val message: String
 ) : ValidationError<TrialStatusEntry> {
     override fun configFormat(config: TrialStatusEntry): String {
-        return "METC=${config.metcStudyID} cohort=${config.cohortName ?: config.cohortId}"
+        return "METC=${config.metcStudyID} cohort=${config.cohortId}"
     }
 }

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusEntry.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/TrialStatusEntry.kt
@@ -1,14 +1,10 @@
 package com.hartwig.actin.trial.status
 
 data class TrialStatusEntry(
-    val studyId: Int,
     val metcStudyID: String,
-    val studyAcronym: String?,
-    val studyTitle: String?,
     val studyStatus: TrialStatus,
     val cohortId: String? = null,
     val cohortParentId: String? = null,
-    val cohortName: String? = null,
     val cohortStatus: TrialStatus? = null,
     val cohortSlotsNumberAvailable: Int? = null,
     val cohortSlotsDateUpdate: String? = null

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/ctc/CTCTrialStatusEntryReader.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/ctc/CTCTrialStatusEntryReader.kt
@@ -18,14 +18,10 @@ class CTCTrialStatusEntryReader : TrialStatusEntryReader {
 
     private fun create(fields: Map<String, Int>, parts: List<String>): TrialStatusEntry {
         return TrialStatusEntry(
-            studyId = ResourceFile.integer(parts[fields["StudyID"]!!]),
             metcStudyID = parts[fields["StudyMETC"]!!],
-            studyAcronym = parts[fields["StudyAcroniem"]!!],
-            studyTitle = parts[fields["StudyTitle"]!!],
             studyStatus = CTCStatusResolver.resolve(parts[fields["StudyStatus"]!!]),
             cohortId = ResourceFile.optionalString(parts[fields["CohortId"]!!]),
             cohortParentId = ResourceFile.optionalString(parts[fields["CohortParentId"]!!]),
-            cohortName = ResourceFile.optionalString(parts[fields["CohortName"]!!]),
             cohortStatus = ResourceFile.optionalString(parts[fields["CohortStatus"]!!])?.let { CTCStatusResolver.resolve(it) },
             cohortSlotsNumberAvailable = ResourceFile.optionalInteger(parts[fields["CohortSlotsNumberAvailable"]!!]),
             cohortSlotsDateUpdate = ResourceFile.optionalString(parts[fields["CohortSlotsDateUpdate"]!!])

--- a/trial/src/main/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReader.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReader.kt
@@ -30,10 +30,7 @@ class NKITrialStatusEntryReader : TrialStatusEntryReader {
             .filter { it.studyStatus in STATUSES_TO_INCLUDE }
             .map {
                 TrialStatusEntry(
-                    studyId = it.studyId.toInt(),
                     metcStudyID = it.studyMetc!!,
-                    studyAcronym = it.studyAcronym,
-                    studyTitle = it.studyTitle,
                     studyStatus = if (it.studyStatus == NKI_OPEN_STATUS) OPEN else CLOSED,
                     cohortId = it.cohortId,
                     cohortStatus = if (it.cohortOpen == true) OPEN else CLOSED,

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseEntryFactory.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseEntryFactory.kt
@@ -6,10 +6,7 @@ import com.hartwig.actin.trial.status.TrialStatusEntry
 object TestTrialStatusDatabaseEntryFactory {
 
     val MINIMAL = TrialStatusEntry(
-        studyId = 0,
         metcStudyID = "",
-        studyAcronym = "",
-        studyTitle = "",
         studyStatus = TrialStatus.OPEN
     )
 

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseFactory.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TestTrialStatusDatabaseFactory.kt
@@ -22,50 +22,32 @@ object TestTrialStatusDatabaseFactory {
 
     private fun createTestTrialStatusEntries(): List<TrialStatusEntry> {
         val study1Mapping1CohortA = TrialStatusEntry(
-            studyId = 1,
             metcStudyID = TestTrialData.TEST_TRIAL_METC_1,
-            studyAcronym = "Acronym-" + TestTrialData.TEST_TRIAL_METC_1,
-            studyTitle = "Title-" + TestTrialData.TEST_TRIAL_METC_1,
             studyStatus = TrialStatus.OPEN,
             cohortId = "1",
-            cohortName = "Cohort A-1",
             cohortStatus = TrialStatus.CLOSED,
             cohortSlotsNumberAvailable = 0
         )
         val study1Mapping2CohortA = TrialStatusEntry(
-            studyId = 1,
             metcStudyID = TestTrialData.TEST_TRIAL_METC_1,
-            studyAcronym = "Acronym-" + TestTrialData.TEST_TRIAL_METC_1,
-            studyTitle = "Title-" + TestTrialData.TEST_TRIAL_METC_1,
             studyStatus = TrialStatus.OPEN,
             cohortId = "2",
-            cohortName = "Cohort A-2",
             cohortStatus = TrialStatus.OPEN,
             cohortSlotsNumberAvailable = 5,
         )
         val study1UnmappedCohort = TrialStatusEntry(
-            studyId = 1,
             metcStudyID = TestTrialData.TEST_TRIAL_METC_1,
-            studyAcronym = "Acronym-" + TestTrialData.TEST_TRIAL_METC_1,
-            studyTitle = "Title-" + TestTrialData.TEST_TRIAL_METC_1,
             studyStatus = TrialStatus.OPEN,
             cohortId = TestTrialData.TEST_UNMAPPED_COHORT_ID,
-            cohortName = "Cohort D",
             cohortStatus = TrialStatus.OPEN,
             cohortSlotsNumberAvailable = 0,
         )
         val study2Mapping = TrialStatusEntry(
-            studyId = 2,
             metcStudyID = TestTrialData.TEST_TRIAL_METC_2,
-            studyAcronym = "Acronym-" + TestTrialData.TEST_TRIAL_METC_2,
-            studyTitle = "Title-" + TestTrialData.TEST_TRIAL_METC_2,
             studyStatus = TrialStatus.OPEN,
         )
         val ignoreStudy = TrialStatusEntry(
-            studyId = 3,
             metcStudyID = TestTrialData.TEST_TRIAL_METC_IGNORE,
-            studyAcronym = "Acronym-Ignore",
-            studyTitle = "Title-Ignore",
             studyStatus = TrialStatus.OPEN,
         )
         return listOf(study1Mapping1CohortA, study1Mapping2CohortA, study1UnmappedCohort, study2Mapping, ignoreStudy)

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TrialStatusDatabaseReaderTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/config/TrialStatusDatabaseReaderTest.kt
@@ -25,33 +25,27 @@ class TrialStatusDatabaseReaderTest {
 
         private fun assertEntries(entries: List<TrialStatusEntry>) {
             assertThat(entries).hasSize(2)
-            val entry1 = findEntryByStudyId(entries, 1)
+            val entry1 = findEntryByStudyId(entries, "METC 1")
             assertThat(entry1.metcStudyID).isEqualTo("METC 1")
-            assertThat(entry1.studyAcronym).isEqualTo("StudyWithCohort")
-            assertThat(entry1.studyTitle).isEqualTo("This is a study with cohort")
             assertThat(entry1.studyStatus).isEqualTo(TrialStatus.OPEN)
             assertThat((entry1.cohortId as String).toLong()).isEqualTo(1)
             assertThat((entry1.cohortParentId as String).toLong()).isEqualTo(2)
-            assertThat(entry1.cohortName).isEqualTo("Cohort A")
             assertThat(entry1.cohortStatus).isEqualTo(TrialStatus.CLOSED)
             assertThat((entry1.cohortSlotsNumberAvailable as Int).toLong()).isEqualTo(5)
             assertThat(entry1.cohortSlotsDateUpdate).isEqualTo("23-04-04")
 
-            val entry2 = findEntryByStudyId(entries, 2)
+            val entry2 = findEntryByStudyId(entries, "METC 2")
             assertThat(entry2.metcStudyID).isEqualTo("METC 2")
-            assertThat(entry2.studyAcronym).isEqualTo("StudyWithoutCohort")
-            assertThat(entry2.studyTitle).isEqualTo("This is a study without cohort")
             assertThat(entry2.studyStatus).isEqualTo(TrialStatus.CLOSED)
             assertThat(entry2.cohortId).isNull()
             assertThat(entry2.cohortParentId).isNull()
-            assertThat(entry2.cohortName).isNull()
             assertThat(entry2.cohortStatus).isNull()
             assertThat(entry2.cohortSlotsNumberAvailable).isNull()
             assertThat(entry2.cohortSlotsDateUpdate).isNull()
         }
 
-        private fun findEntryByStudyId(entries: List<TrialStatusEntry>, studyIdToFind: Int): TrialStatusEntry {
-            return entries.first { it.studyId == studyIdToFind }
+        private fun findEntryByStudyId(entries: List<TrialStatusEntry>, metcToFind: String): TrialStatusEntry {
+            return entries.first { it.metcStudyID == metcToFind }
         }
 
         private fun assertStudyMETCsToIgnore(studyMETCsToIgnore: Set<String>) {

--- a/trial/src/test/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReaderTest.kt
+++ b/trial/src/test/kotlin/com/hartwig/actin/trial/status/nki/NKITrialStatusEntryReaderTest.kt
@@ -13,58 +13,40 @@ class NKITrialStatusEntryReaderTest {
         val status = NKITrialStatusEntryReader().read(resourceOnClasspath("nki_config"))
         assertThat(status).containsExactly(
             TrialStatusEntry(
-                studyId = 1,
                 metcStudyID = "MEC-001",
-                studyAcronym = "OPN-001",
-                studyTitle = "Open trial",
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "abcd",
                 cohortStatus = TrialStatus.OPEN,
                 cohortSlotsNumberAvailable = 1
             ),
             TrialStatusEntry(
-                studyId = 1,
                 metcStudyID = "MEC-001",
-                studyAcronym = "OPN-001",
-                studyTitle = "Open trial",
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcde",
                 cohortStatus = TrialStatus.OPEN,
                 cohortSlotsNumberAvailable = 1
             ),
             TrialStatusEntry(
-                studyId = 1,
                 metcStudyID = "MEC-001",
-                studyAcronym = "OPN-001",
-                studyTitle = "Open trial",
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcdef",
                 cohortStatus = TrialStatus.CLOSED,
                 cohortSlotsNumberAvailable = 1
             ), TrialStatusEntry(
-                studyId = 1,
                 metcStudyID = "MEC-001",
-                studyAcronym = "OPN-001",
-                studyTitle = "Open trial",
                 studyStatus = TrialStatus.OPEN,
                 cohortId = "bcdeg",
                 cohortStatus = TrialStatus.CLOSED,
                 cohortSlotsNumberAvailable = 1
             ), TrialStatusEntry(
-                studyId = 2,
                 metcStudyID = "MEC-002",
-                studyAcronym = "CLS-001",
-                studyTitle = "Closed trial",
                 studyStatus = TrialStatus.CLOSED,
                 cohortId = "cdef",
                 cohortStatus = TrialStatus.OPEN,
                 cohortSlotsNumberAvailable = 1
             ),
             TrialStatusEntry(
-                studyId = 5,
                 metcStudyID = "MEC-005",
-                studyAcronym = "CLS-001",
-                studyTitle = "Suspended trial",
                 studyStatus = TrialStatus.CLOSED,
                 cohortId = "ghij",
                 cohortStatus = TrialStatus.OPEN,


### PR DESCRIPTION
Fields removed are either completely unused or only used in logging and can be replaced.