### PR TITLE
ACTIN-1628: Consider chemoradiotherapy as SOC exhaustion for lung can…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatments.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatments.kt
@@ -7,7 +7,7 @@ import com.hartwig.actin.algo.evaluation.tumor.DoidEvaluationFunctions.createFul
 import com.hartwig.actin.algo.soc.RecommendationEngineFactory
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
-import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.datamodel.clinical.treatment.Treatment
 import com.hartwig.actin.doid.DoidModel
 
 class HasExhaustedSOCTreatments(
@@ -20,9 +20,7 @@ class HasExhaustedSOCTreatments(
         val hasReceivedPlatinumBasedDoubletOrMore =
             TreatmentFunctions.receivedPlatinumDoublet(record) || TreatmentFunctions.receivedPlatinumTripletOrAbove(record)
         val hasReceivedUndefinedChemoradiation = record.oncologicalHistory.any {
-            it.treatments.flatMap { treatment -> treatment.categories() }
-                .containsAll(listOf(TreatmentCategory.CHEMOTHERAPY, TreatmentCategory.RADIOTHERAPY)) &&
-                    !it.hasTypeConfigured()
+            it.treatments.map(Treatment::name).containsAll(listOf("CHEMOTHERAPY", "RADIOTHERAPY"))
         }
 
         return when {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatmentsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasExhaustedSOCTreatmentsTest.kt
@@ -54,32 +54,42 @@ class HasExhaustedSOCTreatmentsTest {
     }
 
     @Test
-    fun `Should pass for patient with NSCLC and chemoradiation in treatment history`() {
+    fun `Should pass for patient with NSCLC and history entry with treatment names CHEMOTHERAPY and RADIOTHERAPY`() {
         every { recommendationEngine.standardOfCareCanBeEvaluatedForPatient(any()) } returns false
         val chemoradiation =
             TreatmentTestFactory.treatmentHistoryEntry(
                 listOf(
                     DrugTreatment(
-                        name = "Unknown chemotherapy drug",
+                        name = "CHEMOTHERAPY",
                         drugs = setOf(
                             Drug(name = "Chemo", category = TreatmentCategory.CHEMOTHERAPY, drugTypes = emptySet()),
                         )
                     ),
-                    TreatmentTestFactory.treatment("radiotherapy", false, setOf(TreatmentCategory.RADIOTHERAPY), emptySet())
+                    TreatmentTestFactory.treatment("RADIOTHERAPY", false, setOf(TreatmentCategory.RADIOTHERAPY), emptySet())
                 )
             )
 
-        val base = TestPatientFactory.createMinimalTestWGSPatientRecord()
-        val record = base.copy(
-            tumor = base.tumor.copy(doids = setOf(DoidConstants.LUNG_NON_SMALL_CELL_CARCINOMA_DOID)),
-            oncologicalHistory = listOf(chemoradiation)
+        val chemoradiationWithOther = chemoradiation.copy(
+            treatments = chemoradiation.treatments + TreatmentTestFactory.treatment(
+                "OTHER",
+                false,
+                setOf(TreatmentCategory.IMMUNOTHERAPY),
+                emptySet()
+            )
         )
 
-        assertEvaluation(EvaluationResult.PASS, function.evaluate(record))
+        val base = TestPatientFactory.createMinimalTestWGSPatientRecord()
+        listOf(chemoradiation, chemoradiationWithOther).forEach {
+            val record = base.copy(
+                tumor = base.tumor.copy(doids = setOf(DoidConstants.LUNG_NON_SMALL_CELL_CARCINOMA_DOID)),
+                oncologicalHistory = listOf(it)
+            )
+            assertEvaluation(EvaluationResult.PASS, function.evaluate(record))
+        }
     }
 
     @Test
-    fun `Should fail for patient with NSCLC with other treatment than platinum doublet chemotherapy in treatment history`() {
+    fun `Should fail for patient with NSCLC with other treatment in treatment history`() {
         every { recommendationEngine.standardOfCareCanBeEvaluatedForPatient(any()) } returns false
         val treatment =
             TreatmentTestFactory.drugTreatment("Alectinib", TreatmentCategory.TARGETED_THERAPY, setOf(DrugType.ALK_INHIBITOR))


### PR DESCRIPTION
…cer patients

Intended logic:
- Sometimes we just get "chemoradiation" as treatment input data. In lung cancer we can assume that this means SOC is exhausted (same as we did already for prior platinum doublet treatment).

It works when testing on real patient data, though the entire solution is not super elegant but that's partly due to the fact that we cannot configure chemoradiation treatment properly (it's just a history entry containing chemo treatment and radiotherapy treatment instances)