### PR TITLE
ACTIN-1825: Add registration date so that actin pipeline can filter out missing questionnaire warnings for old patients

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -108,7 +108,7 @@ class EmcClinicalFeedIngestor(
 
             Triple(
                 record,
-                ingestionResult(record.patientId, questionnaire, patientEvaluation, questionnaireCurationErrors, feedRecord, record.patient.registrationDate),
+                ingestionResult(record.patientId, record.patient.registrationDate, questionnaire, patientEvaluation, questionnaireCurationErrors, feedRecord),
                 patientEvaluation
             )
         }
@@ -178,11 +178,11 @@ class EmcClinicalFeedIngestor(
 
     private fun ingestionResult(
         patientId: String,
+        registrationDate: LocalDate,
         questionnaire: Questionnaire?,
         patientEvaluation: CurationExtractionEvaluation,
         questionnaireCurationErrors: List<QuestionnaireCurationError>,
         feedRecord: FeedRecord,
-        registrationDate: LocalDate,
     ): PatientIngestionResult {
         val curationResults = curationResultsFromWarnings(patientEvaluation.warnings)
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -182,7 +182,7 @@ class EmcClinicalFeedIngestor(
         questionnaire: Questionnaire?,
         patientEvaluation: CurationExtractionEvaluation,
         questionnaireCurationErrors: List<QuestionnaireCurationError>,
-        feedRecord: FeedRecord,
+        feedRecord: FeedRecord
     ): PatientIngestionResult {
         val curationResults = curationResultsFromWarnings(patientEvaluation.warnings)
 

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -39,6 +39,7 @@ import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.HEART_RATE
 import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.NON_INVASIVE_BLOOD_PRESSURE
 import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.SPO2
 import com.hartwig.actin.datamodel.clinical.ingestion.FeedValidationWarning
+import com.hartwig.actin.datamodel.clinical.ingestion.Warnings
 import com.hartwig.actin.doid.DoidModel
 import org.apache.logging.log4j.LogManager
 import java.time.LocalDate
@@ -190,7 +191,7 @@ class EmcClinicalFeedIngestor(
             if (questionnaire == null || curationResults.isNotEmpty()) PatientIngestionStatus.WARN else PatientIngestionStatus.PASS
 
         val validationWarnings = if (questionnaire == null) {
-            feedRecord.validationWarnings + FeedValidationWarning(patientId, "No Questionnaire found")
+            feedRecord.validationWarnings + FeedValidationWarning(patientId, Warnings.NO_QUESTIONNAIRE_FOUND)
         } else {
             feedRecord.validationWarnings
         }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -182,7 +182,7 @@ class EmcClinicalFeedIngestor(
         patientEvaluation: CurationExtractionEvaluation,
         questionnaireCurationErrors: List<QuestionnaireCurationError>,
         feedRecord: FeedRecord,
-        registrationDate: LocalDate? = null,
+        registrationDate: LocalDate,
     ): PatientIngestionResult {
         val curationResults = curationResultsFromWarnings(patientEvaluation.warnings)
 
@@ -190,13 +190,14 @@ class EmcClinicalFeedIngestor(
             if (questionnaire == null || curationResults.isNotEmpty()) PatientIngestionStatus.WARN else PatientIngestionStatus.PASS
 
         val validationWarnings = if (questionnaire == null) {
-            feedRecord.validationWarnings + FeedValidationWarning(patientId, "No Questionnaire found", registrationDate)
+            feedRecord.validationWarnings + FeedValidationWarning(patientId, "No Questionnaire found")
         } else {
             feedRecord.validationWarnings
         }
 
         return PatientIngestionResult(
             patientId,
+            registrationDate,
             ingestionStatus,
             curationResults,
             questionnaireCurationErrors.toSet(),

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -39,7 +39,7 @@ import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.HEART_RATE
 import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.NON_INVASIVE_BLOOD_PRESSURE
 import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.SPO2
 import com.hartwig.actin.datamodel.clinical.ingestion.FeedValidationWarning
-import com.hartwig.actin.datamodel.clinical.ingestion.Warnings
+import com.hartwig.actin.datamodel.clinical.ingestion.NO_QUESTIONNAIRE_FOUND
 import com.hartwig.actin.doid.DoidModel
 import org.apache.logging.log4j.LogManager
 import java.time.LocalDate
@@ -191,7 +191,7 @@ class EmcClinicalFeedIngestor(
             if (questionnaire == null || curationResults.isNotEmpty()) PatientIngestionStatus.WARN else PatientIngestionStatus.PASS
 
         val validationWarnings = if (questionnaire == null) {
-            feedRecord.validationWarnings + FeedValidationWarning(patientId, Warnings.NO_QUESTIONNAIRE_FOUND)
+            feedRecord.validationWarnings + FeedValidationWarning(patientId, NO_QUESTIONNAIRE_FOUND)
         } else {
             feedRecord.validationWarnings
         }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -41,6 +41,7 @@ import com.hartwig.actin.datamodel.clinical.VitalFunctionCategory.SPO2
 import com.hartwig.actin.datamodel.clinical.ingestion.FeedValidationWarning
 import com.hartwig.actin.doid.DoidModel
 import org.apache.logging.log4j.LogManager
+import java.time.LocalDate
 
 class EmcClinicalFeedIngestor(
     private val feed: FeedModel,
@@ -107,7 +108,7 @@ class EmcClinicalFeedIngestor(
 
             Triple(
                 record,
-                ingestionResult(record.patientId, questionnaire, patientEvaluation, questionnaireCurationErrors, feedRecord),
+                ingestionResult(record.patientId, questionnaire, patientEvaluation, questionnaireCurationErrors, feedRecord, record.patient.registrationDate),
                 patientEvaluation
             )
         }
@@ -180,7 +181,8 @@ class EmcClinicalFeedIngestor(
         questionnaire: Questionnaire?,
         patientEvaluation: CurationExtractionEvaluation,
         questionnaireCurationErrors: List<QuestionnaireCurationError>,
-        feedRecord: FeedRecord
+        feedRecord: FeedRecord,
+        registrationDate: LocalDate? = null,
     ): PatientIngestionResult {
         val curationResults = curationResultsFromWarnings(patientEvaluation.warnings)
 
@@ -188,7 +190,7 @@ class EmcClinicalFeedIngestor(
             if (questionnaire == null || curationResults.isNotEmpty()) PatientIngestionStatus.WARN else PatientIngestionStatus.PASS
 
         val validationWarnings = if (questionnaire == null) {
-            feedRecord.validationWarnings + FeedValidationWarning(patientId, "No Questionnaire found")
+            feedRecord.validationWarnings + FeedValidationWarning(patientId, "No Questionnaire found", registrationDate)
         } else {
             feedRecord.validationWarnings
         }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestion.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/StandardDataIngestion.kt
@@ -72,6 +72,7 @@ class StandardDataIngestion(
                     record,
                     PatientIngestionResult(
                         record.patientId,
+                        record.patient.registrationDate,
                         if (evaluation.warnings.isEmpty()) PatientIngestionStatus.PASS else PatientIngestionStatus.WARN,
                         curationResultsFromWarnings(evaluation.warnings),
                         emptySet(),

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
@@ -12,24 +12,25 @@ import com.hartwig.actin.clinical.feed.emc.ClinicalFeedReader
 import com.hartwig.actin.clinical.feed.emc.EmcClinicalFeedIngestor
 import com.hartwig.actin.clinical.feed.emc.FEED_DIRECTORY
 import com.hartwig.actin.clinical.feed.emc.FeedModel
-import com.hartwig.actin.datamodel.clinical.ingestion.FeedValidationWarning
-import com.hartwig.actin.datamodel.clinical.ingestion.QuestionnaireCurationError
 import com.hartwig.actin.clinical.feed.emc.questionnaire.QuestionnaireVersion
 import com.hartwig.actin.clinical.serialization.ClinicalRecordJson
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
+import com.hartwig.actin.datamodel.clinical.ingestion.FeedValidationWarning
 import com.hartwig.actin.datamodel.clinical.ingestion.IngestionResult
 import com.hartwig.actin.datamodel.clinical.ingestion.PatientIngestionResult
+import com.hartwig.actin.datamodel.clinical.ingestion.QuestionnaireCurationError
 import com.hartwig.actin.datamodel.clinical.ingestion.UnusedCurationConfig
 import com.hartwig.actin.doid.TestDoidModelFactory
 import com.hartwig.actin.doid.config.DoidManualConfig
 import com.hartwig.actin.icd.TestIcdFactory
 import com.hartwig.actin.testutil.ResourceLocator.resourceOnClasspath
 import com.hartwig.actin.util.json.GsonSerializer
-import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.tuple
 import org.junit.Before
 import org.junit.Test
+import java.io.File
+import java.time.LocalDate
 
 private const val PATIENT = "ACTN01029999"
 private val EXPECTED_CLINICAL_RECORD = "${resourceOnClasspath("clinical_record")}/$PATIENT.clinical.json"
@@ -100,6 +101,7 @@ class ClinicalIngestionFeedAdapterTest {
         val patientResults = ingestionResult.patientResults
         assertThat(patientResults).hasSize(1)
         assertThat(patientResults[0].patientId).isEqualTo(PATIENT)
+        assertThat(patientResults[0].registrationDate).isEqualTo(LocalDate.of(2020, 7,13))
         assertThat(patientResults[0].curationResults).isEmpty()
         assertThat(patientResults[0].questionnaireCurationErrors)
             .containsExactly(QuestionnaireCurationError(PATIENT, "Unrecognized questionnaire option: 'Probbly'"))

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestorTest.kt
@@ -6,6 +6,7 @@ import com.hartwig.actin.clinical.feed.emc.TestFeedFactory.createTestClinicalFee
 import com.hartwig.actin.datamodel.clinical.ClinicalStatus
 import com.hartwig.actin.datamodel.clinical.Comorbidity
 import com.hartwig.actin.datamodel.clinical.TumorDetails
+import com.hartwig.actin.datamodel.clinical.ingestion.Warnings
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -39,7 +40,7 @@ class EmcClinicalFeedIngestorTest {
         )
 
         val (_, patientIngestionResult, _) = emcClinicalFeedIngestor.ingest().first()
-        assertThat(patientIngestionResult.feedValidationWarnings.map { it.message }).contains("No Questionnaire found")
+        assertThat(patientIngestionResult.feedValidationWarnings.map { it.message }).contains(Warnings.NO_QUESTIONNAIRE_FOUND)
 
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestorTest.kt
@@ -6,7 +6,7 @@ import com.hartwig.actin.clinical.feed.emc.TestFeedFactory.createTestClinicalFee
 import com.hartwig.actin.datamodel.clinical.ClinicalStatus
 import com.hartwig.actin.datamodel.clinical.Comorbidity
 import com.hartwig.actin.datamodel.clinical.TumorDetails
-import com.hartwig.actin.datamodel.clinical.ingestion.Warnings
+import com.hartwig.actin.datamodel.clinical.ingestion.NO_QUESTIONNAIRE_FOUND
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -40,7 +40,7 @@ class EmcClinicalFeedIngestorTest {
         )
 
         val (_, patientIngestionResult, _) = emcClinicalFeedIngestor.ingest().first()
-        assertThat(patientIngestionResult.feedValidationWarnings.map { it.message }).contains(Warnings.NO_QUESTIONNAIRE_FOUND)
+        assertThat(patientIngestionResult.feedValidationWarnings.map { it.message }).contains(NO_QUESTIONNAIRE_FOUND)
 
     }
 }

--- a/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
@@ -3,16 +3,8 @@
   "patient": {
     "gender": "MALE",
     "birthYear": 1953,
-    "registrationDate": {
-      "year": 2020,
-      "month": 7,
-      "day": 13
-    },
-    "questionnaireDate": {
-      "year": 2021,
-      "month": 8,
-      "day": 16
-    },
+    "registrationDate": "2020-07-13",
+    "questionnaireDate": "2021-08-16",
     "hasHartwigSequencing": true
   },
   "tumor": {
@@ -185,11 +177,7 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2021,
-        "month": 6,
-        "day": 6
-      },
+      "evaluatedDate": "2021-06-06",
       "source": "EHR",
       "grade": 3,
       "endDate": null,
@@ -203,11 +191,7 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2021,
-        "month": 8,
-        "day": 8
-      },
+      "evaluatedDate": "2021-08-08",
       "source": "EHR",
       "grade": 0,
       "endDate": null,
@@ -221,11 +205,7 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2021,
-        "month": 8,
-        "day": 16
-      },
+      "evaluatedDate": "2021-08-16",
       "source": "QUESTIONNAIRE",
       "grade": 3,
       "endDate": null,
@@ -284,11 +264,7 @@
   "priorSequencingTests": [],
   "labValues": [
     {
-      "date": {
-        "year": 2019,
-        "month": 6,
-        "day": 27
-      },
+      "date": "2019-06-27",
       "measurement": "ADRENOCORTICOTROPIC_HORMONE",
       "comparator": "",
       "value": 5.5,
@@ -301,11 +277,7 @@
   "surgeries": [
     {
       "name": "diagnostics stomach translated",
-      "endDate": {
-        "year": 2020,
-        "month": 8,
-        "day": 28
-      },
+      "endDate": "2020-08-28",
       "status": "PLANNED"
     }
   ],
@@ -336,11 +308,7 @@
   ],
   "bloodTransfusions": [
     {
-      "date": {
-        "year": 2021,
-        "month": 12,
-        "day": 17
-      },
+      "date": "2021-12-17",
       "product": "Thrombocyte concentrate"
     }
   ],
@@ -359,16 +327,8 @@
         "periodBetweenUnit": "mo",
         "ifNeeded": false
       },
-      "startDate": {
-        "year": 2019,
-        "month": 6,
-        "day": 7
-      },
-      "stopDate": {
-        "year": 2019,
-        "month": 6,
-        "day": 7
-      },
+      "startDate": "2019-06-07",
+      "stopDate": "2019-06-07",
       "drug": {
         "name": "PEMBROLIZUMAB",
         "drugTypes": ["TOPO1_INHIBITOR"],

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -3,11 +3,7 @@
   "patient": {
     "gender": "FEMALE",
     "birthYear": 5,
-    "registrationDate": {
-      "year": 2020,
-      "month": 1,
-      "day": 1
-    },
+    "registrationDate": "2020-01-01",
     "questionnaireDate": null
   },
   "tumor": {
@@ -136,18 +132,10 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "evaluatedDate": "2020-01-01",
       "source": "EHR",
       "grade": 5,
-      "endDate": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "endDate": "2020-01-01",
       "comorbidityClass": "TOXICITY"
     },
     {
@@ -209,11 +197,7 @@
         "NTRK3",
         "NRG1"
       ],
-      "date": {
-        "year": 2024,
-        "month": 7,
-        "day": 15
-      },
+      "date": "2024-07-15",
       "variants": [
         {
           "gene": "KRAS",
@@ -228,11 +212,7 @@
   ],
   "labValues": [
     {
-      "date": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2020-01-01",
       "measurement": "O2_SATURATION_BG",
       "comparator": "",
       "value": 88.0,
@@ -242,11 +222,7 @@
       "isOutsideRef": null
     },
     {
-      "date": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2020-01-01",
       "measurement": "THROMBOCYTES_ABS",
       "comparator": "",
       "value": 252.0,
@@ -256,11 +232,7 @@
       "isOutsideRef": null
     },
     {
-      "date": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2020-01-01",
       "measurement": "LYMPHOCYTES_ABS",
       "comparator": "",
       "value": 0.6,
@@ -270,11 +242,7 @@
       "isOutsideRef": null
     },
     {
-      "date": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2020-01-01",
       "measurement": "HEMOGLOBIN",
       "comparator": "",
       "value": 7.7,
@@ -287,11 +255,7 @@
   "surgeries": [
     {
       "name": "diagnostics stomach translated",
-      "endDate": {
-        "year": 2021,
-        "month": 1,
-        "day": 1
-      },
+      "endDate": "2021-01-01",
       "status": "CANCELLED"
     }
   ],
@@ -345,11 +309,7 @@
   ],
   "bloodTransfusions": [
     {
-      "date": {
-        "year": 2020,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2020-01-01",
       "product": "Erytrocytes Filtered"
     }
   ],

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
@@ -52,8 +52,8 @@ object ClinicalGsonDeserializer {
             return if (jsonElement.isJsonNull) {
                 null
             } else {
-                val dateObject = jsonElement.asJsonObject
-                LocalDate.of(integer(dateObject, "year"), integer(dateObject, "month"), integer(dateObject, "day"))
+                val dateString = jsonElement.asString
+                LocalDate.parse(dateString)
             }
         }
     }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
@@ -13,8 +13,8 @@ import com.hartwig.actin.datamodel.clinical.treatment.OtherTreatmentType
 import com.hartwig.actin.datamodel.clinical.treatment.RadiotherapyType
 import com.hartwig.actin.datamodel.clinical.treatment.Treatment
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.util.json.GsonLocalDateAdapter
 import com.hartwig.actin.util.json.GsonLocalDateTimeAdapter
-import com.hartwig.actin.util.json.Json.integer
 import com.hartwig.actin.util.json.StrictEnumDeserializer
 import java.lang.reflect.Type
 import java.time.LocalDate
@@ -33,7 +33,7 @@ object ClinicalGsonDeserializer {
     private fun gsonBuilder(): GsonBuilder {
         return GsonBuilder().serializeNulls()
             .enableComplexMapKeySerialization()
-            .registerTypeAdapter(LocalDate::class.java, LocalDateAdapter())
+            .registerTypeAdapter(LocalDate::class.java, GsonLocalDateAdapter())
             .registerTypeAdapter(LocalDateTime::class.java, GsonLocalDateTimeAdapter())
             .registerTypeAdapter(Treatment::class.java, TreatmentAdapter())
             .registerTypeAdapter(Comorbidity::class.java, ComorbidityAdapter())
@@ -41,25 +41,6 @@ object ClinicalGsonDeserializer {
             .registerTypeAdapter(OtherTreatmentType::class.java, StrictEnumDeserializer(OtherTreatmentType::class.java))
             .registerTypeAdapter(RadiotherapyType::class.java, StrictEnumDeserializer(RadiotherapyType::class.java))
             .registerTypeAdapter(TreatmentCategory::class.java, StrictEnumDeserializer(TreatmentCategory::class.java))
-    }
-
-    private class LocalDateAdapter : JsonDeserializer<LocalDate?> {
-
-        override fun deserialize(
-            jsonElement: JsonElement, type: Type,
-            jsonDeserializationContext: JsonDeserializationContext
-        ): LocalDate? {
-            return if (jsonElement.isJsonNull) {
-                null
-            } else if (jsonElement.isJsonObject){
-                val dateObject = jsonElement.asJsonObject
-                LocalDate.of(integer(dateObject, "year"), integer(dateObject, "month"), integer(dateObject, "day"))
-            }
-            else {
-                val dateString = jsonElement.asString
-                LocalDate.parse(dateString)
-            }
-        }
     }
 
     private class DrugNameAdapter(private val drugsByName: Map<String, Drug>) : JsonDeserializer<Drug> {

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/serialization/ClinicalGsonDeserializer.kt
@@ -51,7 +51,11 @@ object ClinicalGsonDeserializer {
         ): LocalDate? {
             return if (jsonElement.isJsonNull) {
                 null
-            } else {
+            } else if (jsonElement.isJsonObject){
+                val dateObject = jsonElement.asJsonObject
+                LocalDate.of(integer(dateObject, "year"), integer(dateObject, "month"), integer(dateObject, "day"))
+            }
+            else {
                 val dateString = jsonElement.asString
                 LocalDate.parse(dateString)
             }

--- a/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
@@ -18,44 +18,12 @@ class GsonLocalDateAdapter : TypeAdapter<LocalDate?>() {
 
     override fun read(reader: JsonReader): LocalDate? {
         val firstToken: JsonToken = reader.peek()
-        when (firstToken) {
-            JsonToken.NULL -> {
+        if (firstToken == JsonToken.NULL) {
                 reader.skipValue()
                 return null
-            }
-
-            JsonToken.STRING -> {
-                reader.peek()
-                return LocalDate.parse(reader.nextString())
-            }
-
-            else -> {
-                var year: Int = -1
-                var month: Int = -1
-                var day: Int = -1
-                reader.beginObject()
-                var field: String = reader.nextName()
-                while (reader.hasNext()) {
-                    val token: JsonToken = reader.peek()
-                    if (token == JsonToken.NAME) {
-                        field = reader.nextName()
-                    }
-                    if ((field == "year")) {
-                        reader.peek()
-                        year = reader.nextInt()
-                    }
-                    if ((field == "month")) {
-                        reader.peek()
-                        month = reader.nextInt()
-                    }
-                    if ((field == "day")) {
-                        reader.peek()
-                        day = reader.nextInt()
-                    }
-                }
-                reader.endObject()
-                return LocalDate.of(year, month, day)
-            }
         }
+
+        reader.peek()
+        return LocalDate.parse(reader.nextString())
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
@@ -12,14 +12,7 @@ class GsonLocalDateAdapter : TypeAdapter<LocalDate?>() {
         if (localDate == null) {
             writer.nullValue()
         } else {
-            writer.beginObject()
-            writer.name("year")
-            writer.value(localDate.year.toLong())
-            writer.name("month")
-            writer.value(localDate.monthValue.toLong())
-            writer.name("day")
-            writer.value(localDate.dayOfMonth.toLong())
-            writer.endObject()
+            writer.value(localDate.toString())
         }
     }
 
@@ -29,30 +22,7 @@ class GsonLocalDateAdapter : TypeAdapter<LocalDate?>() {
             reader.skipValue()
             return null
         }
-        var year: Int = -1
-        var month: Int = -1
-        var day: Int = -1
-        reader.beginObject()
-        var field: String = reader.nextName()
-        while (reader.hasNext()) {
-            val token: JsonToken = reader.peek()
-            if (token == JsonToken.NAME) {
-                field = reader.nextName()
-            }
-            if ((field == "year")) {
-                reader.peek()
-                year = reader.nextInt()
-            }
-            if ((field == "month")) {
-                reader.peek()
-                month = reader.nextInt()
-            }
-            if ((field == "day")) {
-                reader.peek()
-                day = reader.nextInt()
-            }
-        }
-        reader.endObject()
-        return LocalDate.of(year, month, day)
+        reader.peek()
+        return LocalDate.parse(reader.nextString())
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
@@ -17,13 +17,9 @@ class GsonLocalDateAdapter : TypeAdapter<LocalDate?>() {
     }
 
     override fun read(reader: JsonReader): LocalDate? {
-        val firstToken: JsonToken = reader.peek()
-        if (firstToken == JsonToken.NULL) {
-                reader.skipValue()
-                return null
-        }
-
-        reader.peek()
-        return LocalDate.parse(reader.nextString())
+        return if (reader.peek() == JsonToken.NULL) {
+            reader.skipValue()
+            null
+        } else LocalDate.parse(reader.nextString())
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/util/json/GsonLocalDateAdapter.kt
@@ -18,11 +18,44 @@ class GsonLocalDateAdapter : TypeAdapter<LocalDate?>() {
 
     override fun read(reader: JsonReader): LocalDate? {
         val firstToken: JsonToken = reader.peek()
-        if (firstToken == JsonToken.NULL) {
-            reader.skipValue()
-            return null
+        when (firstToken) {
+            JsonToken.NULL -> {
+                reader.skipValue()
+                return null
+            }
+
+            JsonToken.STRING -> {
+                reader.peek()
+                return LocalDate.parse(reader.nextString())
+            }
+
+            else -> {
+                var year: Int = -1
+                var month: Int = -1
+                var day: Int = -1
+                reader.beginObject()
+                var field: String = reader.nextName()
+                while (reader.hasNext()) {
+                    val token: JsonToken = reader.peek()
+                    if (token == JsonToken.NAME) {
+                        field = reader.nextName()
+                    }
+                    if ((field == "year")) {
+                        reader.peek()
+                        year = reader.nextInt()
+                    }
+                    if ((field == "month")) {
+                        reader.peek()
+                        month = reader.nextInt()
+                    }
+                    if ((field == "day")) {
+                        reader.peek()
+                        day = reader.nextInt()
+                    }
+                }
+                reader.endObject()
+                return LocalDate.of(year, month, day)
+            }
         }
-        reader.peek()
-        return LocalDate.parse(reader.nextString())
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/algo/serialization/TreatmentMatchJsonTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/algo/serialization/TreatmentMatchJsonTest.kt
@@ -56,7 +56,7 @@ class TreatmentMatchJsonTest {
             {
                 "patientId":"ACTN01029999",
                 "sampleId":"ACTN01029999T",
-                "referenceDate":{"year":2021,"month":8,"day":2},
+                "referenceDate":"2021-08-02",
                 "referenceDateIsLive":true,
                 "trialMatches":[
                 {

--- a/common/src/test/resources/algo/patient.treatment_match.json
+++ b/common/src/test/resources/algo/patient.treatment_match.json
@@ -1,11 +1,7 @@
 {
   "patientId": "ACTN01029999",
   "sampleId": "ACTN01029999T",
-  "referenceDate": {
-    "year": 2021,
-    "month": 8,
-    "day": 2
-  },
+  "referenceDate": "2021-08-02",
   "referenceDateIsLive": true,
   "trialMatches": [
     {

--- a/common/src/test/resources/clinical/records/patient.clinical.json
+++ b/common/src/test/resources/clinical/records/patient.clinical.json
@@ -3,16 +3,8 @@
   "patient": {
     "gender": "MALE",
     "birthYear": 1960,
-    "registrationDate": {
-      "year": 2021,
-      "month": 6,
-      "day": 1
-    },
-    "questionnaireDate": {
-      "year": 2021,
-      "month": 8,
-      "day": 1
-    }
+    "registrationDate": "2021-06-01",
+    "questionnaireDate": "2021-08-01"
   },
   "tumor": {
     "primaryTumorLocation": null,
@@ -132,11 +124,7 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2019,
-        "month": 4,
-        "day": 4
-      },
+      "evaluatedDate": "2019-04-04",
       "source": "QUESTIONNAIRE",
       "grade": 3,
       "comorbidityClass": "TOXICITY"
@@ -149,11 +137,7 @@
           "extensionCode": null
         }
       ],
-      "evaluatedDate": {
-        "year": 2020,
-        "month": 3,
-        "day": 3
-      },
+      "evaluatedDate": "2020-03-03",
       "source": "EHR",
       "grade": 1,
       "comorbidityClass": "TOXICITY"
@@ -209,11 +193,7 @@
   "priorSequencingTests": [],
   "labValues": [
     {
-      "date": {
-        "year": 2020,
-        "month": 8,
-        "day": 8
-      },
+      "date": "2020-08-08",
       "measurement": "CREATININE_CLEARANCE_CG",
       "comparator": "",
       "value": 11,
@@ -223,11 +203,7 @@
       "isOutsideRef": null
     },
     {
-      "date": {
-        "year": 2020,
-        "month": 8,
-        "day": 8
-      },
+      "date": "2020-08-08",
       "measurement": "HEMOGLOBIN",
       "comparator": "",
       "value": 8.8,
@@ -239,11 +215,7 @@
   ],
   "surgeries": [
     {
-      "endDate": {
-        "year": 2012,
-        "month": 10,
-        "day": 10
-      },
+      "endDate": "2012-10-10",
       "status": "PLANNED"
     }
   ],
@@ -266,11 +238,7 @@
   ],
   "bloodTransfusions": [
     {
-      "date": {
-        "year": 2018,
-        "month": 1,
-        "day": 1
-      },
+      "date": "2018-01-01",
       "product": "white blood cells"
     }
   ],
@@ -288,16 +256,8 @@
         "frequencyUnit": "day",
         "ifNeeded": false
       },
-      "startDate": {
-        "year": 2018,
-        "month": 1,
-        "day": 1
-      },
-      "stopDate": {
-        "year": 2018,
-        "month": 2,
-        "day": 1
-      },
+      "startDate": "2018-01-01",
+      "stopDate": "2018-02-01",
       "drug": null,
       "cypInteractions": [
         {
@@ -325,16 +285,8 @@
         "frequencyUnit": null,
         "ifNeeded": null
       },
-      "startDate": {
-        "year": 2019,
-        "month": 5,
-        "day": 25
-      },
-      "stopDate": {
-        "year": 2019,
-        "month": 6,
-        "day": 25
-      },
+      "startDate": "2019-05-25",
+      "stopDate": "2019-06-25",
       "cypInteractions": [],
       "transporterInteractions": [],
       "qtProlongatingRisk": "KNOWN",

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -81,7 +81,5 @@ data class FeedValidationWarning(val subject: String, val message: String) : Com
     }
 }
 
-object Warnings{
-    const val NO_QUESTIONNAIRE_FOUND = "No Questionnaire Found"
-}
+const val NO_QUESTIONNAIRE_FOUND = "No Questionnaire Found"
 

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -80,3 +80,8 @@ data class FeedValidationWarning(val subject: String, val message: String) : Com
             .compare(this, other)
     }
 }
+
+object Warnings{
+    const val NO_QUESTIONNAIRE_FOUND = "No Questionnaire Found"
+}
+

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -15,7 +15,6 @@ enum class PatientIngestionStatus {
 
 data class PatientIngestionResult(
     val patientId: String,
-    val patientRegistrationDate: LocalDate,
     val status: PatientIngestionStatus,
     val curationResults: Set<CurationResult>,
     val questionnaireCurationErrors: Set<QuestionnaireCurationError>,

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -15,6 +15,7 @@ enum class PatientIngestionStatus {
 
 data class PatientIngestionResult(
     val patientId: String,
+    val registrationDate: LocalDate,
     val status: PatientIngestionStatus,
     val curationResults: Set<CurationResult>,
     val questionnaireCurationErrors: Set<QuestionnaireCurationError>,
@@ -71,7 +72,7 @@ data class QuestionnaireCurationError(val subject: String, val message: String) 
     }
 }
 
-data class FeedValidationWarning(val subject: String, val message: String, val registrationDate: LocalDate? = null) : Comparable<FeedValidationWarning> {
+data class FeedValidationWarning(val subject: String, val message: String) : Comparable<FeedValidationWarning> {
 
     override fun compareTo(other: FeedValidationWarning): Int {
         return Comparator.comparing(FeedValidationWarning::subject)

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -1,5 +1,7 @@
 package com.hartwig.actin.datamodel.clinical.ingestion
 
+import java.time.LocalDate
+
 data class IngestionResult(
     val configValidationErrors: Set<CurationConfigValidationError> = emptySet(),
     val patientResults: List<PatientIngestionResult> = emptyList(),
@@ -13,6 +15,7 @@ enum class PatientIngestionStatus {
 
 data class PatientIngestionResult(
     val patientId: String,
+    val patientRegistrationDate: LocalDate,
     val status: PatientIngestionStatus,
     val curationResults: Set<CurationResult>,
     val questionnaireCurationErrors: Set<QuestionnaireCurationError>,

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/IngestionResult.kt
@@ -72,7 +72,7 @@ data class QuestionnaireCurationError(val subject: String, val message: String) 
     }
 }
 
-data class FeedValidationWarning(val subject: String, val message: String) : Comparable<FeedValidationWarning> {
+data class FeedValidationWarning(val subject: String, val message: String, val registrationDate: LocalDate? = null) : Comparable<FeedValidationWarning> {
 
     override fun compareTo(other: FeedValidationWarning): Int {
         return Comparator.comparing(FeedValidationWarning::subject)

--- a/system/src/test/resources/example_patient_data/EXAMPLE-LUNG-01.patient_record.json
+++ b/system/src/test/resources/example_patient_data/EXAMPLE-LUNG-01.patient_record.json
@@ -3,16 +3,8 @@
   "patient": {
     "gender": "FEMALE",
     "birthYear": 1975,
-    "registrationDate": {
-      "year": 2025,
-      "month": 2,
-      "day": 20
-    },
-    "questionnaireDate": {
-      "year": 2025,
-      "month": 2,
-      "day": 20
-    },
+    "registrationDate": "2025-02-20",
+    "questionnaireDate": "2025-02-20",
     "hasHartwigSequencing": true
   },
   "tumor": {
@@ -116,11 +108,7 @@
   ],
   "labValues": [
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "ALAT",
       "name": "Alanine aminotransferase",
       "comparator": "",
@@ -131,11 +119,7 @@
       "isOutsideRef": false
     },
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "ASAT",
       "name": "Aspartate aminotransferase",
       "comparator": "",
@@ -146,11 +130,7 @@
       "isOutsideRef": false
     },
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "TOTAL_BILIRUBIN",
       "name": "total bilirubin",
       "comparator": "",
@@ -161,11 +141,7 @@
       "isOutsideRef": false
     },
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "Hb",
       "name": "hemoglobin",
       "comparator": "",
@@ -176,11 +152,7 @@
       "isOutsideRef": false
     },
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "THROMBOCYTES_ABS",
       "name": "absolute thrombocyte count",
       "comparator": "",
@@ -191,11 +163,7 @@
       "isOutsideRef": true
     },
     {
-      "date": {
-        "year": 2025,
-        "month": 1,
-        "day": 15
-      },
+      "date": "2025-01-15",
       "code": "LYMPHOCYTES_ABS_EDA",
       "name": "absolute lymphocyte count eDA",
       "comparator": "",
@@ -209,11 +177,7 @@
   "surgeries": [
     {
       "name": "Cholecystectomy",
-      "endDate": {
-        "year": 2024,
-        "month": 8,
-        "day": 1
-      },
+      "endDate": "2024-08-01",
       "status": "FINISHED"
     }
   ],
@@ -259,11 +223,7 @@
   ],
   "bloodTransfusions": [
     {
-      "date": {
-        "year": 2024,
-        "month": 9,
-        "day": 20
-      },
+      "date": "2024-09-20",
       "product": "ERTHROCYTES_FILTERED"
     }
   ],
@@ -282,11 +242,7 @@
         "periodBetweenUnit": "DAYS",
         "ifNeeded": false
       },
-      "startDate": {
-        "year": 2023,
-        "month": 2,
-        "day": 1
-      },
+      "startDate": "2023-02-01",
       "stopDate": null,
       "drug": null,
       "cypInteractions": [
@@ -386,11 +342,7 @@
         "hasSufficientQuality": true,
         "testTypeDisplay": null,
         "experimentType": "HARTWIG_WHOLE_GENOME",
-        "date": {
-          "year": 2025,
-          "month": 2,
-          "day": 22
-        },
+        "date": "2025-02-22",
         "drivers": {
           "variants": [
             {
@@ -429,11 +381,7 @@
                   {
                     "treatment": "OSIMERTINIB",
                     "molecularMatch": {
-                      "sourceDate": {
-                        "year": 2012,
-                        "month": 1,
-                        "day": 1
-                      },
+                      "sourceDate": "2012-01-01",
                       "sourceEvent": "EGFR L858R",
                       "isCategoryEvent": false
                     },
@@ -456,11 +404,7 @@
                   {
                     "treatment": "AFATINIB",
                     "molecularMatch": {
-                      "sourceDate": {
-                        "year": 2012,
-                        "month": 1,
-                        "day": 1
-                      },
+                      "sourceDate": "2012-01-01",
                       "sourceEvent": "EGFR L858R",
                       "isCategoryEvent": false
                     },
@@ -487,11 +431,7 @@
                     "title": "EGFR-L858R-TRIAL",
                     "molecularMatches": [
                       {
-                        "sourceDate": {
-                          "year": 2012,
-                          "month": 1,
-                          "day": 1
-                        },
+                        "sourceDate": "2012-01-01",
                         "sourceEvent": "EGFR L858R",
                         "isCategoryEvent": false
                       }
@@ -532,11 +472,7 @@
                     "title": "EGFR-BE",
                     "molecularMatches": [
                       {
-                        "sourceDate": {
-                          "year": 2012,
-                          "month": 1,
-                          "day": 1
-                        },
+                        "sourceDate": "2012-01-01",
                         "sourceEvent": "EGFR L858R",
                         "isCategoryEvent": false
                       }
@@ -604,11 +540,7 @@
                   {
                     "treatment": "AFATINIB",
                     "molecularMatch": {
-                      "sourceDate": {
-                        "year": 2012,
-                        "month": 1,
-                        "day": 1
-                      },
+                      "sourceDate": "2012-01-01",
                       "sourceEvent": "EGFR C797S",
                       "isCategoryEvent": false
                     },
@@ -635,11 +567,7 @@
                     "title": "EGFR-C797S-TRIAL",
                     "molecularMatches": [
                       {
-                        "sourceDate": {
-                          "year": 2012,
-                          "month": 1,
-                          "day": 1
-                        },
+                        "sourceDate": "2012-01-01",
                         "sourceEvent": "EGFR C797S",
                         "isCategoryEvent": false
                       }
@@ -761,11 +689,7 @@
                     "title": "KRAS-G12C-TRIAL-DE",
                     "molecularMatches": [
                       {
-                        "sourceDate": {
-                          "year": 2012,
-                          "month": 1,
-                          "day": 1
-                        },
+                        "sourceDate": "2012-01-01",
                         "sourceEvent": "KRAS G12C",
                         "isCategoryEvent": false
                       }

--- a/system/src/test/resources/example_treatment_match/EXAMPLE-LUNG-01.treatment_match.json
+++ b/system/src/test/resources/example_treatment_match/EXAMPLE-LUNG-01.treatment_match.json
@@ -1,11 +1,7 @@
 {
   "patientId": "EXAMPLE-LUNG-01",
   "sampleId": "EXAMPLE-LUNG-01-T",
-  "referenceDate": {
-    "year": 2025,
-    "month": 2,
-    "day": 25
-  },
+  "referenceDate": "2025-02-25",
   "referenceDateIsLive": true,
   "trialMatches": [
     {


### PR DESCRIPTION
This is to prevent old patients from showing the missing questionnaire warning. I simply modified the feedValidationWarning to have an optional registration date that is passed in if there is a missing questionnaire warning. The rest of the changes are in actin pipeline