### PR TITLE
ACTIN-1682: Fix usage of wrong unit in message & clarify string in case of conversion

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedLabValue.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedLabValue.kt
@@ -18,17 +18,21 @@ class HasLimitedLabValue(
             ?: return EvaluationFactory.recoverableUndetermined(
                 "Could not convert value for ${labMeasurement.display()} to ${targetUnit.display()}"
             )
-
-        val labValueString = "${labValue(labMeasurement, convertedValue, labValue.unit)} ${targetUnit.display()}"
+        val labValueString = labValue(
+            labMeasurement,
+            convertedValue,
+            targetUnit
+        ) + (" (converted from: ${labValue.value} ${labValue.unit.display()})".takeIf { convertedValue != labValue.value } ?: "")
+        val refString = "$maxValue ${targetUnit.display()}"
 
         return when (evaluateVersusMaxValueWithMargin(convertedValue, labValue.comparator, maxValue)) {
             LabEvaluation.LabEvaluationResult.EXCEEDS_THRESHOLD_AND_OUTSIDE_MARGIN -> {
-                EvaluationFactory.recoverableFail("$labValueString exceeds max of $maxValue ${targetUnit.display()}")
+                EvaluationFactory.recoverableFail("$labValueString exceeds max of $refString")
             }
 
             LabEvaluation.LabEvaluationResult.EXCEEDS_THRESHOLD_BUT_WITHIN_MARGIN -> {
                 EvaluationFactory.recoverableUndetermined(
-                    "$labValueString exceeds max of $maxValue ${targetUnit.display()} but within margin of error"
+                    "$labValueString exceeds max of $refString but within margin of error"
                 )
             }
 
@@ -39,7 +43,7 @@ class HasLimitedLabValue(
             }
 
             LabEvaluation.LabEvaluationResult.WITHIN_THRESHOLD -> {
-                EvaluationFactory.recoverablePass("$labValueString below max of $maxValue ${targetUnit.display()}")
+                EvaluationFactory.recoverablePass("$labValueString below max of $refString")
             }
         }
     }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasSufficientLabValue.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasSufficientLabValue.kt
@@ -18,7 +18,11 @@ class HasSufficientLabValue(
             ?: return EvaluationFactory.recoverableUndetermined(
                 "Could not convert value for ${labMeasurement.display()} to ${targetUnit.display()}"
             )
-        val labValueString = "${labValue(labMeasurement, convertedValue, labValue.unit)} ${targetUnit.display()}"
+        val labValueString = labValue(
+            labMeasurement,
+            convertedValue,
+            targetUnit
+        ) + (" (converted from: ${labValue.value} ${labValue.unit.display()})".takeIf { convertedValue != labValue.value } ?: "")
         val refString = "$minValue ${targetUnit.display()}"
 
         return when (evaluateVersusMinValueWithMargin(convertedValue, labValue.comparator, minValue)) {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedLabValueTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasLimitedLabValueTest.kt
@@ -46,6 +46,7 @@ class HasLimitedLabValueTest {
         val actual = function.evaluate(record, measurement, LabTestFactory.create(measurement, 2.0))
         assertEvaluation(EvaluationResult.FAIL, actual)
         assertThat(actual.recoverable).isTrue()
+        assertThat(actual.failMessages).containsExactly("Absolute thrombocyte count 2.0 10^9/L exceeds max of 1.0 10^9/L")
     }
 
     @Test
@@ -58,7 +59,10 @@ class HasLimitedLabValueTest {
         assertEvaluation(EvaluationResult.FAIL, function.evaluate(record, measurement, targetUnit.copy(value = 2.0)))
         assertEvaluation(EvaluationResult.PASS, function.evaluate(record, measurement, targetUnit.copy(value = 0.5)))
         assertEvaluation(EvaluationResult.PASS, function.evaluate(record, measurement, offUnit.copy(value = 80.0)))
-        assertEvaluation(EvaluationResult.FAIL, function.evaluate(record, measurement, offUnit.copy(value = 120.0)))
+
+        val evaluation = function.evaluate(record, measurement, offUnit.copy(value = 120.0))
+        assertEvaluation(EvaluationResult.FAIL, evaluation)
+        assertThat(evaluation.failMessages).containsExactly("Creatinine 1.4 mg/dL (converted from: 120.0 umol/L) exceeds max of 1.0 mg/dL")
 
         // Test that evaluation becomes undetermined if lab evaluation cannot convert.
         assertEvaluation(

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasSufficientLabValueTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/laboratory/HasSufficientLabValueTest.kt
@@ -46,6 +46,7 @@ class HasSufficientLabValueTest {
         val actual = function.evaluate(record, measurement, LabTestFactory.create(measurement, 100.0))
         assertEvaluation(EvaluationResult.FAIL, actual)
         assertThat(actual.recoverable).isTrue()
+        assertThat(actual.failMessages).containsExactly("Absolute thrombocyte count 100.0 10^9/L below min of 200.0 10^9/L")
     }
 
     @Test
@@ -63,7 +64,10 @@ class HasSufficientLabValueTest {
 
         // Different unit
         assertEvaluation(EvaluationResult.PASS, function.evaluate(record, measurement, offUnit.copy(value = 12.2)))
-        assertEvaluation(EvaluationResult.FAIL, function.evaluate(record, measurement, offUnit.copy(value = 8.2)))
+
+        val evaluation = function.evaluate(record, measurement, offUnit.copy(value = 8.2))
+        assertEvaluation(EvaluationResult.FAIL, evaluation)
+        assertThat(evaluation.failMessages).containsExactly("Hemoglobin 5.1 mmol/L (converted from: 8.2 g/dL) below min of 7.5 mmol/L")
 
         // Works with other unit as target unit as well.
         val function2 = HasSufficientLabValue(7.5, measurement, LabUnit.GRAMS_PER_DECILITER)


### PR DESCRIPTION
- (wrong) unit(s) were shown in duplicate in message
- clarified string in case of conversion
- fixed for all usages of 'convert' and added tests for message generation.