### PR TITLE
ACTIN-1559: Fix rounding of 0 VCNs

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactory.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/interpretation/MolecularDriverEntryFactory.kt
@@ -53,7 +53,7 @@ class MolecularDriverEntryFactory(private val molecularDriversInterpreter: Molec
 
     private fun formatCopyNumberString(copyNumber: Double): String {
         val boundedCopyNumber = copyNumber.coerceAtLeast(0.0)
-        return if (boundedCopyNumber < 1) Formats.singleDigitNumber(boundedCopyNumber) else Formats.noDigitNumber(boundedCopyNumber)
+        return if (boundedCopyNumber < 1) Formats.forcedSingleDigitNumber(boundedCopyNumber) else Formats.noDigitNumber(boundedCopyNumber)
     }
 
     private fun fromCopyNumber(copyNumber: CopyNumber): List<MolecularDriverEntry> {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/util/Formats.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/util/Formats.kt
@@ -21,6 +21,7 @@ object Formats {
     private val DECIMAL_FORMAT_SYMBOLS = DecimalFormatSymbols.getInstance(Locale.ENGLISH)
     private val TWO_DIGIT_FORMAT = DecimalFormat("#.##", DECIMAL_FORMAT_SYMBOLS)
     private val SINGLE_DIGIT_FORMAT = DecimalFormat("#.#", DECIMAL_FORMAT_SYMBOLS)
+    private val FORCED_SINGLE_DIGIT_FORMAT = DecimalFormat("#0.0", DECIMAL_FORMAT_SYMBOLS)
     private val NO_DIGIT_FORMAT = DecimalFormat("#", DECIMAL_FORMAT_SYMBOLS)
     private val PERCENTAGE_FORMAT = DecimalFormat("#'%'", DECIMAL_FORMAT_SYMBOLS)
     private val SINGLE_DIGIT_PERCENTAGE_FORMAT = DecimalFormat("#.#'%'", DECIMAL_FORMAT_SYMBOLS)
@@ -31,6 +32,10 @@ object Formats {
 
     fun singleDigitNumber(number: Number): String {
         return SINGLE_DIGIT_FORMAT.format(number)
+    }
+
+    fun forcedSingleDigitNumber(number: Number): String {
+        return FORCED_SINGLE_DIGIT_FORMAT.format(number)
     }
 
     fun noDigitNumber(number: Double): String {

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/util/FormatsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/util/FormatsTest.kt
@@ -12,4 +12,13 @@ class FormatsTest {
         assertThat(Formats.twoDigitNumber(2.1)).isEqualTo("2.1")
         assertThat(Formats.twoDigitNumber(2.0)).isEqualTo("2")
     }
+
+    @Test
+    fun `Should force a single digit when required`() {
+        assertThat(Formats.forcedSingleDigitNumber(2.123)).isEqualTo("2.1")
+        assertThat(Formats.forcedSingleDigitNumber(2.12)).isEqualTo("2.1")
+        assertThat(Formats.forcedSingleDigitNumber(2.1)).isEqualTo("2.1")
+        assertThat(Formats.forcedSingleDigitNumber(2.0)).isEqualTo("2.0")
+        assertThat(Formats.forcedSingleDigitNumber(0.0)).isEqualTo("0.0")
+    }
 }


### PR DESCRIPTION
Before this change, the following behaviour is in place:
 -> VCN 0.2 becomes 0.2
 -> VCN 0.1 becomes 0.1
 -> VCN 0.0 becomes 0

And "0" does not imply 0.0 necessarily. 
