### PR TITLE
ACTIN-1815: Revert complication data missing evaluation to recovarableUndetermined in HasSpecificComplication

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/complication/HasSpecificComplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/complication/HasSpecificComplication.kt
@@ -29,7 +29,7 @@ class HasSpecificComplication(private val icdModel: IcdModel, private val target
 
             hasComplicationsWithoutNames(record) -> EvaluationFactory.undetermined("Complication(s) present but unknown if $icdTitleText")
 
-            record.clinicalStatus.hasComplications == null -> EvaluationFactory.undetermined(
+            record.clinicalStatus.hasComplications == null -> EvaluationFactory.recoverableUndetermined(
                 "Undetermined presence of complication $icdTitleText (complication data missing)"
             )
 


### PR DESCRIPTION
Was recoverable before. And I think should be, because now lead to message on the report but if complications are empty we can just assume the patients hasn't any and I wouldn't show this message.