### PR TITLE
ACTIN-1958 Adjust to change to pathology done in NKI feed

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractor.kt
@@ -11,13 +11,11 @@ class PathologyReportsExtractor : StandardDataExtractor<List<PathologyReport>> {
             ehrPatientRecord.tumorDetails.pathology.takeIf { !it.isNullOrEmpty() }?.map {
                 PathologyReport(
                     tissueId = it.tissueId,
-                    reportRequested = it.reportRequested,
-                    source = it.source,
                     lab = it.lab,
                     diagnosis = it.diagnosis,
                     tissueDate = it.tissueDate,
                     authorisationDate = it.authorisationDate,
-                    externalDate = it.externalDate,
+                    reportDate = it.reportDate,
                     report = it.rawPathologyReport
                 )
             } ?: emptyList(), CurationExtractionEvaluation()

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractorTest.kt
@@ -22,7 +22,7 @@ class PathologyReportsExtractorTest {
     fun `Should extract pathology reports from the tumor details pathology`() {
         val providedPathologyReport = ProvidedPathologyReport(
             reportRequested = false,
-            source = "internal",
+            lab = "NKI-AvL",
             diagnosis = "diagnosis",
             tissueDate = defaultDate,
             authorisationDate = defaultDate,
@@ -36,9 +36,8 @@ class PathologyReportsExtractorTest {
                     providedPathologyReport.copy(
                         tissueId = "tissueId",
                         reportRequested = true,
-                        source = "external",
                         lab = "lab",
-                        externalDate = defaultDate,
+                        reportDate = defaultDate,
                         rawPathologyReport = "raw pathology report"
                     )
                 )
@@ -46,8 +45,7 @@ class PathologyReportsExtractorTest {
         )
 
         val expected = PathologyReport(
-            reportRequested = false,
-            source = "internal",
+            lab = "NKI-AvL",
             diagnosis = "diagnosis",
             tissueDate = defaultDate,
             authorisationDate = defaultDate,
@@ -61,10 +59,8 @@ class PathologyReportsExtractorTest {
                 expected,
                 expected.copy(
                     tissueId = "tissueId",
-                    reportRequested = true,
-                    source = "external",
                     lab = "lab",
-                    externalDate = defaultDate,
+                    reportDate = defaultDate,
                     report = "raw pathology report"
                 )
             )

--- a/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
+++ b/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
@@ -248,7 +248,7 @@
       {
         "tissueId": "T-1000090",
         "reportRequested": false,
-        "source": "internal",
+        "lab": "NKI-AvL",
         "diagnosis": "diagnosis",
         "tissueDate": "2020-01-01T10:10:00",
         "authorisationDate": "2020-01-02T10:10:00",
@@ -257,11 +257,9 @@
       {
         "tissueId": "T-1000091",
         "reportRequested": false,
-        "source": "external",
         "lab": "ext lab",
         "diagnosis": "diagnosis",
-        "tissueDate": "2020-02-01T10:10:00",
-        "authorisationDate": "2020-02-02T10:10:00",
+        "reportDate": "2020-02-01T10:10:00",
         "rawPathologyReport": "Raw Pathology Report"
       }
     ]

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -306,8 +306,7 @@
   "pathologyReports": [
     {
       "tissueId": "T-1000090",
-      "reportRequested": false,
-      "source": "internal",
+      "lab": "NKI-AvL",
       "diagnosis": "diagnosis",
       "tissueDate": "2020-01-01",
       "authorisationDate": "2020-01-02",
@@ -315,12 +314,9 @@
     },
     {
       "tissueId": "T-1000091",
-      "reportRequested": false,
-      "source": "external",
       "lab": "ext lab",
       "diagnosis": "diagnosis",
-      "tissueDate": "2020-02-01",
-      "authorisationDate": "2020-02-02",
+      "reportDate": "2020-02-01",
       "report": "Raw Pathology Report"
     }
   ]

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PathologyReport.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PathologyReport.kt
@@ -2,19 +2,12 @@ package com.hartwig.actin.datamodel.clinical
 
 import java.time.LocalDate
 
-private const val INTERNAL_SOURCE = "internal"
-
 data class PathologyReport(
     val tissueId: String? = null,
-    val reportRequested: Boolean,
-    val source: String,
-    val lab: String? = null,
+    val lab: String,
     val diagnosis: String,
-    val externalDate: LocalDate? = null,
     val tissueDate: LocalDate? = null,
     val authorisationDate: LocalDate? = null,
+    val reportDate: LocalDate? = null,
     val report: String
-) {
-    val isSourceInternal: Boolean
-        get() = source.equals(INTERNAL_SOURCE, ignoreCase = true)
-}
+)

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/provided/ProvidedClinicalDatamodel.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/provided/ProvidedClinicalDatamodel.kt
@@ -83,18 +83,16 @@ data class ProvidedPathologyReport(
     val tissueId: String? = null,
     @Description("Indication on whether the report was requested")
     val reportRequested: Boolean,
-    @Description("Source of the report (internal or external)")
-    val source: String,
-    @Description("Lab that performed the report (for external sources only)")
-    val lab: String? = null,
+    @Description("Lab that performed the report")
+    val lab: String,
     @Description("Diagnosis written in the pathology reports")
     val diagnosis: String,
-    @Description("Date of the external report (not clear what this data represents) - present only when the source is external")
-    val externalDate: LocalDate? = null,
     @Description("Date of tissue collection - present only when the source is internal")
     val tissueDate: LocalDate? = null,
     @Description("Latest date of report authorization - present only when the source is internal")
     val authorisationDate: LocalDate? = null,
+    @Description("Date of the report (not clear what this data represents) - used when tissueDate and authorisationDate and not known")
+    val reportDate: LocalDate? = null,
     @Description("Raw pathology report of molecular test results")
     val rawPathologyReport: String
 )

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestClinicalFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestClinicalFactory.kt
@@ -508,9 +508,7 @@ object TestClinicalFactory {
         return listOf(
             PathologyReport(
                 tissueId = "T-10100",
-                reportRequested = true,
-                source = "internal",
-                lab = "lab",
+                lab = "NKI-AvL",
                 diagnosis = "long*onderkwab*rechts*biopt*niet-kleincellig carcinoom",
                 tissueDate = FIXED_DATE,
                 authorisationDate = FIXED_DATE,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
@@ -16,8 +16,8 @@ import com.hartwig.actin.report.pdf.chapters.PersonalizedEvidenceChapter
 import com.hartwig.actin.report.pdf.chapters.ReportChapter
 import com.hartwig.actin.report.pdf.chapters.ResistanceEvidenceChapter
 import com.hartwig.actin.report.pdf.chapters.SummaryChapter
-import com.hartwig.actin.report.pdf.chapters.TrialMatchingOtherResultsChapter
 import com.hartwig.actin.report.pdf.chapters.TrialMatchingDetailsChapter
+import com.hartwig.actin.report.pdf.chapters.TrialMatchingOtherResultsChapter
 import com.hartwig.actin.report.pdf.tables.TableGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.BloodTransfusionGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.MedicationGenerator
@@ -120,7 +120,7 @@ class ReportContentProvider(private val report: Report, private val enableExtend
         return listOfNotNull(
             clinicalHistoryGenerator,
             MolecularSummaryGenerator(
-                report = report,
+                patientRecord = report.patientRecord,
                 cohorts = cohorts,
                 keyWidth = keyWidth,
                 valueWidth = valueWidth,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
@@ -103,14 +103,7 @@ class MolecularDetailsChapter(
     ) {
 
         pathologyReport?.let {
-            topTable.addCell(
-                Cells.create(
-                    PathologyReportFunctions.getPathologyReportSummary(
-                        pathologyReport = it,
-                        requestingHospital = report.requestingHospital
-                    )
-                )
-            )
+            topTable.addCell(Cells.create(PathologyReportFunctions.getPathologyReportSummary(pathologyReport = it)))
         }
 
         val tableWidth = topTable.width.value - 2 * Formats.STANDARD_INNER_TABLE_WIDTH_DECREASE

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/MolecularSummaryGenerator.kt
@@ -1,13 +1,13 @@
 package com.hartwig.actin.report.pdf.tables.molecular
 
 import com.hartwig.actin.algo.evaluation.molecular.IhcTestFilter
+import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.clinical.IhcTest
 import com.hartwig.actin.datamodel.clinical.PathologyReport
 import com.hartwig.actin.datamodel.molecular.ExperimentType
 import com.hartwig.actin.datamodel.molecular.MolecularRecord
 import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.molecular.filter.MolecularTestFilter
-import com.hartwig.actin.report.datamodel.Report
 import com.hartwig.actin.report.interpretation.IhcTestInterpreter
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.pdf.tables.TableGenerator
@@ -17,7 +17,7 @@ import com.itextpdf.layout.element.Table
 import org.apache.logging.log4j.LogManager
 
 class MolecularSummaryGenerator(
-    private val report: Report,
+    private val patientRecord: PatientRecord,
     private val cohorts: List<InterpretedCohort>,
     private val keyWidth: Float,
     private val valueWidth: Float,
@@ -26,7 +26,6 @@ class MolecularSummaryGenerator(
 ) : TableGenerator {
 
     private val logger = LogManager.getLogger(MolecularSummaryGenerator::class.java)
-    private val patientRecord = report.patientRecord
 
     override fun title(): String {
         return "Recent molecular results"
@@ -51,14 +50,7 @@ class MolecularSummaryGenerator(
         for ((pathologyReport, tests) in groupedByPathologyReport) {
             val (_, molecularTests, ihcTests) = tests
             pathologyReport?.let {
-                table.addCell(
-                    Cells.create(
-                        PathologyReportFunctions.getPathologyReportSummary(
-                            pathologyReport = pathologyReport,
-                            requestingHospital = report.requestingHospital
-                        )
-                    )
-                )
+                table.addCell(Cells.create(PathologyReportFunctions.getPathologyReportSummary(pathologyReport = pathologyReport)))
                 val reportTable = Tables.createSingleCol()
                 content(pathologyReport, molecularTests, ihcTests, reportTable)
                 table.addCell(Cells.create(reportTable))


### PR DESCRIPTION
Changes: 
 - the source field was removed
 - the lab became mandatory, sending NKI-AvL for internal reports
 - externalDate was renamed to reportDate but the meaning remains the same

 ReportRequested will no longer be propagated into the ACTIN datamodel as it’s only relevant during curation.