### PR TITLE
ACTIN-1924: Split MedicationCategory "Gonadorelin" into "Gonadotropin agonists" and "Gonadotropin antagonists"

### DIFF
--- a/algo/README.md
+++ b/algo/README.md
@@ -630,7 +630,8 @@ Bisphosphonates ("M05BA" or "M05BB") <br>
 Bone resorptive ("M05B" or "H05") <br>
 Colony stimulating factors ("L03AA") <br>
 Coumarin derivative ("B01AA") <br>
-Gonadorelin ("H01CC", "H01CA", "G03XA" or "L02AE") <br>
+Gonadotropin agonists ("H01CA" or "L02AE") <br>
+Gonadotropin antagonists ("H01CC" or "G03XA") <br>
 Immunostimulants ("L03") <br>
 Immunosuppressants ("L04") <br>
 Nitrosoureas ("L01AD") <br>
@@ -673,7 +674,7 @@ from "Gonadorelin" using the table below in 5]
 5] Cancer therapy list (with corresponding ATC level codes between brackets): <br>
 Chemotherapy ("L01XA", "L01BC", "L01CD" or "L01A") <br>
 Endocrine therapy ("L02") <br>
-Gonadorelin ("H01CC", "H01CA", "G03XA" or "L02AE") <br>
+Gonadotropin agonists + Gonadotropin antagonists ("H01CC", "H01CA", "G03XA" or "L02AE") <br>
 Hypomethylating agents ("L01BC07" (Azacitidine) or "L01BC08" (Decitabine)) <br>
 Immunotherapy ("L01FF" or "L01FX04" (Ipilimumab)) <br>
 Monoclonal antibodies and antibody drug conjugates ("L01F") <br>

--- a/algo/README.md
+++ b/algo/README.md
@@ -668,7 +668,7 @@ Systemic corticosteroids ("H02" or "M01BA") <br>
 *Where <atcLevel> is a level defined above in 3] and <category> is X OR a member of the set of ATC codes derived from X using the table
 below in 5]
 **Where <atcLevel> is a level defined above in 3] and <category> is equal to "L01", "L02", "L04" OR a member of the set of ATC codes derived
-from "Gonadorelin" using the table below in 5]
+from "Gonadotropin agonists" or "Gonadotropin antagonists" using the table below in 5]
 ***Categories are mapped to corresponding Treatment 'Categories' and 'Types'
 
 5] Cancer therapy list (with corresponding ATC level codes between brackets): <br>

--- a/common/src/main/kotlin/com/hartwig/actin/medication/MedicationCategories.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/medication/MedicationCategories.kt
@@ -35,7 +35,8 @@ class MedicationCategories(private val knownCategories: Map<String, Set<AtcLevel
         )
 
         val MEDICATION_CATEGORIES_TO_DRUG_TYPES = mapOf(
-            "Gonadorelin" to setOf(DrugType.GONADOTROPIN_AGONIST, DrugType.GONADOTROPIN_ANTAGONIST),
+            "Gonadotropin agonists" to setOf(DrugType.GONADOTROPIN_AGONIST),
+            "Gonadotropin antagonists" to setOf(DrugType.GONADOTROPIN_ANTAGONIST),
             "Hypomethylating agents" to setOf(DrugType.DNMT_INHIBITOR),
             "Monoclonal antibodies and antibody drug conjugates" to setOf(
                 DrugType.MONOCLONAL_ANTIBODY_TARGETED_THERAPY,
@@ -70,7 +71,8 @@ class MedicationCategories(private val knownCategories: Map<String, Set<AtcLevel
                     "Colony stimulating factors" to convertToAtcLevel(setOf("L03AA"), atcTree),
                     "Coumarin derivative" to convertToAtcLevel(setOf("B01AA"), atcTree),
                     "Endocrine therapy" to convertToAtcLevel(setOf("L02"), atcTree),
-                    "Gonadorelin" to convertToAtcLevel(setOf("H01CC", "H01CA", "G03XA", "L02AE"), atcTree),
+                    "Gonadotropin agonists" to convertToAtcLevel(setOf("H01CA", "L02AE"), atcTree),
+                    "Gonadotropin antagonists" to convertToAtcLevel(setOf("H01CC", "G03XA"), atcTree),
                     "Hypomethylating agents" to convertToAtcLevel(setOf("L01BC07", "L01BC08"), atcTree),
                     "Immunostimulants" to convertToAtcLevel(setOf("L03"), atcTree),
                     "Immunosuppressants" to convertToAtcLevel(setOf("L04"), atcTree),


### PR DESCRIPTION
We somehow once named this category "Gonadorelin" but that is not a suitable name for it (gonadorelin is an example of an "gonadotropin agonist"). Splitting it is cleaner.

(Encountered this while curating a trial)