### PR TITLE
ACTIN-1534: Bump SERVE version to 7.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-
-        <serve.version>7.0.0</serve.version>
+        <serve.version>7.1.0</serve.version>
         <actin-personalization.version>0.24.0</actin-personalization.version>
         <orange-datamodel.version>2.6.0</orange-datamodel.version>
         <actin-transvar.version>0.4.1-beta.1</actin-transvar.version>


### PR DESCRIPTION
This upgrade removes dependency on Google guava that we pull in through ACTIN