### PR TITLE
ACTIN-1936: Reuse location display logic from trial tables in molecular details table

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
@@ -7,7 +7,9 @@ import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortsSummarizer
 import com.hartwig.actin.report.interpretation.MolecularDriverEntryFactory
 import com.hartwig.actin.report.interpretation.MolecularDriversInterpreter
+import com.hartwig.actin.report.interpretation.TrialAcronymAndLocations
 import com.hartwig.actin.report.pdf.tables.TableGenerator
+import com.hartwig.actin.report.pdf.tables.trial.TrialLocations
 import com.hartwig.actin.report.pdf.util.Cells
 import com.hartwig.actin.report.pdf.util.Formats
 import com.hartwig.actin.report.pdf.util.Tables
@@ -46,10 +48,7 @@ class MolecularDriversGenerator(
             table.addCell(Cells.createContent(entry.driverType))
             table.addCell(Cells.createContent(entry.display()))
             table.addCell(Cells.createContent(formatDriverLikelihood(entry.driverLikelihood)))
-            table.addCell(
-                Cells.createContent(entry.actinTrials.joinToString(", ")
-                { "${it.trialAcronym} ${if (it.locations.isNotEmpty()) "(${it.locations.joinToString()})" else ""}" })
-            )
+            table.addCell(Cells.createContent(formatActinTrials(entry.actinTrials)))
             table.addCell(Cells.createContent(externalTrialsPerSingleEvent[entry.event]?.let { concatEligibleTrials(it) } ?: ""))
             table.addCell(Cells.createContent(entry.bestResponsiveEvidence ?: ""))
             table.addCell(Cells.createContent(entry.bestResistanceEvidence ?: ""))
@@ -63,6 +62,22 @@ class MolecularDriversGenerator(
 
     private fun formatDriverLikelihood(driverLikelihood: DriverLikelihood?): String {
         return driverLikelihood?.let(DriverLikelihood::toString) ?: Formats.VALUE_UNKNOWN
+    }
+
+    private fun formatActinTrials(actinTrials: Set<TrialAcronymAndLocations>): String {
+        return actinTrials.joinToString(", ")
+        {
+            "${it.trialAcronym} ${
+                if (it.locations.isNotEmpty()) "(${
+                    TrialLocations.actinTrialLocation(
+                        null,
+                        null,
+                        it.locations,
+                        false
+                    )
+                }" else ""
+            }"
+        }
     }
 
     private fun concatEligibleTrials(externalTrials: Iterable<ExternalTrialSummary>): String {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
@@ -75,7 +75,7 @@ class MolecularDriversGenerator(
                         it.locations,
                         false
                     )
-                }" else ""
+                })" else ""
             }"
         }
     }

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularDriversGenerator.kt
@@ -5,7 +5,6 @@ import com.hartwig.actin.datamodel.molecular.driver.DriverLikelihood
 import com.hartwig.actin.report.interpretation.ClonalityInterpreter
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortsSummarizer
-import com.hartwig.actin.report.interpretation.MolecularDriverEntry
 import com.hartwig.actin.report.interpretation.MolecularDriverEntryFactory
 import com.hartwig.actin.report.interpretation.MolecularDriversInterpreter
 import com.hartwig.actin.report.pdf.tables.TableGenerator
@@ -43,7 +42,7 @@ class MolecularDriversGenerator(
         val molecularDriversInterpreter = MolecularDriversInterpreter(molecular.drivers, InterpretedCohortsSummarizer.fromCohorts(cohorts))
         val externalTrialsPerSingleEvent = DriverTableFunctions.groupByEvent(externalTrials)
         val factory = MolecularDriverEntryFactory(molecularDriversInterpreter)
-        factory.create().forEach { entry: MolecularDriverEntry ->
+        factory.create().forEach { entry ->
             table.addCell(Cells.createContent(entry.driverType))
             table.addCell(Cells.createContent(entry.display()))
             table.addCell(Cells.createContent(formatDriverLikelihood(entry.driverLikelihood)))

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctions.kt
@@ -7,7 +7,7 @@ import com.hartwig.actin.report.trial.ExternalTrialSummary
 object ExternalTrialFunctions {
 
     private val format: (Collection<String>) -> String = { items ->
-        if (items.size > MAX_TO_DISPLAY) MANY_SEE_LINK else items.joinToString()
+        if (items.size > MAX_TO_DISPLAY) MANY_LOCATIONS else items.joinToString()
     }
 
     private fun formatHospitalsAndCities(hospitalsPerCity: Map<String, Set<Hospital>>): Pair<String, String> {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctions.kt
@@ -7,7 +7,7 @@ import com.hartwig.actin.report.trial.ExternalTrialSummary
 object ExternalTrialFunctions {
 
     private val format: (Collection<String>) -> String = { items ->
-        if (items.size > MAX_TO_DISPLAY) MANY_LOCATIONS else items.joinToString()
+        if (items.size > MAX_TO_DISPLAY) MANY_LOCATIONS_SEE_LINK else items.joinToString()
     }
 
     private fun formatHospitalsAndCities(hospitalsPerCity: Map<String, Set<Hospital>>): Pair<String, String> {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialGeneratorFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialGeneratorFunctions.kt
@@ -21,9 +21,6 @@ import com.itextpdf.layout.element.Paragraph
 import com.itextpdf.layout.element.Table
 import com.itextpdf.layout.element.Text
 
-const val MAX_TO_DISPLAY = 3
-const val MANY_SEE_LINK = "3+ locations - see link"
-
 data class ContentDefinition(val textEntries: List<String>, val deEmphasizeContent: Boolean)
 
 object TrialGeneratorFunctions {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialGeneratorFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialGeneratorFunctions.kt
@@ -5,9 +5,6 @@ import com.hartwig.actin.datamodel.trial.TrialPhase
 import com.hartwig.actin.datamodel.trial.TrialSource
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortComparator
-import com.hartwig.actin.report.interpretation.InterpretedCohortFunctions
-import com.hartwig.actin.report.pdf.tables.trial.ExternalTrialFunctions.countryNamesWithCities
-import com.hartwig.actin.report.pdf.tables.trial.ExternalTrialFunctions.hospitalsAndCitiesInCountry
 import com.hartwig.actin.report.pdf.util.Cells
 import com.hartwig.actin.report.pdf.util.Formats
 import com.hartwig.actin.report.pdf.util.Styles
@@ -47,18 +44,11 @@ object TrialGeneratorFunctions {
             table.addCell(contentFunction(trial.actinMolecularEvents.joinToString(", ")))
 
             val country = if (trial.countries.none { it.country == countryOfReference }) null else countryOfReference
-            table.addCell(contentFunction(externalTrialLocation(trial, country)))
+            table.addCell(contentFunction(TrialLocations.externalTrialLocation(trial, country)))
             if (includeFeedback) {
                 table.addCell(contentFunction(""))
             }
         }
-    }
-
-    private fun externalTrialLocation(trial: ExternalTrialSummary, countryOfReference: Country?): String {
-        return countryOfReference?.let {
-            val (hospitals, cities) = hospitalsAndCitiesInCountry(trial, it)
-            if (countryOfReference == Country.NETHERLANDS && hospitals != MANY_SEE_LINK) hospitals else cities
-        } ?: countryNamesWithCities(trial)
     }
 
     private fun sortedCohortsGroupedByTrial(
@@ -168,7 +158,7 @@ object TrialGeneratorFunctions {
                     listOfNotNull(
                         "${Formats.ITALIC_TEXT_MARKER}Applies to all cohorts below${Formats.ITALIC_TEXT_MARKER}",
                         concat(commonEvents, allEventsEmpty && includeFeedback),
-                        concatLocations(cohortsForTrial.first().source, requestingSource, commonLocations),
+                        TrialLocations.actinTrialLocation(cohortsForTrial.first().source, requestingSource, commonLocations, true),
                         concat(commonFeedback).takeIf { includeFeedback }
                     ),
                     deEmphasizeContent
@@ -181,30 +171,14 @@ object TrialGeneratorFunctions {
                 listOfNotNull(
                     cohort.name ?: "",
                     concat(cohort.molecularEvents - commonEvents, commonEvents.isEmpty() && (!allEventsEmpty || hidePrefix)),
-                    concatLocations(cohort.source, requestingSource, cohort.locations - commonLocations),
+                    TrialLocations.actinTrialLocation(cohort.source, requestingSource, cohort.locations - commonLocations, true),
                     if (includeFeedback) concat(feedbackFunction(cohort) - commonFeedback, commonFeedback.isEmpty()) else null
                 ),
                 !cohort.isOpen || !cohort.hasSlotsAvailable
             )
         }
     }
-
-    private fun concatLocations(source: TrialSource?, requestingSource: TrialSource?, locations: Set<String>): String {
-        val showRequestingSite = requestingSource != null &&
-                InterpretedCohortFunctions.sourceOrLocationMatchesRequestingSource(source, locations, requestingSource)
-
-        return when {
-            showRequestingSite && locations.size > MAX_TO_DISPLAY - 1 -> {
-                val otherLocationCount = locations.size - 1
-                "${requestingSource?.description} and $otherLocationCount other locations - see link"
-            }
-
-            locations.size > MAX_TO_DISPLAY -> MANY_SEE_LINK
-
-            else -> concat(locations, false)
-        }
-    }
-
+    
     private fun findCommonMembersInCohorts(
         cohorts: List<InterpretedCohort>, retrieveMemberFunction: (InterpretedCohort) -> Set<String>
     ): Set<String> {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
@@ -8,7 +8,7 @@ import com.hartwig.actin.report.trial.ExternalTrialSummary
 
 const val MAX_TO_DISPLAY = 3
 private const val MANY_LOCATIONS = "$MAX_TO_DISPLAY+ locations"
-private const val SEE_LINK = " - see link"
+private const val SEE_LINK = " (see link)"
 const val MANY_LOCATIONS_SEE_LINK = "$MANY_LOCATIONS$SEE_LINK"
 
 object TrialLocations {

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
@@ -1,27 +1,37 @@
 package com.hartwig.actin.report.pdf.tables.trial
 
+import com.hartwig.actin.datamodel.molecular.evidence.Country
 import com.hartwig.actin.datamodel.trial.TrialSource
 import com.hartwig.actin.report.interpretation.InterpretedCohortFunctions
 import com.hartwig.actin.report.pdf.util.Formats
+import com.hartwig.actin.report.trial.ExternalTrialSummary
 
 const val MAX_TO_DISPLAY = 3
-const val MANY_SEE_LINK = "3+ locations - see link"
+const val MANY_LOCATIONS = "$MAX_TO_DISPLAY+ locations"
+const val SEE_LINK = " - see link"
 
 object TrialLocations {
 
-    fun concat(source: TrialSource?, requestingSource: TrialSource?, locations: Set<String>): String {
+    fun actinTrialLocation(trialSource: TrialSource?, requestingSource: TrialSource?, locations: Set<String>, showLinks: Boolean): String {
         val showRequestingSite = requestingSource != null &&
-                InterpretedCohortFunctions.sourceOrLocationMatchesRequestingSource(source, locations, requestingSource)
+                InterpretedCohortFunctions.sourceOrLocationMatchesRequestingSource(trialSource, locations, requestingSource)
 
         return when {
             showRequestingSite && locations.size > MAX_TO_DISPLAY - 1 -> {
                 val otherLocationCount = locations.size - 1
-                "${requestingSource?.description} and $otherLocationCount other locations - see link"
+                "${requestingSource?.description} and $otherLocationCount other locations${if (showLinks) SEE_LINK else ""}"
             }
 
-            locations.size > MAX_TO_DISPLAY -> MANY_SEE_LINK
+            locations.size > MAX_TO_DISPLAY -> "$MANY_LOCATIONS${ if (showLinks) SEE_LINK else "" }"
 
             else -> locations.sorted().joinToString(Formats.COMMA_SEPARATOR)
         }
+    }
+
+    fun externalTrialLocation(trial: ExternalTrialSummary, countryOfReference: Country?): String {
+        return countryOfReference?.let {
+            val (hospitals, cities) = ExternalTrialFunctions.hospitalsAndCitiesInCountry(trial, it)
+            if (countryOfReference == Country.NETHERLANDS && hospitals != MANY_LOCATIONS) hospitals else cities
+        } ?: ExternalTrialFunctions.countryNamesWithCities(trial)
     }
 }

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
@@ -1,0 +1,27 @@
+package com.hartwig.actin.report.pdf.tables.trial
+
+import com.hartwig.actin.datamodel.trial.TrialSource
+import com.hartwig.actin.report.interpretation.InterpretedCohortFunctions
+import com.hartwig.actin.report.pdf.util.Formats
+
+const val MAX_TO_DISPLAY = 3
+const val MANY_SEE_LINK = "3+ locations - see link"
+
+object TrialLocations {
+
+    fun concat(source: TrialSource?, requestingSource: TrialSource?, locations: Set<String>): String {
+        val showRequestingSite = requestingSource != null &&
+                InterpretedCohortFunctions.sourceOrLocationMatchesRequestingSource(source, locations, requestingSource)
+
+        return when {
+            showRequestingSite && locations.size > MAX_TO_DISPLAY - 1 -> {
+                val otherLocationCount = locations.size - 1
+                "${requestingSource?.description} and $otherLocationCount other locations - see link"
+            }
+
+            locations.size > MAX_TO_DISPLAY -> MANY_SEE_LINK
+
+            else -> locations.sorted().joinToString(Formats.COMMA_SEPARATOR)
+        }
+    }
+}

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocations.kt
@@ -7,8 +7,9 @@ import com.hartwig.actin.report.pdf.util.Formats
 import com.hartwig.actin.report.trial.ExternalTrialSummary
 
 const val MAX_TO_DISPLAY = 3
-const val MANY_LOCATIONS = "$MAX_TO_DISPLAY+ locations"
-const val SEE_LINK = " - see link"
+private const val MANY_LOCATIONS = "$MAX_TO_DISPLAY+ locations"
+private const val SEE_LINK = " - see link"
+const val MANY_LOCATIONS_SEE_LINK = "$MANY_LOCATIONS$SEE_LINK"
 
 object TrialLocations {
 

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctionsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialFunctionsTest.kt
@@ -79,12 +79,12 @@ class ExternalTrialFunctionsTest {
             externalTrialBelgium,
             Country.BELGIUM
         )
-        assertThat(hospitalsAndCitiesExternalTrialNetherlands.first).isEqualTo("3+ locations - see link")
+        assertThat(hospitalsAndCitiesExternalTrialNetherlands.first).isEqualTo("3+ locations (see link)")
         assertThat(hospitalsAndCitiesExternalTrialNetherlands.second).isEqualTo("Nijmegen, Leiden, Amsterdam")
         assertThat(hospitalsAndCitiesExternalTrialNetherlandsGermany.first).isEqualTo("AMC, LUMC")
         assertThat(hospitalsAndCitiesExternalTrialNetherlandsGermany.second).isEqualTo("Amsterdam, Leiden")
         assertThat(hospitalsAndCitiesExternalTrialBelgium.first).isEqualTo("Brussels hospital")
-        assertThat(hospitalsAndCitiesExternalTrialBelgium.second).isEqualTo("3+ locations - see link")
+        assertThat(hospitalsAndCitiesExternalTrialBelgium.second).isEqualTo("3+ locations (see link)")
     }
 
     @Test(expected = IllegalStateException::class)
@@ -97,7 +97,7 @@ class ExternalTrialFunctionsTest {
         assertThat(ExternalTrialFunctions.countryNamesWithCities(externalTrialNetherlandsGermany))
             .isEqualTo("NL (Amsterdam, Leiden), Germany (Berlin)")
         assertThat(ExternalTrialFunctions.countryNamesWithCities(externalTrialBelgium))
-            .isEqualTo("Belgium (3+ locations - see link)")
+            .isEqualTo("Belgium (3+ locations (see link))")
         assertThat(ExternalTrialFunctions.countryNamesWithCities(externalTrialNetherlands))
             .isEqualTo("NL (Nijmegen, Leiden, Amsterdam)")
     }

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
@@ -1,0 +1,11 @@
+package com.hartwig.actin.report.pdf.tables.trial
+
+import org.junit.Test
+
+class TrialLocationsTest {
+    
+    @Test
+    fun `Should display all locations`() {
+        
+    } 
+} 

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class TrialLocationsTest {
 
     @Test
-    fun `Should display all locations when count is small`() {
+    fun `Should display all locations when there are few locations`() {
         assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2"), false)).isEqualTo("1, 2")
 
         assertThat(
@@ -21,10 +21,10 @@ class TrialLocationsTest {
     }
 
     @Test
-    fun `Should display many-warning when there are many trials and no requesting source`() {
+    fun `Should display many-warning when there are many locations and no requesting source`() {
         assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2", "3", "4"), false)).isEqualTo("3+ locations")
         
-        assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2", "3", "4"), true)).isEqualTo("3+ locations - see link")
+        assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2", "3", "4"), true)).isEqualTo("3+ locations (see link)")
     }
 
     @Test
@@ -45,7 +45,7 @@ class TrialLocationsTest {
                 setOf("Example", "2", "3", "4"),
                 true
             )
-        ).isEqualTo("Example and 3 other locations - see link")
+        ).isEqualTo("Example and 3 other locations (see link)")
 
         assertThat(
             TrialLocations.actinTrialLocation(
@@ -54,6 +54,6 @@ class TrialLocationsTest {
                 setOf("Example", "2", "3", "4"),
                 true
             )
-        ).isEqualTo("Example and 3 other locations - see link")
+        ).isEqualTo("Example and 3 other locations (see link)")
     }
 } 

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/TrialLocationsTest.kt
@@ -1,11 +1,59 @@
 package com.hartwig.actin.report.pdf.tables.trial
 
+import com.hartwig.actin.datamodel.trial.TrialSource
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class TrialLocationsTest {
-    
+
     @Test
-    fun `Should display all locations`() {
+    fun `Should display all locations when count is small`() {
+        assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2"), false)).isEqualTo("1, 2")
+
+        assertThat(
+            TrialLocations.actinTrialLocation(
+                null,
+                TrialSource.EXAMPLE,
+                setOf("Another", "Example"),
+                false
+            )
+        ).isEqualTo("Another, Example")
+    }
+
+    @Test
+    fun `Should display many-warning when there are many trials and no requesting source`() {
+        assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2", "3", "4"), false)).isEqualTo("3+ locations")
         
-    } 
+        assertThat(TrialLocations.actinTrialLocation(null, null, setOf("1", "2", "3", "4"), true)).isEqualTo("3+ locations - see link")
+    }
+
+    @Test
+    fun `Should hide other locations when many locations and requesting source is present`() {
+        assertThat(
+            TrialLocations.actinTrialLocation(
+                TrialSource.EXAMPLE,
+                TrialSource.EXAMPLE,
+                setOf("Example", "2", "3", "4"),
+                false
+            )
+        ).isEqualTo("Example and 3 other locations")
+
+        assertThat(
+            TrialLocations.actinTrialLocation(
+                TrialSource.EXAMPLE,
+                TrialSource.EXAMPLE,
+                setOf("Example", "2", "3", "4"),
+                true
+            )
+        ).isEqualTo("Example and 3 other locations - see link")
+
+        assertThat(
+            TrialLocations.actinTrialLocation(
+                null,
+                TrialSource.EXAMPLE,
+                setOf("Example", "2", "3", "4"),
+                true
+            )
+        ).isEqualTo("Example and 3 other locations - see link")
+    }
 } 


### PR DESCRIPTION
While fixing this issue I found a few more opportunities for simplifications (e.g. better reuse between external and actin trials) but have left out of scope for this change.

Have left "mention requesting hospital if present" out of scope for molecular details as that requires more work (the requesting hospital isn't propagated into the driver table generator)