### PR TITLE
ACTIN-1619: Ignore case in ICD title check for curation input

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -18,9 +18,7 @@ class IcdModel(
 
     fun isValidIcdTitle(icdTitle: String): Boolean {
         val titles = icdTitle.split('&')
-        return titles.size in 1..2 && titles.all { title ->
-            titleToCodeMap.keys.any { it.equals(title, ignoreCase = true) }
-        }
+        return titles.size in 1..2 && titles.map(String::lowercase).all(titleToCodeMap::containsKey)
     }
 
     fun isValidIcdCode(icdCode: String): Boolean {
@@ -29,7 +27,7 @@ class IcdModel(
     }
 
     fun resolveCodeForTitle(icdTitle: String): IcdCode? {
-        val split = icdTitle.split('&')
+        val split = icdTitle.lowercase().split('&')
         return titleToCodeMap[split[0]]?.let { mainCode ->
             split.takeIf { it.size == 2 }?.get(1)?.trim()?.ifEmpty { null }?.let { extensionTitle ->
                 titleToCodeMap[extensionTitle]?.let { IcdCode(mainCode, it) } ?: return null
@@ -95,6 +93,7 @@ class IcdModel(
         }
 
         private fun createCodeToNodeMap(icdNodes: List<IcdNode>): Map<String, IcdNode> = icdNodes.associateBy { it.code }
-        private fun createTitleToCodeMap(icdNodes: List<IcdNode>): Map<String, String> = icdNodes.associate { it.title to it.code }
+        private fun createTitleToCodeMap(icdNodes: List<IcdNode>): Map<String, String> =
+            icdNodes.associate { it.title.lowercase() to it.code }
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
@@ -66,6 +66,12 @@ class IcdModelTest {
     }
 
     @Test
+    fun `Should ignore case in code to title resolution`() {
+        assertThat(icdModel.resolveCodeForTitle("TargetMainTitle&targetEXTENSIONTitle"))
+            .isEqualTo(IcdCode("targetMainCode", "targetExtensionCode"))
+    }
+
+    @Test
     fun `Should successfully resolve code with parents`() {
         assertThat(icdModel.codeWithAllParents("targetMainCode")).containsExactly("targetMainParentCode", "targetMainCode")
         assertThat(icdModel.codeWithAllParents("targetExtensionCode")).containsExactly(


### PR DESCRIPTION
I did not like to drop the quick lookup with `titles.all(titleToCodeMap::containsKey)`, but ignore case helps making trial curation a little bit more efficient.

I had another solution in mind (below), but this might be slower since you convert the entire map for every title you validate.

```
fun isValidIcdTitle(icdTitle: String): Boolean {
        val titles = icdTitle.split('&').map(String::lowercase)
        val normalisedMap = titleToCodeMap.mapKeys { it.key.lowercase() }
        return titles.size in 1..2 && titles.all(normalisedMap::containsKey)
    }
```