### PR TITLE
ACTIN-1831: Add external configuration of panel gene lists 

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionApplication.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionApplication.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.TreatmentDatabaseFactory
 import com.hartwig.actin.clinical.curation.CurationDatabaseContext
 import com.hartwig.actin.clinical.curation.CurationDoidValidator
 import com.hartwig.actin.clinical.feed.emc.EmcClinicalFeedIngestor
+import com.hartwig.actin.clinical.feed.standard.PanelGeneList
 import com.hartwig.actin.clinical.feed.standard.StandardDataIngestion
 import com.hartwig.actin.clinical.serialization.ClinicalRecordJson
 import com.hartwig.actin.datamodel.clinical.ingestion.IngestionResult
@@ -80,7 +81,10 @@ class ClinicalIngestionApplication(private val config: ClinicalIngestionConfig) 
             drugInteractionsDatabase,
             qtProlongatingDatabase,
             doidModel,
-            treatmentDatabase
+            treatmentDatabase,
+            PanelGeneList.create(
+                config.panelGeneListTsv ?: throw IllegalStateException("Panel gene list is required when running in standard feed format")
+            )
         )
         val clinicalIngestionAdapter =
             ClinicalIngestionFeedAdapter(

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionConfig.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/ClinicalIngestionConfig.kt
@@ -24,7 +24,8 @@ data class ClinicalIngestionConfig(
     val atcOverridesTsv: String,
     val treatmentDirectory: String,
     val outputDirectory: String,
-    val feedFormat: FeedFormat
+    val feedFormat: FeedFormat,
+    val panelGeneListTsv: String?,
 ) {
 
     companion object {
@@ -42,6 +43,7 @@ data class ClinicalIngestionConfig(
         private const val OUTPUT_DIRECTORY = "output_directory"
         private const val LOG_DEBUG = "log_debug"
         private const val FEED_FORMAT = "feed_format"
+        private const val PANEL_GENE_LIST_TSV = "panel_gene_list_tsv"
 
         fun createOptions(): Options {
             val options = Options()
@@ -55,6 +57,11 @@ data class ClinicalIngestionConfig(
             options.addOption(ATC_OVERRIDES_TSV, true, "Path to TSV file containing ATC code overrides")
             options.addOption(TREATMENT_DIRECTORY, true, "Directory containing the treatment data")
             options.addOption(OUTPUT_DIRECTORY, true, "Directory where clinical data output will be written to")
+            options.addOption(
+                PANEL_GENE_LIST_TSV,
+                true,
+                "Path to TSV file containing panel test names and their corresponding tested genes"
+            )
             options.addOption(LOG_DEBUG, false, "If set, debug logging gets enabled")
             options.addOption(
                 FEED_FORMAT,
@@ -80,7 +87,8 @@ data class ClinicalIngestionConfig(
                 atcOverridesTsv = ApplicationConfig.nonOptionalFile(cmd, ATC_OVERRIDES_TSV),
                 treatmentDirectory = ApplicationConfig.nonOptionalDir(cmd, TREATMENT_DIRECTORY),
                 outputDirectory = ApplicationConfig.nonOptionalDir(cmd, OUTPUT_DIRECTORY),
-                feedFormat = ApplicationConfig.optionalValue(cmd, FEED_FORMAT)?.let { FeedFormat.valueOf(it) } ?: FeedFormat.EMC_TSV
+                feedFormat = ApplicationConfig.optionalValue(cmd, FEED_FORMAT)?.let { FeedFormat.valueOf(it) } ?: FeedFormat.EMC_TSV,
+                panelGeneListTsv = ApplicationConfig.optionalFile(cmd, PANEL_GENE_LIST_TSV)
             )
         }
     }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
@@ -11,7 +11,7 @@ private fun ProvidedPatientRecord.scrubMedications() =
 
 private fun ProvidedPatientRecord.addAlwaysTestedGenes(panelGeneList: PanelGeneList) =
     this.copy(molecularTests = this.molecularTests.map {
-        it.copy(testedGenes = panelGeneList[it.test] + (it.testedGenes ?: emptySet()))
+        it.copy(testedGenes = panelGeneList.matchGenesForTest(it.test) + (it.testedGenes ?: emptySet()))
     })
 
 class DataQualityMask(private val panelGeneList: PanelGeneList) {

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
@@ -12,9 +12,9 @@ private fun ProvidedPatientRecord.scrubModifications() =
 private fun ProvidedPatientRecord.scrubMedications() =
     this.copy(medications = null)
 
-private fun ProvidedPatientRecord.addAlwaysTestedGenes() =
+private fun ProvidedPatientRecord.addAlwaysTestedGenes(panelGeneList: PanelGeneList) =
     this.copy(molecularTests = this.molecularTests.map {
-        it.copy(testedGenes = knownGenes(it))
+        it.copy(testedGenes = panelGeneList[it.test] + (it.testedGenes ?: emptySet()))
     })
 
 fun knownGenes(test: ProvidedMolecularTest): Set<String>? {
@@ -28,8 +28,8 @@ fun knownGenes(test: ProvidedMolecularTest): Set<String>? {
     }
 }
 
-class DataQualityMask {
+class DataQualityMask(private val panelGeneList: PanelGeneList) {
     fun apply(ehrPatientRecord: ProvidedPatientRecord): ProvidedPatientRecord {
-        return ehrPatientRecord.scrubMedications().scrubModifications().addAlwaysTestedGenes()
+        return ehrPatientRecord.scrubMedications().scrubModifications().addAlwaysTestedGenes(panelGeneList)
     }
 } 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMask.kt
@@ -1,10 +1,7 @@
 package com.hartwig.actin.clinical.feed.standard
 
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
 
-val ARCHER_ALWAYS_TESTED_GENES = setOf("ALK", "ROS1", "RET", "MET", "NTRK1", "NTRK2", "NTRK3", "NRG1")
-val GENERIC_PANEL_ALWAYS_TESTED_GENES = setOf("EGFR", "BRAF", "KRAS")
 
 private fun ProvidedPatientRecord.scrubModifications() =
     this.copy(treatmentHistory = this.treatmentHistory.map { it.copy(modifications = emptyList()) })
@@ -16,17 +13,6 @@ private fun ProvidedPatientRecord.addAlwaysTestedGenes(panelGeneList: PanelGeneL
     this.copy(molecularTests = this.molecularTests.map {
         it.copy(testedGenes = panelGeneList[it.test] + (it.testedGenes ?: emptySet()))
     })
-
-fun knownGenes(test: ProvidedMolecularTest): Set<String>? {
-    val testNameLowerCase = test.test.lowercase()
-    return when {
-        testNameLowerCase.contains("archer") -> ARCHER_ALWAYS_TESTED_GENES + (test.testedGenes ?: emptySet())
-        testNameLowerCase.contains("avl") || testNameLowerCase.contains("next generation sequencing") || testNameLowerCase
-            .contains("ngs") -> GENERIC_PANEL_ALWAYS_TESTED_GENES + (test.testedGenes ?: emptySet())
-
-        else -> test.testedGenes
-    }
-}
 
 class DataQualityMask(private val panelGeneList: PanelGeneList) {
     fun apply(ehrPatientRecord: ProvidedPatientRecord): ProvidedPatientRecord {

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneList.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneList.kt
@@ -1,0 +1,28 @@
+package com.hartwig.actin.clinical.feed.standard
+
+import com.fasterxml.jackson.dataformat.csv.CsvMapper
+import com.fasterxml.jackson.dataformat.csv.CsvSchema
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import java.io.File
+
+class PanelGeneList(private val panelRegexToGenes: Map<Regex, List<String>>) {
+
+    operator fun get(input: String): Set<String> {
+        return panelRegexToGenes
+            .filter { (regex, _) -> regex.containsMatchIn(input.lowercase()) }
+            .flatMap { (_, value) -> value }
+            .toSet()
+    }
+
+    companion object {
+        fun create(panelGeneListTsvPath: String): PanelGeneList {
+
+            class PanelGeneEntry(val testNameRegex: String, val gene: String)
+
+            val entries = CsvMapper().apply { registerModule(KotlinModule.Builder().build()) }.readerFor(PanelGeneEntry::class.java)
+                .with(CsvSchema.emptySchema().withHeader().withColumnSeparator('\t')).readValues<PanelGeneEntry>(File(panelGeneListTsvPath))
+            return PanelGeneList(entries.readAll().groupBy { it.testNameRegex }.mapKeys { Regex(it.key) }
+                .mapValues { it.value.map { e -> e.gene } })
+        }
+    }
+}

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneList.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneList.kt
@@ -7,22 +7,18 @@ import java.io.File
 
 class PanelGeneList(private val panelRegexToGenes: Map<Regex, List<String>>) {
 
-    operator fun get(input: String): Set<String> {
-        return panelRegexToGenes
-            .filter { (regex, _) -> regex.containsMatchIn(input.lowercase()) }
-            .flatMap { (_, value) -> value }
-            .toSet()
+    fun matchGenesForTest(testName: String): Set<String> {
+        return panelRegexToGenes.filterKeys { it.containsMatchIn(testName.lowercase()) }.values.flatten().toSet()
     }
 
     companion object {
         fun create(panelGeneListTsvPath: String): PanelGeneList {
 
-            class PanelGeneEntry(val testNameRegex: String, val gene: String)
+            data class PanelGeneEntry(val testNameRegex: String, val gene: String)
 
             val entries = CsvMapper().apply { registerModule(KotlinModule.Builder().build()) }.readerFor(PanelGeneEntry::class.java)
                 .with(CsvSchema.emptySchema().withHeader().withColumnSeparator('\t')).readValues<PanelGeneEntry>(File(panelGeneListTsvPath))
-            return PanelGeneList(entries.readAll().groupBy { it.testNameRegex }.mapKeys { Regex(it.key) }
-                .mapValues { it.value.map { e -> e.gene } })
+            return PanelGeneList(entries.readAll().groupBy(PanelGeneEntry::testNameRegex, PanelGeneEntry::gene).mapKeys { Regex(it.key) })
         }
     }
 }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestion.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestion.kt
@@ -150,7 +150,8 @@ class StandardDataIngestion(
             drugInteractionDatabase: DrugInteractionsDatabase,
             qtProlongatingDatabase: QtProlongatingDatabase,
             doidModel: DoidModel,
-            treatmentDatabase: TreatmentDatabase
+            treatmentDatabase: TreatmentDatabase,
+            panelGeneList: PanelGeneList
         ) = StandardDataIngestion(
             directory,
             StandardMedicationExtractor(atcModel, drugInteractionDatabase, qtProlongatingDatabase, treatmentDatabase),
@@ -172,7 +173,7 @@ class StandardDataIngestion(
             StandardBodyHeightExtractor(),
             StandardPriorIHCTestExtractor(curationDatabaseContext.molecularTestIhcCuration),
             StandardPriorSequencingTestExtractor(curationDatabaseContext.sequencingTestCuration),
-            DataQualityMask()
+            DataQualityMask(panelGeneList)
         )
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
@@ -32,7 +32,7 @@ class DataQualityMaskTest {
                 )
             )
         )
-        every { panelGeneList["NGS panel"] } returns setOf("EGFR")
+        every { panelGeneList.matchGenesForTest("NGS panel") } returns setOf("EGFR")
         val result = DataQualityMask(panelGeneList).apply(ehrPatientRecord)
         val ngsTest = result.molecularTests[0]
         assertThat(ngsTest.testedGenes).containsExactly("EGFR", "additional_gene")

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
@@ -1,6 +1,8 @@
 package com.hartwig.actin.clinical.feed.standard
 
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
+import io.mockk.every
+import io.mockk.mockk
 import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -10,46 +12,31 @@ private val EHR_TREATMENT_HISTORY = EhrTestData.createEhrTreatmentHistory()
 
 class DataQualityMaskTest {
 
+    private val panelGeneList = mockk<PanelGeneList>()
+    private val dataQualityMask = DataQualityMask(panelGeneList)
+
     @Test
     fun `Should remove all modifications from treatment history`() {
         val ehrPatientRecord =
             EHR_PATIENT_RECORD.copy(treatmentHistory = listOf(EHR_TREATMENT_HISTORY.copy(modifications = listOf(EhrTestData.createEhrModification()))))
-        val result = DataQualityMask().apply(ehrPatientRecord)
+        val result = dataQualityMask.apply(ehrPatientRecord)
         assertThat(result.treatmentHistory.flatMap { it.modifications!! }).isEmpty()
     }
 
     @Test
     fun `Should add always tested genes for archer and ngs panels`() {
-        val ehrPatientRecord =
-            EHR_PATIENT_RECORD.copy(
-                molecularTests = listOf(
-                    ProvidedMolecularTest(
-                        test = "Archer FusionPlex",
-                        date = LocalDate.now(),
-                        testedGenes = setOf("additional_gene"),
-                        results = emptySet()
-                    ),
-                    ProvidedMolecularTest(
-                        test = "NGS panel",
-                        date = LocalDate.now(),
-                        testedGenes = setOf("additional_gene"),
-                        results = emptySet()
-                    )
+        val ehrPatientRecord = EHR_PATIENT_RECORD.copy(
+            molecularTests = listOf(
+               ProvidedMolecularTest(
+                    test = "NGS panel", date = LocalDate.now(), testedGenes = setOf("additional_gene"), results = emptySet()
                 )
             )
-        val result = DataQualityMask().apply(ehrPatientRecord)
-        val archerTest = result.molecularTests[0]
-        val ngsTest = result.molecularTests[1]
+        )
+        every { panelGeneList["NGS panel"] } returns setOf("ALK")
+        val result = DataQualityMask(panelGeneList).apply(ehrPatientRecord)
+        val ngsTest = result.molecularTests[0]
         assertThat(archerTest.testedGenes).containsExactly(
-            "ALK",
-            "ROS1",
-            "RET",
-            "MET",
-            "NTRK1",
-            "NTRK2",
-            "NTRK3",
-            "NRG1",
-            "additional_gene"
+            "ALK", "ROS1", "RET", "MET", "NTRK1", "NTRK2", "NTRK3", "NRG1", "additional_gene"
         )
         assertThat(ngsTest.testedGenes).containsExactly("EGFR", "BRAF", "KRAS", "additional_gene")
     }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/DataQualityMaskTest.kt
@@ -27,17 +27,14 @@ class DataQualityMaskTest {
     fun `Should add always tested genes for archer and ngs panels`() {
         val ehrPatientRecord = EHR_PATIENT_RECORD.copy(
             molecularTests = listOf(
-               ProvidedMolecularTest(
+                ProvidedMolecularTest(
                     test = "NGS panel", date = LocalDate.now(), testedGenes = setOf("additional_gene"), results = emptySet()
                 )
             )
         )
-        every { panelGeneList["NGS panel"] } returns setOf("ALK")
+        every { panelGeneList["NGS panel"] } returns setOf("EGFR")
         val result = DataQualityMask(panelGeneList).apply(ehrPatientRecord)
         val ngsTest = result.molecularTests[0]
-        assertThat(archerTest.testedGenes).containsExactly(
-            "ALK", "ROS1", "RET", "MET", "NTRK1", "NTRK2", "NTRK3", "NRG1", "additional_gene"
-        )
-        assertThat(ngsTest.testedGenes).containsExactly("EGFR", "BRAF", "KRAS", "additional_gene")
+        assertThat(ngsTest.testedGenes).containsExactly("EGFR", "additional_gene")
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
@@ -1,0 +1,18 @@
+package com.hartwig.actin.clinical.feed.standard
+
+import com.hartwig.actin.testutil.ResourceLocator
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class PanelGeneListTest {
+    
+    @Test
+    fun `Should read from panel gene list TSV and match gene lists on test name regex`() {
+        val geneList = PanelGeneList.create(ResourceLocator.resourceOnClasspath("panel_gene_list/panel_gene_list.tsv"))
+        val oncoPanel = geneList["HMF oncopanel "]
+        assertThat(oncoPanel).containsExactly("ABCB1", "ABL1")
+        val avlPanelGenes = geneList["an ngs test"]
+        assertThat(avlPanelGenes).containsExactly("EGFR")
+    }
+    
+}

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
@@ -5,13 +5,13 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class PanelGeneListTest {
-    
+
     @Test
     fun `Should read from panel gene list TSV and match gene lists on test name regex`() {
         val geneList = PanelGeneList.create(ResourceLocator.resourceOnClasspath("panel_gene_list/panel_gene_list.tsv"))
-        val oncoPanel = geneList["HMF oncopanel "]
+        val oncoPanel = geneList.matchGenesForTest("HMF oncopanel ")
         assertThat(oncoPanel).containsExactly("ABCB1", "ABL1")
-        val avlPanelGenes = geneList["an ngs test"]
+        val avlPanelGenes = geneList.matchGenesForTest("an ngs test")
         assertThat(avlPanelGenes).containsExactly("EGFR")
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/PanelGeneListTest.kt
@@ -14,5 +14,4 @@ class PanelGeneListTest {
         val avlPanelGenes = geneList["an ngs test"]
         assertThat(avlPanelGenes).containsExactly("EGFR")
     }
-    
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestionTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestionTest.kt
@@ -1,9 +1,6 @@
 package com.hartwig.actin.clinical.feed.standard
 
 import com.hartwig.actin.TestTreatmentDatabaseFactory
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationRequirement
-import com.hartwig.actin.datamodel.clinical.ingestion.CurationResult
-import com.hartwig.actin.datamodel.clinical.ingestion.PatientIngestionStatus
 import com.hartwig.actin.clinical.curation.CURATION_DIRECTORY
 import com.hartwig.actin.clinical.curation.CurationDatabaseContext
 import com.hartwig.actin.clinical.curation.CurationDoidValidator
@@ -14,12 +11,12 @@ import com.hartwig.actin.clinical.feed.standard.extraction.StandardBloodTransfus
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardBodyHeightExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardBodyWeightExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardClinicalStatusExtractor
+import com.hartwig.actin.clinical.feed.standard.extraction.StandardComorbidityExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardLabValuesExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardMedicationExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardOncologicalHistoryExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardPatientDetailsExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardPriorIHCTestExtractor
-import com.hartwig.actin.clinical.feed.standard.extraction.StandardComorbidityExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardPriorPrimariesExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardPriorSequencingTestExtractor
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSurgeryExtractor
@@ -28,6 +25,9 @@ import com.hartwig.actin.clinical.feed.standard.extraction.StandardVitalFunction
 import com.hartwig.actin.clinical.feed.tumor.TumorStageDeriver
 import com.hartwig.actin.clinical.serialization.ClinicalRecordJson
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationRequirement
+import com.hartwig.actin.datamodel.clinical.ingestion.CurationResult
+import com.hartwig.actin.datamodel.clinical.ingestion.PatientIngestionStatus
 import com.hartwig.actin.doid.TestDoidModelFactory
 import com.hartwig.actin.doid.config.DoidManualConfig
 import com.hartwig.actin.icd.TestIcdFactory
@@ -98,7 +98,22 @@ class StandardDataIngestionTest {
             bodyHeightExtractor = StandardBodyHeightExtractor(),
             ihcTestExtractor = StandardPriorIHCTestExtractor(curationDatabase.molecularTestIhcCuration),
             sequencingTestExtractor = StandardPriorSequencingTestExtractor(curationDatabase.sequencingTestCuration),
-            dataQualityMask = DataQualityMask()
+            dataQualityMask = DataQualityMask(
+                PanelGeneList(
+                    mapOf(
+                        Regex("archer") to listOf(
+                            "ALK",
+                            "ROS1",
+                            "RET",
+                            "MET",
+                            "NTRK1",
+                            "NTRK2",
+                            "NTRK3",
+                            "NRG1"
+                        )
+                    )
+                )
+            )
         )
         val expected = ClinicalRecordJson.read(OUTPUT_RECORD_JSON)
         val result = feed.ingest()

--- a/clinical/src/test/resources/panel_gene_list/panel_gene_list.tsv
+++ b/clinical/src/test/resources/panel_gene_list/panel_gene_list.tsv
@@ -1,0 +1,4 @@
+testNameRegex	gene
+oncopanel	ABCB1
+oncopanel	ABL1
+avl|next generation sequencing|ngs	EGFR


### PR DESCRIPTION
Replace the hardcoded list of genes with a TSV file configuration.

The TSV file will have two column, a name (regex) and a gene. The
name unfortunately needs to be duplicated for each gene but that's
just the limitation of using TSV.
