### PR TITLE
ACTIN-1775: Clarify insufficient molecular data message

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressed.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressed.kt
@@ -14,4 +14,11 @@ class AnyGeneFromSetIsNotExpressed(maxTestAge: LocalDate? = null, private val ge
             isMissingMolecularResultForEvaluation = true
         )
     }
+
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine non-expression of ${concat(genes)} in RNA",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressed.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressed.kt
@@ -8,16 +8,16 @@ import java.time.LocalDate
 
 class AnyGeneFromSetIsNotExpressed(maxTestAge: LocalDate? = null, private val genes: Set<String>) : MolecularEvaluationFunction(maxTestAge){
 
-    override fun evaluate(molecular: MolecularRecord): Evaluation {
+    override fun noMolecularRecordEvaluation(): Evaluation {
         return EvaluationFactory.undetermined(
-            "Non-expression of ${concat(genes)} in RNA undetermined",
+            "No molecular data to determine non-expression of ${concat(genes)} in RNA",
             isMissingMolecularResultForEvaluation = true
         )
     }
 
-    override fun noMolecularRecordEvaluation(): Evaluation {
+    override fun evaluate(molecular: MolecularRecord): Evaluation {
         return EvaluationFactory.undetermined(
-            "No molecular data to determine non-expression of ${concat(genes)} in RNA",
+            "Non-expression of ${concat(genes)} in RNA undetermined",
             isMissingMolecularResultForEvaluation = true
         )
     }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressed.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressed.kt
@@ -15,4 +15,11 @@ class AnyGeneFromSetIsOverexpressed(maxTestAge: LocalDate? = null, private val g
             isMissingMolecularResultForEvaluation = true
         )
     }
+
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine overexpression of ${concat(genes)} in RNA",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressed.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressed.kt
@@ -9,16 +9,16 @@ import java.time.LocalDate
 class AnyGeneFromSetIsOverexpressed(maxTestAge: LocalDate? = null, private val genes: Set<String>) :
     MolecularEvaluationFunction(maxTestAge) {
 
-    override fun evaluate(molecular: MolecularRecord): Evaluation {
+    override fun noMolecularRecordEvaluation(): Evaluation {
         return EvaluationFactory.undetermined(
-            "Overexpression of ${concat(genes)} in RNA undetermined",
+            "No molecular data to determine overexpression of ${concat(genes)} in RNA",
             isMissingMolecularResultForEvaluation = true
         )
     }
 
-    override fun noMolecularRecordEvaluation(): Evaluation {
+    override fun evaluate(molecular: MolecularRecord): Evaluation {
         return EvaluationFactory.undetermined(
-            "No molecular data to determine overexpression of ${concat(genes)} in RNA",
+            "Overexpression of ${concat(genes)} in RNA undetermined",
             isMissingMolecularResultForEvaluation = true
         )
     }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiency.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiency.kt
@@ -27,4 +27,11 @@ class HasHeterozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEv
             }
         }
     }
+
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine heterozygous DPYD deficiency",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiency.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiency.kt
@@ -10,6 +10,13 @@ import java.time.LocalDate
 
 class HasHeterozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEvaluationFunction(maxTestAge, true) {
 
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine heterozygous DPYD deficiency",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
+
     override fun evaluate(molecular: MolecularRecord): Evaluation {
         val pharmaco = molecular.pharmaco.firstOrNull { it.gene == PharmacoGene.DPYD }
             ?: return EvaluationFactory.undetermined("DPYD haplotype undetermined")
@@ -26,12 +33,5 @@ class HasHeterozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEv
                 EvaluationFactory.fail("Is not heterozygous DPYD deficient")
             }
         }
-    }
-
-    override fun noMolecularRecordEvaluation(): Evaluation {
-        return EvaluationFactory.undetermined(
-            "No molecular data to determine heterozygous DPYD deficiency",
-            isMissingMolecularResultForEvaluation = true
-        )
     }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiency.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiency.kt
@@ -9,6 +9,13 @@ import java.time.LocalDate
 
 class HasHomozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEvaluationFunction(maxTestAge, true) {
 
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine homozygous DPYD deficiency",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
+
     override fun evaluate(molecular: MolecularRecord): Evaluation {
         val pharmaco = molecular.pharmaco.firstOrNull { it.gene == PharmacoGene.DPYD }
             ?: return EvaluationFactory.undetermined("DPYD haplotype undetermined")
@@ -25,12 +32,5 @@ class HasHomozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEval
                 EvaluationFactory.fail("Is not homozygous DPYD deficient")
             }
         }
-    }
-
-    override fun noMolecularRecordEvaluation(): Evaluation {
-        return EvaluationFactory.undetermined(
-            "No molecular data to determine homozygous DPYD deficiency",
-            isMissingMolecularResultForEvaluation = true
-        )
     }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiency.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiency.kt
@@ -26,4 +26,11 @@ class HasHomozygousDPYDDeficiency(maxTestAge: LocalDate? = null) : MolecularEval
             }
         }
     }
+
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine homozygous DPYD deficiency",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1Haplotype.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1Haplotype.kt
@@ -21,6 +21,12 @@ class HasUGT1A1Haplotype(private val haplotypeToFind: String, maxTestAge: LocalD
         }
     }
 
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine UGT1A1 haplotype"
+        )
+    }
+
     private fun hasUGT1A1Type(pharmacoEntry: PharmacoEntry, hapolotypeToFind: String): Boolean {
         return pharmacoEntry.gene == PharmacoGene.UGT1A1 &&
                 pharmacoEntry.haplotypes.any { it.toHaplotypeString().lowercase() == hapolotypeToFind.lowercase() }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1Haplotype.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1Haplotype.kt
@@ -10,6 +10,13 @@ import java.time.LocalDate
 class HasUGT1A1Haplotype(private val haplotypeToFind: String, maxTestAge: LocalDate? = null) :
     MolecularEvaluationFunction(maxTestAge, true) {
 
+    override fun noMolecularRecordEvaluation(): Evaluation {
+        return EvaluationFactory.undetermined(
+            "No molecular data to determine UGT1A1 haplotype",
+            isMissingMolecularResultForEvaluation = true
+        )
+    }
+
     override fun evaluate(molecular: MolecularRecord): Evaluation {
         val pharmaco = molecular.pharmaco.firstOrNull { it.gene == PharmacoGene.UGT1A1 }
             ?: return EvaluationFactory.undetermined("UGT1A1 haplotype undetermined")
@@ -19,12 +26,6 @@ class HasUGT1A1Haplotype(private val haplotypeToFind: String, maxTestAge: LocalD
         } else {
             EvaluationFactory.fail("Does not have required UGT1A1 type $haplotypeToFind")
         }
-    }
-
-    override fun noMolecularRecordEvaluation(): Evaluation {
-        return EvaluationFactory.undetermined(
-            "No molecular data to determine UGT1A1 haplotype"
-        )
     }
 
     private fun hasUGT1A1Type(pharmacoEntry: PharmacoEntry, hapolotypeToFind: String): Boolean {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressedTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressedTest.kt
@@ -19,7 +19,7 @@ class AnyGeneFromSetIsNotExpressedTest {
     }
 
     @Test
-    fun `Should return undetermined when molecular record not available`() {
+    fun `Should evaluate to undetermined when molecular record not available`() {
         val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
         assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine non-expression of gene a, gene b and gene c in RNA")

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressedTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsNotExpressedTest.kt
@@ -8,13 +8,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class AnyGeneFromSetIsNotExpressedTest {
+    val function = AnyGeneFromSetIsNotExpressed(LocalDate.of(2024, 11, 6), setOf("gene a", "gene b", "gene c"))
 
     @Test
     fun `Should evaluate to undetermined with correct message`() {
-        val function = AnyGeneFromSetIsNotExpressed(LocalDate.of(2024, 11, 6), setOf("gene a", "gene b", "gene c"))
         val evaluation = function.evaluate(TestPatientFactory.createMinimalTestWGSPatientRecord())
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
         assertThat(evaluation.undeterminedMessages)
             .contains("Non-expression of gene a, gene b and gene c in RNA undetermined")
+    }
+
+    @Test
+    fun `Should return undetermined when molecular record not available`() {
+        val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
+        assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
+        assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine non-expression of gene a, gene b and gene c in RNA")
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressedTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressedTest.kt
@@ -19,7 +19,7 @@ class AnyGeneFromSetIsOverexpressedTest {
     }
 
     @Test
-    fun `Should return undetermined when molecular record not available`() {
+    fun `Should evaluate to undetermined when molecular record not available`() {
         val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
         assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine overexpression of gene a, gene b and gene c in RNA")

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressedTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/AnyGeneFromSetIsOverexpressedTest.kt
@@ -8,13 +8,20 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class AnyGeneFromSetIsOverexpressedTest {
+    val function = AnyGeneFromSetIsOverexpressed(LocalDate.of(2024, 11, 6), setOf("gene a", "gene b", "gene c"))
 
     @Test
     fun `Should evaluate to undetermined with correct message`() {
-        val function = AnyGeneFromSetIsOverexpressed(LocalDate.of(2024, 11, 6), setOf("gene a", "gene b", "gene c"))
         val evaluation = function.evaluate(TestPatientFactory.createMinimalTestWGSPatientRecord())
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
         assertThat(evaluation.undeterminedMessages)
             .contains("Overexpression of gene a, gene b and gene c in RNA undetermined")
+    }
+
+    @Test
+    fun `Should return undetermined when molecular record not available`() {
+        val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
+        assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
+        assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine overexpression of gene a, gene b and gene c in RNA")
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiencyTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiencyTest.kt
@@ -30,7 +30,7 @@ class HasHeterozygousDPYDDeficiencyTest {
     }
 
     @Test
-    fun `Should return undetermined when molecular record not available`() {
+    fun `Should evaluate to undetermined when molecular record not available`() {
         val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
         assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine heterozygous DPYD deficiency")

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiencyTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHeterozygousDPYDDeficiencyTest.kt
@@ -1,11 +1,13 @@
 package com.hartwig.actin.algo.evaluation.molecular
 
 import com.hartwig.actin.algo.evaluation.EvaluationAssert
+import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.molecular.pharmaco.Haplotype
 import com.hartwig.actin.datamodel.molecular.pharmaco.HaplotypeFunction
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoEntry
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoGene
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class HasHeterozygousDPYDDeficiencyTest {
@@ -25,6 +27,13 @@ class HasHeterozygousDPYDDeficiencyTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `Should return undetermined when molecular record not available`() {
+        val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
+        assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
+        assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine heterozygous DPYD deficiency")
     }
 
     @Test

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiencyTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiencyTest.kt
@@ -27,7 +27,7 @@ class HasHomozygousDPYDDeficiencyTest {
     }
 
     @Test
-    fun `Should return undetermined when molecular record not available`() {
+    fun `Should evaluate to undetermined when molecular record not available`() {
         val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
         assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine homozygous DPYD deficiency")

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiencyTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasHomozygousDPYDDeficiencyTest.kt
@@ -1,11 +1,13 @@
 package com.hartwig.actin.algo.evaluation.molecular
 
 import com.hartwig.actin.algo.evaluation.EvaluationAssert
+import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.molecular.pharmaco.Haplotype
 import com.hartwig.actin.datamodel.molecular.pharmaco.HaplotypeFunction
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoEntry
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoGene
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class HasHomozygousDPYDDeficiencyTest {
@@ -22,6 +24,13 @@ class HasHomozygousDPYDDeficiencyTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `Should return undetermined when molecular record not available`() {
+        val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
+        assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
+        assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine homozygous DPYD deficiency")
     }
 
     @Test

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1HaplotypeTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1HaplotypeTest.kt
@@ -1,11 +1,13 @@
 package com.hartwig.actin.algo.evaluation.molecular
 
 import com.hartwig.actin.algo.evaluation.EvaluationAssert
+import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.molecular.pharmaco.Haplotype
 import com.hartwig.actin.datamodel.molecular.pharmaco.HaplotypeFunction
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoEntry
 import com.hartwig.actin.datamodel.molecular.pharmaco.PharmacoGene
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class HasUGT1A1HaplotypeTest {
@@ -61,5 +63,12 @@ class HasUGT1A1HaplotypeTest {
                 )
             )
         )
+    }
+
+    @Test
+    fun `Should return undetermined when molecular record not available`() {
+        val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
+        assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
+        assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine UGT1A1 haplotype")
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1HaplotypeTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/HasUGT1A1HaplotypeTest.kt
@@ -66,7 +66,7 @@ class HasUGT1A1HaplotypeTest {
     }
 
     @Test
-    fun `Should return undetermined when molecular record not available`() {
+    fun `Should evaluate to undetermined when molecular record not available`() {
         val evaluation = function.evaluate(TestPatientFactory.createEmptyMolecularTestPatientRecord())
         assertThat(evaluation.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(evaluation.undeterminedMessages).containsExactly("No molecular data to determine UGT1A1 haplotype")


### PR DESCRIPTION
This is the one we recently talked about in slack. I played around with a few solutions, but came to the conclusion that we already have a solution for this (the `noMolecularRecordEvaluation()`), we just hadn't implemented it yet for these functions. Tested on real patient, and looks good.