### PR TITLE
ACTIN-1966 add range rank to MolecularMatchDetails

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/EvidenceDatabase.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/EvidenceDatabase.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.datamodel.molecular.evidence.ClinicalEvidence
 import com.hartwig.actin.datamodel.molecular.driver.CopyNumber
 import com.hartwig.actin.datamodel.molecular.driver.Disruption
 import com.hartwig.actin.datamodel.molecular.driver.HomozygousDisruption
+import com.hartwig.actin.datamodel.molecular.driver.TranscriptVariantImpact
 import com.hartwig.actin.datamodel.molecular.driver.Virus
 import com.hartwig.actin.molecular.evidence.actionability.ClinicalEvidenceMatcher
 import com.hartwig.actin.molecular.evidence.known.KnownEventResolver
@@ -37,8 +38,8 @@ class EvidenceDatabase(
         return knownEventResolver.resolveForVariant(variant)
     }
 
-    fun evidenceForVariant(variant: VariantMatchCriteria): ClinicalEvidence {
-        return clinicalEvidenceMatcher.matchForVariant(variant)
+    fun evidenceForVariant(variant: VariantMatchCriteria, canonicalImpact: TranscriptVariantImpact? = null): ClinicalEvidence {
+        return clinicalEvidenceMatcher.matchForVariant(variant, canonicalImpact)
     }
 
     fun geneAlterationForCopyNumber(copyNumber: CopyNumber): GeneAlteration? {

--- a/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/actionability/ClinicalEvidenceMatcher.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/actionability/ClinicalEvidenceMatcher.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.datamodel.molecular.evidence.ClinicalEvidence
 import com.hartwig.actin.datamodel.molecular.driver.CopyNumber
 import com.hartwig.actin.datamodel.molecular.driver.Disruption
 import com.hartwig.actin.datamodel.molecular.driver.HomozygousDisruption
+import com.hartwig.actin.datamodel.molecular.driver.TranscriptVariantImpact
 import com.hartwig.actin.datamodel.molecular.driver.Virus
 import com.hartwig.actin.molecular.evidence.matching.FusionMatchCriteria
 import com.hartwig.actin.molecular.evidence.matching.VariantMatchCriteria
@@ -35,8 +36,8 @@ class ClinicalEvidenceMatcher(
         return clinicalEvidenceFactory.create(signatureEvidence.findTumorLoadMatches(hasHighTumorMutationalLoad))
     }
 
-    fun matchForVariant(variant: VariantMatchCriteria): ClinicalEvidence {
-        return clinicalEvidenceFactory.create(variantEvidence.findMatches(variant))
+    fun matchForVariant(variant: VariantMatchCriteria, canonicalImpact: TranscriptVariantImpact?): ClinicalEvidence {
+        return clinicalEvidenceFactory.create(variantEvidence.findMatches(variant), canonicalImpact)
     }
 
     fun matchForCopyNumber(copyNumber: CopyNumber): ClinicalEvidence {

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/actionability/ActionableEventExtractionTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/actionability/ActionableEventExtractionTest.kt
@@ -30,7 +30,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.HOTSPOT_MUTATION to actionableHotspot
+            ExtractedEvent(EvidenceType.HOTSPOT_MUTATION, null, actionableHotspot)
         )
     }
 
@@ -49,7 +49,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.CODON_MUTATION to actionableCodon
+            ExtractedEvent(EvidenceType.CODON_MUTATION, null, actionableCodon)
         )
     }
 
@@ -68,7 +68,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.EXON_MUTATION to actionableExon
+            ExtractedEvent(EvidenceType.EXON_MUTATION, null, actionableExon)
         )
     }
 
@@ -85,7 +85,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.PROMISCUOUS_FUSION to actionableGene
+            ExtractedEvent(EvidenceType.PROMISCUOUS_FUSION, null, actionableGene)
         )
     }
 
@@ -103,7 +103,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.FUSION_PAIR to actionableFusion
+            ExtractedEvent(EvidenceType.FUSION_PAIR, null, actionableFusion)
         )
     }
 
@@ -118,7 +118,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.SIGNATURE to actionableCharacteristic
+            ExtractedEvent(EvidenceType.SIGNATURE, null, actionableCharacteristic)
         )
     }
 
@@ -133,7 +133,7 @@ class ActionableEventExtractionTest {
         )
 
         assertThat(ActionableEventExtraction.extractEvent(molecularCriterium)).isEqualTo(
-            EvidenceType.HLA to actionableHla
+            ExtractedEvent(EvidenceType.HLA, null, actionableHla)
         )
     }
 }

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/evidence/MolecularMatchDetails.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/evidence/MolecularMatchDetails.kt
@@ -6,5 +6,6 @@ data class MolecularMatchDetails(
     val sourceDate: LocalDate,
     val sourceEvent: String,
     val sourceEvidenceType: EvidenceType,
+    val rangeRank: Int?,
     val sourceUrl: String
 )

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/evidence/TestMolecularMatchDetailsFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/evidence/TestMolecularMatchDetailsFactory.kt
@@ -9,6 +9,6 @@ object TestMolecularMatchDetailsFactory {
                sourceEvidenceType: EvidenceType = EvidenceType.ANY_MUTATION,
                sourceUrl: String = SOURCE_EVENT_URL
     ): MolecularMatchDetails {
-        return MolecularMatchDetails(sourceDate, sourceEvent, sourceEvidenceType, sourceUrl)
+        return MolecularMatchDetails(sourceDate, sourceEvent, sourceEvidenceType, null, sourceUrl)
     }
 }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/MolecularRecordAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/MolecularRecordAnnotator.kt
@@ -89,7 +89,8 @@ class MolecularRecordAnnotator(private val evidenceDatabase: EvidenceDatabase) :
             proteinEffect = alteration.proteinEffect,
             isAssociatedWithDrugResistance = alteration.isAssociatedWithDrugResistance
         )
-        val evidence = evidenceDatabase.evidenceForVariant(MatchingCriteriaFunctions.createVariantCriteria(variantWithGeneAlteration))
+        val evidence = evidenceDatabase.evidenceForVariant(MatchingCriteriaFunctions.createVariantCriteria(variantWithGeneAlteration),
+            variant.canonicalImpact)
         return variantWithGeneAlteration.copy(evidence = evidence)
     }
 


### PR DESCRIPTION
See https://hartwigmedical.atlassian.net/browse/ACTIN-1966 

In the OncoAct internal data model the affected Codon / affected Exon is passed on in a field called rangeRank. That naming I used here as well.

I did not see a way to get this information from the Serve datamodel (though it seems that it should be in there) so instead I pass it on from the Variant. 

I'm not particularly happy with this solution, however I could not think of an alternative. 

I did not add any tests yet as I first want to check if this is an acceptable solution, or if there are perhaps better alternatives before I spent more time on this approach