### PR TITLE
ACTIN-1716: Improve HasHadOtherConditionWithIcdCodeFromSetRecently me…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/OtherConditionRuleMapper.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/othercondition/OtherConditionRuleMapper.kt
@@ -65,20 +65,20 @@ class OtherConditionRuleMapper(resources: RuleMappingResources) : RuleMapper(res
                 setOf(IcdCode(IcdConstants.ACUTE_MYOCARDIAL_INFARCT_CODE)),
                 "myocardial infarct"
             ),
-            EligibilityRule.HAS_HISTORY_OF_MYOCARDIAL_INFARCT_WITHIN_X_MONTHS to hasRecentPriorConditionWithIcdCodeFromSetCreator(
+            EligibilityRule.HAS_HISTORY_OF_MYOCARDIAL_INFARCT_WITHIN_X_MONTHS to hasRecentComorbidityWithIcdCodeFromSetCreator(
                 setOf(IcdCode(IcdConstants.ACUTE_MYOCARDIAL_INFARCT_CODE)), "myocardial infarct"
             ),
-            EligibilityRule.HAS_HISTORY_OF_SPECIFIC_CONDITION_WITH_ICD_TITLE_X_WITHIN_Y_MONTHS to hasRecentPriorConditionWithConfiguredIcdCodeCreator(),
+            EligibilityRule.HAS_HISTORY_OF_SPECIFIC_CONDITION_WITH_ICD_TITLE_X_WITHIN_Y_MONTHS to hasRecentComorbidityWithConfiguredIcdCodeCreator(),
             EligibilityRule.HAS_HISTORY_OF_PNEUMONITIS to hasOtherConditionWithIcdCodesFromSetCreator(
                 setOf(IcdCode(IcdConstants.PNEUMONITIS_BLOCK)),
                 "pneumonitis"
             ),
             EligibilityRule.HAS_HISTORY_OF_STROKE to hasHistoryOfStrokeCreator(),
-            EligibilityRule.HAS_HISTORY_OF_STROKE_WITHIN_X_MONTHS to hasRecentPriorConditionWithIcdCodeFromSetCreator(
+            EligibilityRule.HAS_HISTORY_OF_STROKE_WITHIN_X_MONTHS to hasRecentComorbidityWithIcdCodeFromSetCreator(
                 IcdConstants.STROKE_SET.map { IcdCode(it) }.toSet(),
                 "CVA"
             ),
-            EligibilityRule.HAS_HISTORY_OF_THROMBOEMBOLIC_EVENT_WITHIN_X_MONTHS to hasRecentPriorConditionWithIcdCodeFromSetCreator(
+            EligibilityRule.HAS_HISTORY_OF_THROMBOEMBOLIC_EVENT_WITHIN_X_MONTHS to hasRecentComorbidityWithIcdCodeFromSetCreator(
                 IcdConstants.THROMBOEMBOLIC_EVENT_SET.map { IcdCode(it) }.toSet(),
                 "thrombo-embolic event"
             ),
@@ -174,26 +174,21 @@ class OtherConditionRuleMapper(resources: RuleMappingResources) : RuleMapper(res
         return { HasInheritedPredispositionToBleedingOrThrombosis(icdModel()) }
     }
 
-    private fun hasRecentPriorConditionWithIcdCodeFromSetCreator(
-        targetIcdCodes: Set<IcdCode>,
-        diseaseDescription: String
-    ): FunctionCreator {
+    private fun hasRecentComorbidityWithIcdCodeFromSetCreator(targetIcdCodes: Set<IcdCode>, diseaseDescription: String): FunctionCreator {
         return { function: EligibilityFunction ->
             val maxMonthsAgo = functionInputResolver().createOneIntegerInput(function)
             val minDate = referenceDateProvider().date().minusMonths(maxMonthsAgo.toLong() - 1)
-            HasHadOtherConditionWithIcdCodeFromSetRecently(icdModel(), targetIcdCodes, diseaseDescription, minDate)
+            HasHadOtherConditionWithIcdCodeFromSetRecently(icdModel(), targetIcdCodes, diseaseDescription, minDate, maxMonthsAgo)
         }
     }
 
-    private fun hasRecentPriorConditionWithConfiguredIcdCodeCreator(): FunctionCreator {
+    private fun hasRecentComorbidityWithConfiguredIcdCodeCreator(): FunctionCreator {
         return { function: EligibilityFunction ->
             val input = functionInputResolver().createOneIcdTitleOneIntegerInput(function)
             val targetIcdCode = icdModel().resolveCodeForTitle(input.icdTitle)!!
             val maxMonthsAgo = input.integer
             val minDate = referenceDateProvider().date().minusMonths(maxMonthsAgo.toLong() - 1)
-            HasHadOtherConditionWithIcdCodeFromSetRecently(
-                icdModel(), setOf(targetIcdCode), input.icdTitle, minDate
-            )
+            HasHadOtherConditionWithIcdCodeFromSetRecently(icdModel(), setOf(targetIcdCode), input.icdTitle, minDate, maxMonthsAgo)
         }
     }
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/DateComparison.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/DateComparison.kt
@@ -21,6 +21,10 @@ object DateComparison {
         return isAfterDate(maxDate, year, month)?.not()
     }
 
+    fun isExactYearAndMonth(refDate: LocalDate, year: Int?, month: Int?): Boolean {
+        return year == refDate.year && month == refDate.monthValue
+    }
+
     fun minWeeksBetweenDates(startYear: Int?, startMonth: Int?, stopYear: Int?, stopMonth: Int?): Long? {
         return if (startYear != null && stopYear != null) {
             ChronoUnit.WEEKS.between(

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/othercondition/HasHadOtherConditionWithIcdCodeFromSetRecentlyTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/othercondition/HasHadOtherConditionWithIcdCodeFromSetRecentlyTest.kt
@@ -12,42 +12,45 @@ import org.junit.Test
 
 class HasHadOtherConditionWithIcdCodeFromSetRecentlyTest {
 
-    private val minDate: LocalDate = LocalDate.of(2021, 8, 2)
+    private val referenceDate: LocalDate = LocalDate.of(2022, 2, 2)
+    private val maxMonthsAgo = 6
+    private val minDate: LocalDate = referenceDate.minusMonths(maxMonthsAgo.toLong())
     private val targetIcdCodes = IcdConstants.STROKE_SET.map { IcdCode(it) }.toSet()
     private val icdModel = IcdModel.create(targetIcdCodes.map { IcdNode(it.mainCode, emptyList(), it.mainCode + "node") })
     private val function =
-        HasHadOtherConditionWithIcdCodeFromSetRecently(icdModel, targetIcdCodes, "stroke", minDate)
+        HasHadOtherConditionWithIcdCodeFromSetRecently(icdModel, targetIcdCodes, "stroke", minDate, maxMonthsAgo)
 
     @Test
     fun `Should warn if condition in history with correct ICD code and within first 2 months of specified time-frame`() {
-        EvaluationAssert.assertEvaluation(
-            EvaluationResult.WARN,
-            function.evaluate(
-                ComorbidityTestFactory.withOtherCondition(
-                    ComorbidityTestFactory.otherCondition(
-                        year = minDate.plusMonths(1).year,
-                        month = minDate.plusMonths(1).monthValue,
-                        icdMainCode = targetIcdCodes.first().mainCode
-                    )
+        val conditionDate = minDate.plusMonths(1)
+        val evaluation = function.evaluate(
+            ComorbidityTestFactory.withOtherCondition(
+                ComorbidityTestFactory.otherCondition(
+                    name = "cerebral bleeding",
+                    year = conditionDate.year,
+                    month = conditionDate.monthValue,
+                    icdMainCode = targetIcdCodes.first().mainCode
                 )
             )
+        )
+        EvaluationAssert.assertEvaluation(EvaluationResult.WARN, evaluation)
+        assertThat(evaluation.warnMessages).containsExactly(
+            "History of stroke within last $maxMonthsAgo months (cerebral bleeding (${conditionDate.year}-${conditionDate.monthValue}))"
         )
     }
 
     @Test
     fun `Should pass if condition in history with correct ICD code and within specified time-frame but not in first 2 months`() {
-        val evaluation = function.evaluate(
-            ComorbidityTestFactory.withOtherCondition(
-                ComorbidityTestFactory.otherCondition(
-                    name = "cerebral bleeding",
-                    year = minDate.plusYears(1).year,
-                    month = 1,
-                    icdMainCode = targetIcdCodes.first().mainCode
-                )
-            )
+        val bleeding = ComorbidityTestFactory.otherCondition(
+            name = "cerebral bleeding",
+            year = minDate.plusYears(1).year,
+            month = 1,
+            icdMainCode = targetIcdCodes.first().mainCode
         )
+        val infarction = bleeding.copy(name = "cerebral infarction")
+        val evaluation = function.evaluate(ComorbidityTestFactory.withOtherConditions(listOf(bleeding, infarction)))
         EvaluationAssert.assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessages).containsExactly("Recent stroke (cerebral bleeding)")
+        assertThat(evaluation.passMessages).containsExactly("Recent stroke (cerebral bleeding, cerebral infarction)")
     }
 
     @Test
@@ -68,6 +71,24 @@ class HasHadOtherConditionWithIcdCodeFromSetRecentlyTest {
     }
 
     @Test
+    fun `Should warn if history contains condition with correct ICD code and date equal to minDate`() {
+        val evaluation = function.evaluate(
+            ComorbidityTestFactory.withOtherCondition(
+                ComorbidityTestFactory.otherCondition(
+                    name = "cerebral bleeding",
+                    year = minDate.year,
+                    month = minDate.monthValue,
+                    icdMainCode = targetIcdCodes.first().mainCode
+                )
+            )
+        )
+        EvaluationAssert.assertEvaluation(EvaluationResult.WARN, evaluation)
+        assertThat(evaluation.warnMessages).containsExactly(
+            "History of stroke within last $maxMonthsAgo months (cerebral bleeding (${minDate.year}-${minDate.monthValue}))"
+        )
+    }
+
+    @Test
     fun `Should evaluate to undetermined if condition in history with correct ICD code but unknown date`() {
         EvaluationAssert.assertEvaluation(
             EvaluationResult.UNDETERMINED,
@@ -84,7 +105,7 @@ class HasHadOtherConditionWithIcdCodeFromSetRecentlyTest {
     @Test
     fun `Should evaluate to undetermined if condition matches main ICD code but has unknown extension`() {
         val function = HasHadOtherConditionWithIcdCodeFromSetRecently(
-            icdModel, setOf(IcdCode(IcdConstants.STROKE_NOS_CODE, "extensionCode")), "stroke", minDate
+            icdModel, setOf(IcdCode(IcdConstants.STROKE_NOS_CODE, "extensionCode")), "stroke", minDate, maxMonthsAgo
         )
         EvaluationAssert.assertEvaluation(
             EvaluationResult.UNDETERMINED,

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/util/DateComparisonTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/util/DateComparisonTest.kt
@@ -31,6 +31,19 @@ class DateComparisonTest {
     }
 
     @Test
+    fun `Should determine if year and month are exactly the same as reference date`() {
+        val refMonth = 6
+        val refYear = 2020
+        val refDate = LocalDate.of(refYear, refMonth, 20)
+        assertThat(DateComparison.isExactYearAndMonth(refDate, null, null)).isFalse()
+        assertThat(DateComparison.isExactYearAndMonth(refDate, refYear, null)).isFalse()
+        assertThat(DateComparison.isExactYearAndMonth(refDate, refYear, refMonth)).isTrue()
+        assertThat(DateComparison.isExactYearAndMonth(refDate, null, refMonth)).isFalse()
+        assertThat(DateComparison.isExactYearAndMonth(refDate, refYear, refMonth.minus(1))).isFalse()
+        assertThat(DateComparison.isExactYearAndMonth(refDate, refYear.minus(1), refMonth)).isFalse()
+    }
+
+    @Test
     fun `Should return null when start or stop year is null`() {
         assertThat(DateComparison.minWeeksBetweenDates(null, null, null, null)).isNull()
         assertThat(DateComparison.minWeeksBetweenDates(1900, null, null, null)).isNull()


### PR DESCRIPTION
…ssaging

It makes more sense to me to write the condition we are evaluating first, and the specific condition the patient has (which belongs to the category or condition we are evaluating) in parentheses. Also, "belonging to" is too vague in my opinion, if you miss the technical context (that it belongs to some ICD-11 parent condition).