### PR TITLE
ACTIN-1712 Allow Java to use most of the RAM

### DIFF
--- a/algo/Dockerfile
+++ b/algo/Dockerfile
@@ -4,4 +4,4 @@ ARG VERSION=local-SNAPSHOT
 
 COPY target/algo-${VERSION}-jar-with-dependencies.jar /usr/local/actin.jar
 
-ENTRYPOINT ["java", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.algo.TreatmentMatcherApplicationKt"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=95", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.algo.TreatmentMatcherApplicationKt"]

--- a/clinical/Dockerfile
+++ b/clinical/Dockerfile
@@ -4,4 +4,4 @@ ARG VERSION=local-SNAPSHOT
 
 COPY target/clinical-${VERSION}-jar-with-dependencies.jar /usr/local/actin.jar
 
-ENTRYPOINT ["java", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.clinical.ClinicalIngestionApplicationKt" ]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=95", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.clinical.ClinicalIngestionApplicationKt" ]

--- a/molecular/Dockerfile
+++ b/molecular/Dockerfile
@@ -4,4 +4,4 @@ ARG VERSION=local-SNAPSHOT
 
 COPY target/molecular-${VERSION}-jar-with-dependencies.jar /usr/local/actin.jar
 
-ENTRYPOINT ["java", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.molecular.MolecularInterpreterApplicationKt"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=95", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.molecular.MolecularInterpreterApplicationKt"]

--- a/trial/Dockerfile
+++ b/trial/Dockerfile
@@ -4,4 +4,4 @@ ARG VERSION
 
 COPY target/trial-${VERSION}-jar-with-dependencies.jar /usr/local/actin.jar
 
-ENTRYPOINT ["java", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.trial.TrialCreatorApplicationKt" ]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=95", "-cp", "/usr/local/actin.jar", "com.hartwig.actin.trial.TrialCreatorApplicationKt" ]


### PR DESCRIPTION
There has been a sample with a larger-than-normal (like an order of magnitude larger) JSON file which has caused bedlam as it has worked its way through the components of the system.

Since all of our containers are single-purpose it should not cause problems to have the JVM configured to take up as much of the RAM on the pod as we dare, I think 95% should be safe-ish.

Without this parameter I think we are going to have more trouble tuning the workloads to use what we want because we'll be fighting with the JVM defaults which vary depending on the overall size of the VM.