### PR TITLE
ACTIN-1870: Make ignoring complete sequencing tests case sensitive

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabase.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/CurationDatabase.kt
@@ -16,7 +16,10 @@ class CurationDatabase<T : CurationConfig>(
     private val evaluatedInputFunction: (CurationExtractionEvaluation) -> Set<String>
 ) {
 
-    fun find(input: InputText) = configs[input.lowercase()] ?: emptySet()
+    fun find(input: InputText, isCaseSensitive: Boolean = false): Set<T> {
+        val inputToFind = if (!isCaseSensitive) input.lowercase() else input
+        return configs[inputToFind] ?: emptySet()
+    }
 
     fun reportUnusedConfig(evaluation: CurationExtractionEvaluation): List<UnusedCurationConfig> {
         return (configs.keys - evaluatedInputFunction(evaluation)).map { UnusedCurationConfig(category, it) }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractor.kt
@@ -22,7 +22,9 @@ class StandardPriorSequencingTestExtractor(val curation: CurationDatabase<Sequen
 
     override fun extract(ehrPatientRecord: ProvidedPatientRecord): ExtractionResult<List<PriorSequencingTest>> {
         val extracted = ehrPatientRecord.molecularTests.mapNotNull { test ->
-            val ignoreEntireTest = curation.find(patientQualifiedTestName(ehrPatientRecord.patientDetails.hashedId, test)).any { it.ignore }
+            val ignoreEntireTest =
+                curation.find(patientQualifiedTestName(ehrPatientRecord.patientDetails.hashedId, test), isCaseSensitive = true)
+                    .any { it.ignore }
             if (!ignoreEntireTest) {
                 val nonIHCTestResults = test.results.filter { it.ihcResult == null }.toSet()
                 val (onlyFreeTextResults, populatedResults) = nonIHCTestResults

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/CurationDatabaseTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/CurationDatabaseTest.kt
@@ -12,6 +12,7 @@ import org.junit.Test
 import java.io.File
 
 private const val INPUT = "input"
+private const val INPUT_UPPER_CASE = "INPUT"
 private const val INPUT2 = "input2"
 
 class CurationDatabaseTest {
@@ -28,6 +29,18 @@ class CurationDatabaseTest {
     fun `Should return curation configs when key is found`() {
         val database = CurationDatabase(mapOf(INPUT to setOf(testConfig)), emptyList(), CurationCategory.COMORBIDITY) { emptySet() }
         assertThat(database.find(INPUT)).containsExactly(testConfig)
+    }
+
+    @Test
+    fun `Should return curation configs when key is found with different case and isCaseSensitive = false`() {
+        val database = CurationDatabase(mapOf(INPUT to setOf(testConfig)), emptyList(), CurationCategory.COMORBIDITY) { emptySet() }
+        assertThat(database.find(INPUT_UPPER_CASE)).containsExactly(testConfig)
+    }
+
+    @Test
+    fun `Should not return curation configs when key is found with different case and isCaseSensitive = true`() {
+        val database = CurationDatabase(mapOf(INPUT to setOf(testConfig)), emptyList(), CurationCategory.COMORBIDITY) { emptySet() }
+        assertThat(database.find(INPUT_UPPER_CASE, isCaseSensitive = true)).isEmpty()
     }
 
     @Test

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorSequencingTestExtractorTest.kt
@@ -42,7 +42,7 @@ private const val FREE_TEXT = "free text"
 class StandardPriorSequencingTestExtractorTest {
 
     val curation = mockk<CurationDatabase<SequencingTestConfig>> {
-        every { find("$HASHED_ID_IN_BASE64 | $TEST") } returns emptySet()
+        every { find("$HASHED_ID_IN_BASE64 | $TEST", isCaseSensitive = true) } returns emptySet()
     }
     val extractor = StandardPriorSequencingTestExtractor(curation)
 
@@ -223,7 +223,7 @@ class StandardPriorSequencingTestExtractorTest {
 
     @Test
     fun `Should allow for ignoring of full tests`() {
-        every { curation.find("$HASHED_ID_IN_BASE64 | $TEST") } returns setOf(
+        every { curation.find("$HASHED_ID_IN_BASE64 | $TEST", isCaseSensitive = true) } returns setOf(
             SequencingTestConfig(
                 input = "$HASHED_ID_IN_BASE64 | $TEST",
                 ignore = true


### PR DESCRIPTION
... accidentally used ACTIN-1869

Should be: https://hartwigmedical.atlassian.net/browse/ACTIN-1870

Goal: Ignore tests case sensitively, e.g. if test name is "NGS" then ignore only if we curate "NGS" and not "NgS" 