### PR TITLE
ACTIN-1784: Only consider non-canonical impacts if there are no reportable canonical impacts in GeneHasVariantInCodon

### DIFF
--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInCodonTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInCodonTest.kt
@@ -161,5 +161,22 @@ class GeneHasVariantInCodonTest {
         )
     }
 
+    @Test
+    fun `Should pass for a variant with matching canonical and non-canonical impact`() {
+        assertMolecularEvaluation(
+            EvaluationResult.PASS,
+            function.evaluate(
+                MolecularTestFactory.withDrivers(
+                    TestVariantFactory.createMinimal().copy(
+                        gene = TARGET_GENE,
+                        isReportable = true,
+                        canonicalImpact = impactWithCodon(MATCHING_CODON),
+                        otherImpacts = setOf(impactWithCodon(MATCHING_CODON))
+                    )
+                )
+            )
+        )
+    }
+
     private fun impactWithCodon(affectedCodon: Int) = TestTranscriptVariantImpactFactory.createMinimal().copy(affectedCodon = affectedCodon)
 }


### PR DESCRIPTION
Similar to the bug we found in [ACTIN-1736](https://hartwigmedical.atlassian.net/browse/ACTIN-1736?atlOrigin=eyJpIjoiOTNmYTdiYjM4ZDBlNDI3Yzk3MzRjNWVjYWMzMjE3ZDYiLCJwIjoiaiJ9), also a bug in this class resulted in unwanted messages ".. in canonical transcript together with .. in non-canonical transcript" on the report.

Tested on the report I found this in, it's fixed now.

[ACTIN-1736]: https://hartwigmedical.atlassian.net/browse/ACTIN-1736?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ