### PR TITLE
ACTIN-1583: Fix message in HasRecentlyReceivedCancerTherapyOfCategory

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
@@ -30,6 +30,10 @@ object Format {
         return concatStrings(strings.map(String::lowercase), SEPARATOR_AND)
     }
 
+    fun concatLowercaseUnlessNumericWithAnd(strings: Iterable<String>): String {
+        return concatStrings(strings.map { if (it.any(Char::isDigit)) it else it.lowercase() }, SEPARATOR_AND)
+    }
+
     fun concatStringsWithAnd(strings: Iterable<String>): String {
         return concatStrings(strings, SEPARATOR_AND)
     }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedCancerTherapyOfCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/washout/HasRecentlyReceivedCancerTherapyOfCategory.kt
@@ -6,6 +6,7 @@ import com.hartwig.actin.algo.evaluation.medication.MEDICATION_NOT_PROVIDED
 import com.hartwig.actin.algo.evaluation.treatment.TrialFunctions
 import com.hartwig.actin.algo.evaluation.util.DateComparison
 import com.hartwig.actin.algo.evaluation.util.Format.concatLowercaseWithAnd
+import com.hartwig.actin.algo.evaluation.util.Format.concatLowercaseUnlessNumericWithAnd
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpretation
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpreter
 import com.hartwig.actin.datamodel.PatientRecord
@@ -32,8 +33,8 @@ data class TreatmentAssessmentExtended(
             hasHadValidTreatment || other.hasHadValidTreatment,
             hasInconclusiveDate || other.hasInconclusiveDate,
             hasHadTrialAfterMinDate || other.hasHadTrialAfterMinDate,
-            matchingDrugs + other.matchingDrugs,
-            matchingMedicationCategories + other.matchingMedicationCategories
+            matchingMedicationCategories + other.matchingMedicationCategories,
+            matchingDrugs + other.matchingDrugs
         )
     }
 }
@@ -61,7 +62,7 @@ class HasRecentlyReceivedCancerTherapyOfCategory(
         val foundTrialMedication = activeMedications.any(Medication::isTrialMedication)
 
         val foundDrugNames = foundMedicationNames + treatmentAssessment.matchingDrugs
-        val foundMedicationString = if (foundDrugNames.isNotEmpty()) ": ${concatLowercaseWithAnd(foundDrugNames)}" else ""
+        val foundMedicationString = if (foundDrugNames.isNotEmpty()) ": ${concatLowercaseUnlessNumericWithAnd(foundDrugNames)}" else ""
         val foundCategories = foundMedicationCategories.toSet() + treatmentAssessment.matchingMedicationCategories
 
         return when {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/util/FormatTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/util/FormatTest.kt
@@ -35,6 +35,13 @@ class FormatTest {
     }
 
     @Test
+    fun shouldLowerCaseStringsAndJoinWithAndUnlessNumeric() {
+        assertEquals("x and y", Format.concatLowercaseUnlessNumericWithAnd(setOf("X", "y")))
+        assertEquals("x", Format.concatLowercaseUnlessNumericWithAnd(setOf("X")))
+        assertEquals("x and X1", Format.concatLowercaseUnlessNumericWithAnd(setOf("X1", "X")))
+    }
+
+    @Test
     fun shouldLowercaseStringsAndJoinWithCommaAndOr() {
         assertEquals("", Format.concatLowercaseWithCommaAndOr(emptySet()))
         assertEquals("x", Format.concatLowercaseWithCommaAndOr(setOf("X")))


### PR DESCRIPTION
There was a bug in the code switching the drug category and drug names in the message. This is now fixed. I also fixed that if a drug name has numbers in it, it's not lowercased. So PEMBROLIZUMAB -> pembrolizumab. But NVL-520 -> NVL-520.

So 
"Recent 'nvl-520' drug use: anticancer - pay attention to washout period" 
will become:
"Recent 'anticancer' drug use: NVL-520 - pay attention to washout period"

Please let me know if you still think this message is unclear! And thanks for catching this bug!