### PR TITLE
ACTIN-1804 Make the tested genes more dynamic and use "no mutation found"

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorIHCTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorIHCTestExtractor.kt
@@ -1,13 +1,13 @@
 package com.hartwig.actin.clinical.feed.standard.extraction
 
 import com.hartwig.actin.clinical.ExtractionResult
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.CurationResponse
 import com.hartwig.actin.clinical.curation.config.IHCTestConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
 import com.hartwig.actin.datamodel.clinical.PriorIHCTest
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
 
 private const val IHC_STRING = "immunohistochemie"
 
@@ -30,7 +30,7 @@ class StandardPriorIHCTestExtractor(
 
         val extractedIHCTests = ehrPatientRecord.molecularTests.asSequence()
             .flatMap { it.results }
-            .mapNotNull { it.ihcResult }
+            .flatMap { listOfNotNull(it.ihcResult, it.freeText) }
             .map {
                 CurationResponse.createFromConfigs(
                     molecularTestCuration.find(it),

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
@@ -1,20 +1,20 @@
 package com.hartwig.actin.clinical.feed.standard.extraction
 
 import com.hartwig.actin.clinical.ExtractionResult
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.CurationResponse
 import com.hartwig.actin.clinical.curation.config.SequencingTestConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTestResult
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
 import com.hartwig.actin.datamodel.clinical.PriorSequencingTest
 import com.hartwig.actin.datamodel.clinical.SequencedAmplification
 import com.hartwig.actin.datamodel.clinical.SequencedDeletedGene
 import com.hartwig.actin.datamodel.clinical.SequencedFusion
 import com.hartwig.actin.datamodel.clinical.SequencedSkippedExons
 import com.hartwig.actin.datamodel.clinical.SequencedVariant
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
+import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTestResult
+import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
 import kotlin.reflect.full.memberProperties
 
 class StandardPriorSequencingTestExtractor(val curation: CurationDatabase<SequencingTestConfig>) :
@@ -32,24 +32,26 @@ class StandardPriorSequencingTestExtractor(val curation: CurationDatabase<Sequen
                 val allResults =
                     removeCurated(removeCurated(nonIHCTestResults, mandatoryCurationTestResults), optionalCurationTestResults) +
                             extract(mandatoryCurationTestResults) + extract(optionalCurationTestResults)
-                if (allResults.isNotEmpty()) ExtractionResult(
-                    listOf(
-                        PriorSequencingTest(
-                            test = test.test,
-                            date = test.date,
-                            testedGenes = test.testedGenes,
-                            variants = variants(allResults),
-                            fusions = fusions(allResults),
-                            amplifications = amplifications(allResults),
-                            skippedExons = skippedExons(allResults),
-                            deletedGenes = geneDeletions(allResults),
-                            isMicrosatelliteUnstable = msi(allResults),
-                            tumorMutationalBurden = tmb(allResults),
-                        )
-                    ),
-                    mandatoryCurationTestResults.map { curated -> curated.extractionEvaluation }
-                        .fold(CurationExtractionEvaluation()) { acc, extraction -> acc + extraction }
-                ) else null
+                if (allResults.isNotEmpty()) {
+                    ExtractionResult(
+                        listOf(
+                            PriorSequencingTest(
+                                test = test.test,
+                                date = test.date,
+                                variants = variants(allResults),
+                                fusions = fusions(allResults),
+                                amplifications = amplifications(allResults),
+                                skippedExons = skippedExons(allResults),
+                                deletedGenes = geneDeletions(allResults),
+                                isMicrosatelliteUnstable = msi(allResults),
+                                tumorMutationalBurden = tmb(allResults),
+                                noMutationGenes = noMutations(test.testedGenes ?: emptySet(), allResults)
+                            )
+                        ),
+                        mandatoryCurationTestResults.map { curated -> curated.extractionEvaluation }
+                            .fold(CurationExtractionEvaluation()) { acc, extraction -> acc + extraction }
+                    )
+                } else null
             } else {
                 null
             }
@@ -59,6 +61,14 @@ class StandardPriorSequencingTestExtractor(val curation: CurationDatabase<Sequen
         ) { acc, extractionResult ->
             ExtractionResult(acc.extracted + extractionResult.extracted, acc.evaluation + extractionResult.evaluation)
         }
+    }
+
+    private fun noMutations(providedTestedGenes: Set<String>, allResults: Set<ProvidedMolecularTestResult>): Set<String> {
+        val impliedNoMutations =
+            providedTestedGenes - (allResults.map { it.gene } + allResults.map { it.deletedGene } + allResults.map { it.fusionGeneUp } + allResults.map { it.fusionGeneDown } + allResults.map { it.amplifiedGene }).filterNotNull()
+                .toSet()
+        val explicitNoMutations = allResults.filter { it.noMutationsFound == true }.mapNotNull { it.gene }
+        return impliedNoMutations + explicitNoMutations
     }
 
     private fun patientQualifiedTestName(patientId: String, test: ProvidedMolecularTest) = "$patientId | ${test.test}"

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
@@ -65,7 +65,8 @@ class StandardPriorSequencingTestExtractor(val curation: CurationDatabase<Sequen
 
     private fun noMutations(providedTestedGenes: Set<String>, allResults: Set<ProvidedMolecularTestResult>): Set<String> {
         val impliedNoMutations =
-            providedTestedGenes - (allResults.map { it.gene } + allResults.map { it.deletedGene } + allResults.map { it.fusionGeneUp } + allResults.map { it.fusionGeneDown } + allResults.map { it.amplifiedGene }).filterNotNull()
+            providedTestedGenes - (allResults.filter { it.noMutationsFound != true }
+                .map { it.gene } + allResults.map { it.deletedGene } + allResults.map { it.fusionGeneUp } + allResults.map { it.fusionGeneDown } + allResults.map { it.amplifiedGene }).filterNotNull()
                 .toSet()
         val explicitNoMutations = allResults.filter { it.noMutationsFound == true }.mapNotNull { it.gene }
         return impliedNoMutations + explicitNoMutations

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorIHCTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorIHCTestExtractorTest.kt
@@ -1,21 +1,21 @@
 package com.hartwig.actin.clinical.feed.standard.extraction
 
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationWarning
 import com.hartwig.actin.clinical.curation.config.IHCTestConfig
 import com.hartwig.actin.clinical.feed.standard.EhrTestData.createEhrPatientRecord
 import com.hartwig.actin.clinical.feed.standard.HASHED_ID_IN_BASE64
 import com.hartwig.actin.clinical.feed.standard.OTHER_CONDITION_INPUT
 import com.hartwig.actin.datamodel.clinical.PriorIHCTest
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationWarning
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTestResult
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedOtherCondition
 import io.mockk.every
 import io.mockk.mockk
+import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.time.LocalDate
 
 private const val IHC_LINE = "HER2 immunohistochemie: negative"
 private val PRIOR_IHC_TEST =
@@ -159,7 +159,7 @@ class StandardPriorIHCTestExtractorTest {
     }
 
     @Test
-    fun `Should extract and curate IHC lines from molecular test list (new)`() {
+    fun `Should extract and curate IHC lines from molecular test ihc result`() {
         every { molecularTestCuration.find(IHC_LINE) } returns setOf(
             IHCTestConfig(
                 input = IHC_LINE,
@@ -174,13 +174,17 @@ class StandardPriorIHCTestExtractorTest {
                         results = setOf(ProvidedMolecularTestResult(ihcResult = IHC_LINE))
                     ),
                     ProvidedMolecularTest(
+                        test = "IHC",
+                        results = setOf(ProvidedMolecularTestResult(freeText = IHC_LINE))
+                    ),
+                    ProvidedMolecularTest(
                         test = "NGS",
                         results = setOf(ProvidedMolecularTestResult(hgvsCodingImpact = "codingImpact"))
                     ),
                 )
             )
         )
-        assertThat(result.extracted).containsExactly(PRIOR_IHC_TEST)
+        assertThat(result.extracted).containsExactly(PRIOR_IHC_TEST, PRIOR_IHC_TEST)
         assertThat(result.evaluation.warnings).isEmpty()
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
@@ -142,11 +142,12 @@ class StandardPriorSequencingTestExtractorTest {
     fun `Should combine test result genes with provided tested genes`() {
         val variantGene = "variantGene"
         val noMutationsGene = "noMutationsGene"
+        val impliedNoMutationGene = "impliedNoMutationGene"
         val result = extractor.extract(
             EhrTestData.createEhrPatientRecord().copy(
                 molecularTests = listOf(
                     BASE_MOLECULAR_TEST.copy(
-                        testedGenes = setOf(GENE),
+                        testedGenes = setOf(impliedNoMutationGene),
                         results = setOf(
                             ProvidedMolecularTestResult(gene = variantGene, hgvsProteinImpact = "proteinImpact"),
                             ProvidedMolecularTestResult(gene = noMutationsGene, noMutationsFound = true)
@@ -155,7 +156,8 @@ class StandardPriorSequencingTestExtractorTest {
                 )
             )
         )
-        assertThat(result.extracted[0].testedGenes).containsExactlyInAnyOrder(GENE, variantGene, noMutationsGene)
+        assertThat(result.extracted[0].testedGenes).containsExactlyInAnyOrder(variantGene, noMutationsGene, impliedNoMutationGene)
+        assertThat(result.extracted[0].noMutationGenes).containsExactlyInAnyOrder(noMutationsGene, impliedNoMutationGene)
     }
 
     @Test

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
@@ -1,9 +1,7 @@
 package com.hartwig.actin.clinical.feed.standard.extraction
 
 import com.hartwig.actin.clinical.ExtractionResult
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
 import com.hartwig.actin.clinical.curation.CurationDatabase
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationWarning
 import com.hartwig.actin.clinical.curation.config.SequencingTestConfig
 import com.hartwig.actin.clinical.feed.standard.EhrTestData
 import com.hartwig.actin.clinical.feed.standard.HASHED_ID_IN_BASE64
@@ -13,6 +11,8 @@ import com.hartwig.actin.datamodel.clinical.SequencedDeletedGene
 import com.hartwig.actin.datamodel.clinical.SequencedFusion
 import com.hartwig.actin.datamodel.clinical.SequencedSkippedExons
 import com.hartwig.actin.datamodel.clinical.SequencedVariant
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationWarning
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTestResult
 import io.mockk.every
@@ -136,6 +136,26 @@ class StandardPriorSequencingTestExtractorTest {
                 deletedGenes = setOf(SequencedDeletedGene(GENE))
             )
         )
+    }
+
+    @Test
+    fun `Should combine test result genes with provided tested genes`() {
+        val variantGene = "variantGene"
+        val noMutationsGene = "noMutationsGene"
+        val result = extractor.extract(
+            EhrTestData.createEhrPatientRecord().copy(
+                molecularTests = listOf(
+                    BASE_MOLECULAR_TEST.copy(
+                        testedGenes = setOf(GENE),
+                        results = setOf(
+                            ProvidedMolecularTestResult(gene = variantGene, hgvsProteinImpact = "proteinImpact"),
+                            ProvidedMolecularTestResult(gene = noMutationsGene, noMutationsFound = true)
+                        )
+                    )
+                )
+            )
+        )
+        assertThat(result.extracted[0].testedGenes).containsExactlyInAnyOrder(GENE, variantGene, noMutationsGene)
     }
 
     @Test

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -199,7 +199,7 @@
   "priorSequencingTests": [
     {
       "test": "Archer FP Lung Target",
-      "testedGenes": [
+      "noMutationGenes": [
         "ALK",
         "ROS1",
         "RET",

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorSequencingTest.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorSequencingTest.kt
@@ -65,5 +65,5 @@ data class PriorSequencingTest(
             it.geneUp,
             it.geneDown
         )
-    } + deletedGenes.map { it.gene } + noMutationGenes).toSet()
+    } + deletedGenes.map { it.gene } + noMutationGenes).filterNotNull().toSet()
 }

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorSequencingTest.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorSequencingTest.kt
@@ -53,10 +53,17 @@ data class PriorSequencingTest(
     val date: LocalDate? = null,
     val tumorMutationalBurden: Double? = null,
     val isMicrosatelliteUnstable: Boolean? = null,
-    val testedGenes: Set<String>? = null,
     val variants: Set<SequencedVariant> = emptySet(),
     val amplifications: Set<SequencedAmplification> = emptySet(),
     val skippedExons: Set<SequencedSkippedExons> = emptySet(),
     val fusions: Set<SequencedFusion> = emptySet(),
-    val deletedGenes: Set<SequencedDeletedGene> = emptySet()
-)
+    val deletedGenes: Set<SequencedDeletedGene> = emptySet(),
+    val noMutationGenes: Set<String> = emptySet()
+) {
+    val testedGenes = (variants.map { it.gene } + amplifications.map { it.gene } + skippedExons.map { it.gene } + fusions.flatMap {
+        listOf(
+            it.geneUp,
+            it.geneDown
+        )
+    } + deletedGenes.map { it.gene } + noMutationGenes).toSet()
+}

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
@@ -28,7 +28,7 @@ class PanelAnnotator(
         val hasHighTumorMutationalBurden = input.tumorMutationalBurden?.let { it > TMB_HIGH_CUTOFF }
 
         return PanelRecord(
-            testedGenes = input.testedGenes ?: emptySet(),
+            testedGenes = input.testedGenes,
             experimentType = ExperimentType.PANEL,
             testTypeDisplay = input.test,
             date = input.date,


### PR DESCRIPTION
No mutations will be a combination of the implied no mutation (difference between provided list and what is actually
in the results), and test results explicitly marked as no mutation.

I would suggest for the future we remove the tested genes list from the ProvidedMolecularTest model and make it
purely dynamic based on test results. That will remove the duplication in finding the implied no mutation, and avoid any
possible discrepancies between the tested gene list and what is actually specified in the results. 