### PR TITLE
ACTIN-1814: Prevent empty IHC molecular test instance from showing up…

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
@@ -1,7 +1,7 @@
 package com.hartwig.actin.report.pdf.chapters
 
+import com.hartwig.actin.datamodel.molecular.ExperimentType
 import com.hartwig.actin.datamodel.molecular.MolecularRecord
-import com.hartwig.actin.datamodel.molecular.PanelRecord
 import com.hartwig.actin.report.datamodel.Report
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortFactory
@@ -74,7 +74,7 @@ class MolecularDetailsChapter(
         } ?: orangeMolecularTable.addCell(Cells.createContent("No OncoAct WGS and/or Hartwig NGS panel performed"))
         document.add(orangeMolecularTable)
 
-        val externalPanelResults = report.patientRecord.molecularHistory.molecularTests.filterIsInstance<PanelRecord>()
+        val externalPanelResults = report.patientRecord.molecularHistory.molecularTests.filter { it.experimentType == ExperimentType.PANEL }
         for (panel in externalPanelResults) {
             WGSSummaryGenerator(
                 true,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
@@ -29,8 +29,9 @@ class MolecularSummaryGenerator(
 
     override fun contents(): Table {
         val table = Tables.createSingleColWithWidth(keyWidth + valueWidth)
-        val testsIncludedInTrialMatching = molecularTestFilter.apply(patientRecord.molecularHistory.molecularTests)
-        for (molecularTest in testsIncludedInTrialMatching.sortedByDescending { it.date }) {
+        val nonIhcTestsIncludedInTrialMatching =
+            molecularTestFilter.apply(patientRecord.molecularHistory.molecularTests).filterNot { it.experimentType == ExperimentType.IHC }
+        for (molecularTest in nonIhcTestsIncludedInTrialMatching.sortedByDescending { it.date }) {
             if ((molecularTest as? MolecularRecord)?.hasSufficientQuality != false) {
                 if (molecularTest.experimentType != ExperimentType.HARTWIG_WHOLE_GENOME) {
                     logger.warn("Generating WGS results for non-WGS sample")


### PR DESCRIPTION
… in molecular summary and details

This fixes the issue where ALK or ROS1 IHC results are displayed in both the IHC results section as well as empty IHC "molecular test" instances (`IHC (Date unknown) No mutations found`) in molecular summary/details.

Background on why ALK/ROS1 IHC is considered a panel molecular test -> https://github.com/hartwigmedical/actin/pull/817/files

Works well in beta-testing.