### PR TITLE
ACTIN-1711: Annotate disruptions with gene role prior to adding evidence

### DIFF
--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/MolecularRecordAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/MolecularRecordAnnotator.kt
@@ -106,13 +106,13 @@ class MolecularRecordAnnotator(private val evidenceDatabase: EvidenceDatabase) :
 
     private fun annotateDisruption(disruption: Disruption): Disruption {
         val alteration = GeneAlterationFactory.convertAlteration(disruption.gene, evidenceDatabase.geneAlterationForDisruption(disruption))
-        val disruptionWithGeneAlterations = disruption.copy(
+        val disruptionWithGeneAlteration = disruption.copy(
             geneRole = alteration.geneRole,
             proteinEffect = alteration.proteinEffect,
             isAssociatedWithDrugResistance = alteration.isAssociatedWithDrugResistance,
         )
-        val evidence = evidenceDatabase.evidenceForDisruption(disruptionWithGeneAlterations)
-        return disruptionWithGeneAlterations.copy(evidence = evidence)
+        val evidence = evidenceDatabase.evidenceForDisruption(disruptionWithGeneAlteration)
+        return disruptionWithGeneAlteration.copy(evidence = evidence)
     }
 
     private fun annotateFusion(fusion: Fusion): Fusion {


### PR DESCRIPTION
Bug fix where disruptions were annotated with evidence before annotation with geneRole

@spdeleeuw do you need this fix now? then we can merge it and change order for other events later?