### PR TITLE
ACTIN-1714: Handle PD-L1 scoreText for PD-L1 test of undefined type t…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctions.kt
@@ -86,13 +86,14 @@ object PDL1EvaluationFunctions {
     ): EvaluationResult? {
         val result = classifyIhcTest(ihcTest)
         val cpsWithRefEqualAbove10 = ihcTest.measure == "CPS" && pdl1Reference >= 10
-        val tpsWithRefEqualAbove1 = (ihcTest.measure == "TPS" || isLungCancer == true) && pdl1Reference >= 1
+        val hasTPSTest = ihcTest.measure == "TPS" || isLungCancer == true
+        val tpsWithRefEqualAbove1 = hasTPSTest && pdl1Reference >= 1
 
         return when {
             evaluateMaxPDL1 && result == TestResult.NEGATIVE && (tpsWithRefEqualAbove1 || cpsWithRefEqualAbove10) -> EvaluationResult.PASS
 
             !evaluateMaxPDL1 && result == TestResult.POSITIVE && pdl1Reference == 1.0 &&
-                    (ihcTest.measure == "TPS" || ihcTest.measure == "CPS") -> EvaluationResult.PASS
+                    (hasTPSTest || ihcTest.measure == "CPS") -> EvaluationResult.PASS
 
             !evaluateMaxPDL1 && result == TestResult.NEGATIVE && (tpsWithRefEqualAbove1 || cpsWithRefEqualAbove10) -> EvaluationResult.FAIL
 

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctionsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctionsTest.kt
@@ -160,6 +160,17 @@ class PDL1EvaluationFunctionsTest {
     }
 
     @Test
+    fun `Should pass when tumor type is lung cancer and PD-L1 test result of undefined type is negative and evaluating against max PDL1 of 10,0`() {
+        val record = MolecularTestFactory.withIHCTests(pdl1Test.copy(scoreText = "negative", measure = null))
+            .copy(tumor = TumorDetails(doids = setOf(DoidConstants.LUNG_CANCER_DOID)))
+
+        assertEvaluation(
+            EvaluationResult.PASS,
+            evaluatePDL1byIHC(record, TPS, pdl1Reference = 10.0, doidModel = doidModel, evaluateMaxPDL1 = true)
+        )
+    }
+
+    @Test
     fun `Should evaluate to undetermined when TPS test result is positive and evaluating against max PDL1 of 10,0`() {
         val record = MolecularTestFactory.withIHCTests(pdl1Test.copy(scoreText = "positive", measure = TPS))
         assertEvaluation(
@@ -171,6 +182,17 @@ class PDL1EvaluationFunctionsTest {
     @Test
     fun `Should pass when TPS test result is positive and evaluating against min PDL1 of 1,0`() {
         val record = MolecularTestFactory.withIHCTests(pdl1Test.copy(scoreText = "positive", measure = TPS))
+        assertEvaluation(
+            EvaluationResult.PASS,
+            evaluatePDL1byIHC(record, TPS, pdl1Reference = 1.0, doidModel = doidModel, evaluateMaxPDL1 = false)
+        )
+    }
+
+    @Test
+    fun `Should pass when tumor type is lung cancer and PD-L1 test result of undefined type is positive and evaluating against min PDL1 of 1,0`() {
+        val record = MolecularTestFactory.withIHCTests(pdl1Test.copy(scoreText = "positive", measure = null))
+            .copy(tumor = TumorDetails(doids = setOf(DoidConstants.LUNG_CANCER_DOID)))
+
         assertEvaluation(
             EvaluationResult.PASS,
             evaluatePDL1byIHC(record, TPS, pdl1Reference = 1.0, doidModel = doidModel, evaluateMaxPDL1 = false)
@@ -198,7 +220,7 @@ class PDL1EvaluationFunctionsTest {
     @Test
     fun `Should fail when tumor type is lung cancer and PD-L1 test result of undefined type is negative and evaluating against min PD-L1 of 1,0`() {
         val record = MolecularTestFactory.withIHCTests(pdl1Test.copy(scoreText = "negative", measure = null))
-            .copy(tumor = TumorDetails(DoidConstants.LUNG_CANCER_DOID))
+            .copy(tumor = TumorDetails(doids = setOf(DoidConstants.LUNG_CANCER_DOID)))
 
         assertEvaluation(
             EvaluationResult.FAIL,


### PR DESCRIPTION
…he same as TPS-type when tumor type is lung cancer

We already have this logic implemented for PD-L1 test selection in the same class. For lung cancer, the PD-L1 test is always TPS (although frequently not specified in input data), so this saves some unnecessary warnings or undetermined evaluations)