### PR TITLE
ACTIN-1915: Update ORANGE-DATAMODEL version to 3.0.0

### DIFF
--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/DriverEventFactory.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/DriverEventFactory.kt
@@ -6,7 +6,7 @@ import com.hartwig.hmftools.datamodel.linx.LinxFusion
 import com.hartwig.hmftools.datamodel.linx.LinxHomozygousDisruption
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect
-import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss
+import com.hartwig.hmftools.datamodel.purple.PurpleGainDeletion
 import com.hartwig.hmftools.datamodel.purple.PurpleGeneCopyNumber
 import com.hartwig.hmftools.datamodel.purple.PurpleVariant
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect
@@ -31,14 +31,14 @@ object DriverEventFactory {
         )
     }
 
-    fun gainLossEvent(gainLoss: PurpleGainLoss): String {
-        return when (gainLoss.interpretation()) {
+    fun gainDelEvent(gainDel: PurpleGainDeletion): String {
+        return when (gainDel.interpretation()) {
             CopyNumberInterpretation.PARTIAL_GAIN, CopyNumberInterpretation.FULL_GAIN -> {
-                gainLoss.gene() + " amp"
+                gainDel.gene() + " amp"
             }
 
-            CopyNumberInterpretation.PARTIAL_LOSS, CopyNumberInterpretation.FULL_LOSS -> {
-                gainLoss.gene() + " del"
+            CopyNumberInterpretation.PARTIAL_DEL, CopyNumberInterpretation.FULL_DEL -> {
+                gainDel.gene() + " del"
             }
         }
     }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/ImmunologyExtraction.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/ImmunologyExtraction.kt
@@ -12,11 +12,11 @@ object ImmunologyExtraction {
 
     fun extract(record: OrangeRecord): MolecularImmunology {
         val lilac = record.lilac()
-        return MolecularImmunology(isReliable = isQCPass(lilac), hlaAlleles = toHlaAlleles(lilac.alleles()))
+        return MolecularImmunology(isReliable = isQCPass(lilac), hlaAlleles = toHlaAlleles(lilac?.alleles() ?: emptyList()))
     }
 
-    private fun isQCPass(lilac: LilacRecord): Boolean {
-        return lilac.qc() == LILAC_QC_PASS
+    private fun isQCPass(lilac: LilacRecord?): Boolean {
+        return lilac?.qc() == LILAC_QC_PASS
     }
 
     private fun toHlaAlleles(alleles: List<LilacAllele>): Set<HlaAllele> {

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/CopyNumberExtractorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/CopyNumberExtractorTest.kt
@@ -23,19 +23,19 @@ class CopyNumberExtractorTest {
         val driverGene3NonCanonical = TestPurpleFactory.driverBuilder().gene("gene 3").type(PurpleDriverType.AMP).isCanonical(false).build()
         val driverGene4Canonical = TestPurpleFactory.driverBuilder().gene("gene 4").type(PurpleDriverType.AMP).isCanonical(true).build()
 
-        val loss1Canonical = TestPurpleFactory.gainLossBuilder().gene("gene 1").minCopies(0.0).maxCopies(1.0).isCanonical(true)
-            .interpretation(CopyNumberInterpretation.PARTIAL_LOSS).build()
-        val loss1NonCanonical = TestPurpleFactory.gainLossBuilder().gene("gene 1").minCopies(0.0).maxCopies(1.0).isCanonical(false)
-            .interpretation(CopyNumberInterpretation.PARTIAL_LOSS).build()
-        val gain2Canonical = TestPurpleFactory.gainLossBuilder().gene("gene 2").minCopies(20.0).maxCopies(21.0).isCanonical(true)
+        val loss1Canonical = TestPurpleFactory.gainDelBuilder().gene("gene 1").minCopies(0.0).maxCopies(1.0).isCanonical(true)
+            .interpretation(CopyNumberInterpretation.PARTIAL_DEL).build()
+        val loss1NonCanonical = TestPurpleFactory.gainDelBuilder().gene("gene 1").minCopies(0.0).maxCopies(1.0).isCanonical(false)
+            .interpretation(CopyNumberInterpretation.PARTIAL_DEL).build()
+        val gain2Canonical = TestPurpleFactory.gainDelBuilder().gene("gene 2").minCopies(20.0).maxCopies(21.0).isCanonical(true)
             .interpretation(CopyNumberInterpretation.FULL_GAIN).build()
-        val gain2NonCanonical = TestPurpleFactory.gainLossBuilder().gene("gene 2").minCopies(20.0).maxCopies(21.0).isCanonical(false)
+        val gain2NonCanonical = TestPurpleFactory.gainDelBuilder().gene("gene 2").minCopies(20.0).maxCopies(21.0).isCanonical(false)
             .interpretation(CopyNumberInterpretation.FULL_GAIN).build()
-        val gain3Canonical = TestPurpleFactory.gainLossBuilder().gene("gene 3").minCopies(20.0).maxCopies(20.0).isCanonical(true)
+        val gain3Canonical = TestPurpleFactory.gainDelBuilder().gene("gene 3").minCopies(20.0).maxCopies(20.0).isCanonical(true)
             .interpretation(CopyNumberInterpretation.FULL_GAIN).build()
-        val gain3NonCanonical = TestPurpleFactory.gainLossBuilder().gene("gene 3").minCopies(20.0).maxCopies(20.0).isCanonical(false)
+        val gain3NonCanonical = TestPurpleFactory.gainDelBuilder().gene("gene 3").minCopies(20.0).maxCopies(20.0).isCanonical(false)
             .interpretation(CopyNumberInterpretation.FULL_GAIN).build()
-        val gain4Canonical = TestPurpleFactory.gainLossBuilder().gene("gene 4").minCopies(19.6).maxCopies(20.4).isCanonical(true)
+        val gain4Canonical = TestPurpleFactory.gainDelBuilder().gene("gene 4").minCopies(19.6).maxCopies(20.4).isCanonical(true)
             .interpretation(CopyNumberInterpretation.FULL_GAIN).build()
 
         val geneCopyNumber1 =
@@ -60,7 +60,7 @@ class CopyNumberExtractorTest {
         val purple = ImmutablePurpleRecord.builder()
             .from(TestOrangeFactory.createMinimalTestOrangeRecord().purple())
             .addSomaticDrivers(driverGene3Canonical, driverGene3NonCanonical, driverGene2NonCanonical, driverGene4Canonical)
-            .addAllSomaticGainsLosses(
+            .addAllSomaticGainsDels(
                 loss1Canonical,
                 loss1NonCanonical,
                 gain2NonCanonical,
@@ -141,13 +141,13 @@ class CopyNumberExtractorTest {
     @Test(expected = IllegalStateException::class)
     fun `Should throw exception when filtering reported copy number`() {
         val driver = TestPurpleFactory.driverBuilder().gene("gene 1").type(PurpleDriverType.DEL).isCanonical(true).build()
-        val gainLoss = TestPurpleFactory.gainLossBuilder().gene("gene 1").interpretation(CopyNumberInterpretation.PARTIAL_LOSS).build()
+        val gainDel = TestPurpleFactory.gainDelBuilder().gene("gene 1").interpretation(CopyNumberInterpretation.PARTIAL_DEL).build()
         val geneCopyNumber = TestPurpleFactory.geneCopyNumberBuilder().gene("gene 1").build()
 
         val purple = ImmutablePurpleRecord.builder()
             .from(TestOrangeFactory.createMinimalTestOrangeRecord().purple())
             .addSomaticDrivers(driver)
-            .addAllSomaticGainsLosses(gainLoss)
+            .addAllSomaticGainsDels(gainDel)
             .addAllSomaticGeneCopyNumbers(geneCopyNumber)
             .build()
 

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/DriverEventFactoryTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/DriverEventFactoryTest.kt
@@ -5,7 +5,7 @@ import com.hartwig.actin.molecular.orange.datamodel.purple.TestPurpleFactory
 import com.hartwig.actin.molecular.orange.datamodel.virus.TestVirusInterpreterFactory
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect
-import com.hartwig.hmftools.datamodel.purple.PurpleGainLoss
+import com.hartwig.hmftools.datamodel.purple.PurpleGainDeletion
 import com.hartwig.hmftools.datamodel.purple.PurpleVariant
 import com.hartwig.hmftools.datamodel.purple.PurpleVariantEffect
 import com.hartwig.hmftools.datamodel.virus.VirusInterpretation
@@ -48,10 +48,10 @@ class DriverEventFactoryTest {
 
     @Test
     fun `Should generate events for copy numbers`() {
-        assertThat(DriverEventFactory.gainLossEvent(gainLoss("MYC", CopyNumberInterpretation.FULL_GAIN))).isEqualTo("MYC amp")
-        assertThat(DriverEventFactory.gainLossEvent(gainLoss("MYC", CopyNumberInterpretation.PARTIAL_GAIN))).isEqualTo("MYC amp")
-        assertThat(DriverEventFactory.gainLossEvent(gainLoss("PTEN", CopyNumberInterpretation.FULL_LOSS))).isEqualTo("PTEN del")
-        assertThat(DriverEventFactory.gainLossEvent(gainLoss("PTEN", CopyNumberInterpretation.PARTIAL_LOSS))).isEqualTo("PTEN del")
+        assertThat(DriverEventFactory.gainDelEvent(gainDel("MYC", CopyNumberInterpretation.FULL_GAIN))).isEqualTo("MYC amp")
+        assertThat(DriverEventFactory.gainDelEvent(gainDel("MYC", CopyNumberInterpretation.PARTIAL_GAIN))).isEqualTo("MYC amp")
+        assertThat(DriverEventFactory.gainDelEvent(gainDel("PTEN", CopyNumberInterpretation.FULL_DEL))).isEqualTo("PTEN del")
+        assertThat(DriverEventFactory.gainDelEvent(gainDel("PTEN", CopyNumberInterpretation.PARTIAL_DEL))).isEqualTo("PTEN del")
     }
 
     @Test
@@ -101,8 +101,8 @@ class DriverEventFactoryTest {
             .build()
     }
 
-    private fun gainLoss(gene: String, interpretation: CopyNumberInterpretation): PurpleGainLoss {
-        return TestPurpleFactory.gainLossBuilder().gene(gene).interpretation(interpretation).build()
+    private fun gainDel(gene: String, interpretation: CopyNumberInterpretation): PurpleGainDeletion {
+        return TestPurpleFactory.gainDelBuilder().gene(gene).interpretation(interpretation).build()
     }
 
     private fun virus(name: String, interpretation: VirusInterpretation?): VirusInterpreterEntry {

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/datamodel/TestOrangeFactory.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/datamodel/TestOrangeFactory.kt
@@ -11,6 +11,7 @@ import com.hartwig.hmftools.datamodel.chord.ChordRecord
 import com.hartwig.hmftools.datamodel.chord.ChordStatus
 import com.hartwig.hmftools.datamodel.chord.ImmutableChordRecord
 import com.hartwig.hmftools.datamodel.cuppa.CuppaData
+import com.hartwig.hmftools.datamodel.cuppa.CuppaMode
 import com.hartwig.hmftools.datamodel.cuppa.ImmutableCuppaData
 import com.hartwig.hmftools.datamodel.flagstat.ImmutableFlagstat
 import com.hartwig.hmftools.datamodel.hla.ImmutableLilacRecord
@@ -75,7 +76,9 @@ object TestOrangeFactory {
             .fit(TestPurpleFactory.fitBuilder()
                 .qc(TestPurpleFactory.purpleQCBuilder().status(setOf<PurpleQCStatus?>(PurpleQCStatus.FAIL_NO_TUMOR)).build())
                 .build())
+            .tumorStats(TestPurpleFactory.tumorStatsBuilder().build())
             .characteristics(TestPurpleFactory.characteristicsBuilder().build())
+            .chromosomalRearrangements(TestPurpleFactory.chromosomalRearrangementsBuilder().build())
             .build()
     }
 
@@ -139,15 +142,15 @@ object TestOrangeFactory {
                     .reported(true)
                     .build())
                 .build())
-            .addAllSomaticGainsLosses(TestPurpleFactory.gainLossBuilder()
+            .addAllSomaticGainsDels(TestPurpleFactory.gainDelBuilder()
                 .gene("MYC")
                 .interpretation(CopyNumberInterpretation.FULL_GAIN)
                 .minCopies(38.0)
                 .maxCopies(40.0)
                 .build())
-            .addAllSomaticGainsLosses(TestPurpleFactory.gainLossBuilder()
+            .addAllSomaticGainsDels(TestPurpleFactory.gainDelBuilder()
                 .gene("PTEN")
-                .interpretation(CopyNumberInterpretation.FULL_LOSS)
+                .interpretation(CopyNumberInterpretation.FULL_DEL)
                 .minCopies(0.0)
                 .maxCopies(0.0)
                 .build())
@@ -249,6 +252,7 @@ object TestOrangeFactory {
             .build()
 
         return ImmutableCuppaData.builder()
+            .mode(CuppaMode.WGS)
             .addPredictions(cuppaPrediction)
             .bestPrediction(cuppaPrediction)
             .simpleDups32To200B(0)

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/datamodel/purple/TestPurpleFactory.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/orange/datamodel/purple/TestPurpleFactory.kt
@@ -2,15 +2,17 @@ package com.hartwig.actin.molecular.orange.datamodel.purple
 
 import com.hartwig.hmftools.datamodel.purple.CopyNumberInterpretation
 import com.hartwig.hmftools.datamodel.purple.HotspotType
+import com.hartwig.hmftools.datamodel.purple.ImmutableChromosomalRearrangements
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleAllelicDepth
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleCharacteristics
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleDriver
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleFit
-import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleGainLoss
+import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleGainDeletion
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleGeneCopyNumber
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleQC
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleTranscriptImpact
 import com.hartwig.hmftools.datamodel.purple.ImmutablePurpleVariant
+import com.hartwig.hmftools.datamodel.purple.ImmutableTumorStats
 import com.hartwig.hmftools.datamodel.purple.PurpleCodingEffect
 import com.hartwig.hmftools.datamodel.purple.PurpleDriverType
 import com.hartwig.hmftools.datamodel.purple.PurpleFittedPurityMethod
@@ -34,6 +36,16 @@ object TestPurpleFactory {
             .qc(purpleQCBuilder().build())
     }
 
+    fun tumorStatsBuilder(): ImmutableTumorStats.Builder {
+        return ImmutableTumorStats.builder()
+            .maxDiploidProportion(0.0)
+            .hotspotMutationCount(0)
+            .hotspotStructuralVariantCount(0)
+            .smallVariantAlleleReadCount(0)
+            .structuralVariantTumorFragmentCount(0)
+            .bafCount(0)
+    }
+
     fun characteristicsBuilder(): ImmutablePurpleCharacteristics.Builder {
         return ImmutablePurpleCharacteristics.builder()
             .microsatelliteIndelsPerMb(0.0)
@@ -44,6 +56,12 @@ object TestPurpleFactory {
             .tumorMutationalLoadStatus(PurpleTumorMutationalStatus.UNKNOWN)
             .wholeGenomeDuplication(false)
             .svTumorMutationalBurden(0)
+    }
+
+    fun chromosomalRearrangementsBuilder(): ImmutableChromosomalRearrangements.Builder {
+        return ImmutableChromosomalRearrangements.builder()
+            .hasTrisomy1q(false)
+            .hasCodeletion1p19q(false)
     }
 
     fun driverBuilder(): ImmutablePurpleDriver.Builder {
@@ -88,10 +106,10 @@ object TestPurpleFactory {
             .reported(false)
     }
 
-    fun gainLossBuilder(): ImmutablePurpleGainLoss.Builder {
-        return ImmutablePurpleGainLoss.builder()
+    fun gainDelBuilder(): ImmutablePurpleGainDeletion.Builder {
+        return ImmutablePurpleGainDeletion.builder()
             .gene("")
-            .interpretation(CopyNumberInterpretation.FULL_LOSS)
+            .interpretation(CopyNumberInterpretation.FULL_DEL)
             .minCopies(0.0)
             .maxCopies(0.0)
             .chromosome("")
@@ -105,6 +123,8 @@ object TestPurpleFactory {
             .gene("")
             .chromosome("")
             .chromosomeBand("")
+            .transcript("")
+            .isCanonical(false)
             .minCopyNumber(0.0)
             .maxCopyNumber(0.0)
             .minMinorAlleleCopyNumber(0.0)
@@ -113,8 +133,10 @@ object TestPurpleFactory {
     fun purpleQCBuilder(): ImmutablePurpleQC.Builder {
         return ImmutablePurpleQC.builder()
             .status(emptySet())
+            .addAllGermlineAberrations(emptySet())
             .amberMeanDepth(0)
             .contamination(0.0)
+            .totalCopyNumberSegments(0)
             .unsupportedCopyNumberSegments(0)
             .deletedGenes(0)
     }

--- a/molecular/src/test/resources/serialization/real.v3.5.0.orange.json
+++ b/molecular/src/test/resources/serialization/real.v3.5.0.orange.json
@@ -656,9 +656,9 @@
       }
     ],
     "suspectGeneCopyNumbersWithLOH": [],
-    "allSomaticGainsLosses": [
+    "allSomaticGainsDels": [
       {
-        "interpretation": "FULL_LOSS",
+        "interpretation": "FULL_DEL",
         "gene": "DLGAP5P1",
         "chromosome": "Y",
         "chromosomeBand": "p11.2",
@@ -670,7 +670,7 @@
     ],
     "reportableSomaticGainsLosses": [
       {
-        "interpretation": "PARTIAL_LOSS",
+        "interpretation": "PARTIAL_DEL",
         "gene": "PTEN",
         "chromosome": "10",
         "chromosomeBand": "q23.31",
@@ -715,7 +715,7 @@
     ],
     "allGermlineFullLosses": [
       {
-        "interpretation": "PARTIAL_LOSS",
+        "interpretation": "PARTIAL_DEL",
         "gene": "BTNL3",
         "chromosome": "5",
         "chromosomeBand": "q35.3",

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
         <serve.version>8.2.0</serve.version>
         <actin-personalization.version>0.26.0</actin-personalization.version>
-        <orange-datamodel.version>2.6.0</orange-datamodel.version>
+        <orange-datamodel.version>3.0.0</orange-datamodel.version>
         <actin-transvar.version>0.6.0</actin-transvar.version>
         <actin-pave-lite.version>0.6.0</actin-pave-lite.version>
         <pave.version>1.6</pave.version>


### PR DESCRIPTION
I have updated the POM to use 3.0.0, the Orange and Purple TestFactory for the new data model, and the JSON. Some of the references to loss have been replaced with del or deletion but there is still a lot more references to change. 