### PR TITLE
ACTIN-1925: bump version of jars from actin-tools

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
         <serve.version>8.2.0</serve.version>
         <actin-personalization.version>0.26.0</actin-personalization.version>
         <orange-datamodel.version>3.0.0</orange-datamodel.version>
-        <actin-transvar.version>0.6.0</actin-transvar.version>
-        <actin-pave-lite.version>0.6.0</actin-pave-lite.version>
+        <actin-transvar.version>1.0.0</actin-transvar.version>
+        <actin-pave-lite.version>1.0.0</actin-pave-lite.version>
         <pave.version>1.6</pave.version>
 
         <!-- KD: Even though all code is in kotlin, the jooq code generator generates java code that needs to be compiled -->


### PR DESCRIPTION
to version 1.0.0 which is built with jdk 17