### PR TITLE
ACTIN-1968: Keep non-ignored tests with empty results

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
@@ -15,9 +15,8 @@ import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTes
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.variants
 import com.hartwig.actin.datamodel.clinical.SequencingTest
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
-import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTestResult
+import com.hartwig.actin.datamodel.clinical.provided.ProvidedMolecularTest
 import com.hartwig.actin.datamodel.clinical.provided.ProvidedPatientRecord
-import kotlin.reflect.full.memberProperties
 
 class StandardSequencingTestExtractor(
     private val testCuration: CurationDatabase<SequencingTestConfig>,
@@ -26,84 +25,65 @@ class StandardSequencingTestExtractor(
     StandardDataExtractor<List<SequencingTest>> {
 
     override fun extract(ehrPatientRecord: ProvidedPatientRecord): ExtractionResult<List<SequencingTest>> {
-        val extracted = ehrPatientRecord.molecularTests.orEmpty().mapNotNull { test ->
-            val testCurationConfig =
-                CurationResponse.createFromConfigs(
-                    testCuration.find(test.test),
-                    ehrPatientRecord.patientDetails.hashedId,
-                    CurationCategory.SEQUENCING_TEST,
-                    test.test,
-                    "sequencing test",
-                    false
-                )
-            testCurationConfig.config()?.let { testCuration ->
-                if (!testCuration.ignore) {
-                    val nonIhcTestResults = test.results.filter { it.ihcResult == null }.toSet()
-                    val (onlyFreeTextResults, populatedResults) = nonIhcTestResults
-                        .partition { checkAllFieldsNull(it) }
-                    val mandatoryCurationTestResults = curate(ehrPatientRecord, onlyFreeTextResults)
-                    val optionalCurationTestResults = curate(ehrPatientRecord, populatedResults)
-                    val allResults =
-                        removeCurated(removeCurated(nonIhcTestResults, mandatoryCurationTestResults), optionalCurationTestResults) +
-                                extract(mandatoryCurationTestResults + optionalCurationTestResults)
-                    if (allResults.isNotEmpty()) {
-                        ExtractionResult(
-                            listOf(
-                                SequencingTest(
-                                    test = testCuration.curatedName,
-                                    date = test.date,
-                                    variants = variants(allResults),
-                                    fusions = fusions(allResults),
-                                    amplifications = amplifications(allResults),
-                                    skippedExons = skippedExons(allResults),
-                                    deletedGenes = geneDeletions(allResults),
-                                    isMicrosatelliteUnstable = msi(allResults),
-                                    tumorMutationalBurden = tmb(allResults)
-                                )
-                            ),
-                            mandatoryCurationTestResults.map { curated -> curated.extractionEvaluation }
-                                .fold(CurationExtractionEvaluation()) { acc, extraction -> acc + extraction }
-                        )
-                    } else null
-                } else {
-                    null
-                }
-            } ?: ExtractionResult(emptyList(), testCurationConfig.extractionEvaluation)
-        }
-        return extracted.fold(
-            ExtractionResult(emptyList(), CurationExtractionEvaluation())
-        ) { acc, extractionResult ->
-            ExtractionResult(acc.extracted + extractionResult.extracted, acc.evaluation + extractionResult.evaluation)
-        }
-    }
-
-    private fun removeCurated(
-        original: Set<ProvidedMolecularTestResult>,
-        curated: List<CurationResponse<SequencingTestResultConfig>>
-    ): Set<ProvidedMolecularTestResult> {
-        val freeTexts = curated.flatMap { it.configs }.map { it.input }.toSet()
-        return original.filter { it.freeText !in freeTexts }.toSet()
-    }
-
-    private fun extract(curationResults: List<CurationResponse<SequencingTestResultConfig>>) =
-        curationResults.flatMap { it.configs }.filter { !it.ignore }.mapNotNull { it.curated }
-
-    private fun curate(
-        ehrPatientRecord: ProvidedPatientRecord,
-        results: Collection<ProvidedMolecularTestResult>
-    ) = results.mapNotNull { result -> result.freeText }
-        .map { text ->
-            CurationResponse.createFromConfigs(
-                testResultCuration.find(text),
+        return ehrPatientRecord.molecularTests.orEmpty().map { test ->
+            val testCurationResponse = CurationResponse.createFromConfigs(
+                testCuration.find(test.test),
                 ehrPatientRecord.patientDetails.hashedId,
-                CurationCategory.SEQUENCING_TEST_RESULT,
-                text,
-                "sequencing test result",
-                false
+                CurationCategory.SEQUENCING_TEST,
+                test.test,
+                "sequencing test",
+                true
+            )
+
+            if (testCurationResponse.config()?.ignore == true) {
+                ExtractionResult(emptyList(), testCurationResponse.extractionEvaluation)
+            } else {
+                extractTestResults(test, testCurationResponse, ehrPatientRecord.patientDetails.hashedId)
+            }
+        }
+            .fold(ExtractionResult(emptyList(), CurationExtractionEvaluation())) { acc, extractionResult ->
+                ExtractionResult(acc.extracted + extractionResult.extracted, acc.evaluation + extractionResult.evaluation)
+            }
+    }
+
+    private fun extractTestResults(
+        test: ProvidedMolecularTest, sequencingTestCuration: CurationResponse<SequencingTestConfig>, patientId: String
+    ): ExtractionResult<List<SequencingTest>> {
+        return if (test.results.isNotEmpty() && test.results.all { it.ihcResult != null }) {
+            ExtractionResult(emptyList(), CurationExtractionEvaluation())
+        } else {
+            val resultCurations = test.results.mapNotNull { result -> result.freeText?.let { curate(it, patientId) } }
+            val allResults = resultCurations.flatMap {
+                it.configs.filterNot(SequencingTestResultConfig::ignore).mapNotNull(SequencingTestResultConfig::curated)
+            }.toSet()
+            ExtractionResult(
+                listOfNotNull(
+                    sequencingTestCuration.config()?.let {
+                        SequencingTest(
+                            test = it.curatedName,
+                            date = test.date,
+                            variants = variants(allResults),
+                            fusions = fusions(allResults),
+                            amplifications = amplifications(allResults),
+                            skippedExons = skippedExons(allResults),
+                            deletedGenes = geneDeletions(allResults),
+                            isMicrosatelliteUnstable = msi(allResults),
+                            tumorMutationalBurden = tmb(allResults)
+                        )
+                    }
+                ),
+                resultCurations.map(CurationResponse<SequencingTestResultConfig>::extractionEvaluation)
+                    .fold(sequencingTestCuration.extractionEvaluation, CurationExtractionEvaluation::plus)
             )
         }
+    }
 
-    private fun checkAllFieldsNull(result: ProvidedMolecularTestResult) =
-        ProvidedMolecularTestResult::class.memberProperties.filter { it.name != "freeText" }.all { it.get(result) == null }
-
+    private fun curate(result: String, patientId: String) = CurationResponse.createFromConfigs(
+        testResultCuration.find(result),
+        patientId,
+        CurationCategory.SEQUENCING_TEST_RESULT,
+        result,
+        "sequencing test result",
+        false
+    )
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/ClinicalIngestionFeedAdapterTest.kt
@@ -128,7 +128,7 @@ class ClinicalIngestionFeedAdapterTest {
             UnusedCurationConfig(category = CurationCategory.MOLECULAR_TEST_PDL1, input = "cps pd l1 > 20"),
             UnusedCurationConfig(category = CurationCategory.DOSAGE_UNIT_TRANSLATION, input = "stuk"),
             UnusedCurationConfig(category = CurationCategory.SEQUENCING_TEST, input = "archer"),
-            UnusedCurationConfig(category = CurationCategory.SEQUENCING_TEST_RESULT, input = "kras g12f"),
+            UnusedCurationConfig(category = CurationCategory.SEQUENCING_TEST_RESULT, input = "kras c.34g>t"),
             UnusedCurationConfig(category = CurationCategory.SURGERY_NAME, input = "surgery1"),
             UnusedCurationConfig(category = CurationCategory.LESION_LOCATION, input = "and possibly lymph nodes"),
             UnusedCurationConfig(category = CurationCategory.COMORBIDITY, input = "morfine"),

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractorTest.kt
@@ -6,10 +6,6 @@ import com.hartwig.actin.clinical.curation.config.SequencingTestConfig
 import com.hartwig.actin.clinical.curation.config.SequencingTestResultConfig
 import com.hartwig.actin.clinical.feed.standard.EhrTestData
 import com.hartwig.actin.clinical.feed.standard.HASHED_ID_IN_BASE64
-import com.hartwig.actin.datamodel.clinical.SequencedAmplification
-import com.hartwig.actin.datamodel.clinical.SequencedDeletedGene
-import com.hartwig.actin.datamodel.clinical.SequencedFusion
-import com.hartwig.actin.datamodel.clinical.SequencedSkippedExons
 import com.hartwig.actin.datamodel.clinical.SequencedVariant
 import com.hartwig.actin.datamodel.clinical.SequencingTest
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
@@ -35,10 +31,13 @@ private val BASE_SEQUENCING_TEST = SequencingTest(
     test = TEST,
     date = TEST_DATE
 )
-private const val FUSION_GENE_UP = "fusionUp"
-private const val FUSION_GENE_DOWN = "fusionDown"
-private const val AMPLIFIED_GENE = "amplifiedGene"
 private const val FREE_TEXT = "free text"
+private val SEQUENCING_TEST_CURATION_WARNING = CurationWarning(
+    patientId = HASHED_ID_IN_BASE64,
+    category = CurationCategory.SEQUENCING_TEST,
+    feedInput = TEST,
+    message = "Could not find sequencing test config for input 'test'"
+)
 
 class StandardSequencingTestExtractorTest {
 
@@ -60,14 +59,7 @@ class StandardSequencingTestExtractorTest {
         every { testCuration.find(TEST) } returns emptySet()
         val result = extractor.extract(EhrTestData.createEhrPatientRecord().copy(molecularTests = listOf(BASE_MOLECULAR_TEST)))
         assertThat(result.extracted).isEmpty()
-        assertThat(result.evaluation.warnings).containsExactly(
-            CurationWarning(
-                patientId = HASHED_ID_IN_BASE64,
-                category = CurationCategory.SEQUENCING_TEST,
-                feedInput = TEST,
-                message = "Could not find sequencing test config for input 'test'"
-            )
-        )
+        assertThat(result.evaluation.warnings).containsExactly(SEQUENCING_TEST_CURATION_WARNING)
     }
 
     @Test
@@ -87,78 +79,34 @@ class StandardSequencingTestExtractorTest {
     }
 
     @Test
-    fun `Should extract sequencing with variants`() {
-        val result = extractionResult(
-            ProvidedMolecularTestResult(
-                gene = GENE, hgvsCodingImpact = CODING, hgvsProteinImpact = PROTEIN
-            )
-        )
-        assertResultContains(
-            result, BASE_SEQUENCING_TEST.copy(
-                variants = setOf(SequencedVariant(gene = GENE, hgvsCodingImpact = CODING, hgvsProteinImpact = PROTEIN))
-            )
-        )
-    }
-
-    @Test
-    fun `Should extract sequencing with fusions`() {
-        val result = extractionResult(
-            ProvidedMolecularTestResult(
-                fusionGeneUp = FUSION_GENE_UP, fusionGeneDown = FUSION_GENE_DOWN
-            )
-        )
-        assertResultContains(
-            result,
-            BASE_SEQUENCING_TEST.copy(
-                fusions = setOf(SequencedFusion(geneUp = FUSION_GENE_UP, geneDown = FUSION_GENE_DOWN))
+    fun `Should return curation warnings for test and results when neither is curated`() {
+        every { testCuration.find(TEST) } returns emptySet()
+        every { testResultCuration.find(FREE_TEXT) } returns emptySet()
+        val molecularTests = listOf(BASE_MOLECULAR_TEST.copy(results = setOf(ProvidedMolecularTestResult(freeText = FREE_TEXT))))
+        val result = extractor.extract(EhrTestData.createEhrPatientRecord().copy(molecularTests = molecularTests))
+        assertThat(result.extracted).isEmpty()
+        assertThat(result.evaluation.warnings).containsExactly(
+            SEQUENCING_TEST_CURATION_WARNING,
+            CurationWarning(
+                patientId = HASHED_ID_IN_BASE64,
+                category = CurationCategory.SEQUENCING_TEST_RESULT,
+                feedInput = FREE_TEXT,
+                message = "Could not find sequencing test result config for input '$FREE_TEXT'"
             )
         )
     }
 
     @Test
-    fun `Should extract sequencing with amplifications`() {
-        val result = extractionResult(
-            ProvidedMolecularTestResult(
-                amplifiedGene = AMPLIFIED_GENE
-            )
-        )
-        assertResultContains(
-            result,
-            BASE_SEQUENCING_TEST.copy(amplifications = setOf(SequencedAmplification(gene = AMPLIFIED_GENE)))
-        )
-    }
-
-    @Test
-    fun `Should extract sequencing with exon skipping`() {
-        val result = extractionResult(ProvidedMolecularTestResult(gene = GENE, exonSkipStart = 1, exonSkipEnd = 2))
-        assertResultContains(
-            result, BASE_SEQUENCING_TEST.copy(
-                skippedExons = setOf(
-                    SequencedSkippedExons(gene = GENE, exonStart = 1, exonEnd = 2)
+    fun `Should curate test name and extract sequencing with test name and date, even when no results present`() {
+        val result = extractor.extract(
+            EhrTestData.createEhrPatientRecord().copy(
+                molecularTests = listOf(
+                    BASE_MOLECULAR_TEST.copy(testedGenes = setOf(GENE), results = emptySet())
                 )
             )
         )
-    }
-
-    @Test
-    fun `Should extract sequencing with TMB and MSI`() {
-        val result = extractionResult(ProvidedMolecularTestResult(tmb = 1.0, msi = true))
-        assertResultContains(
-            result, BASE_SEQUENCING_TEST.copy(
-                tumorMutationalBurden = 1.0,
-                isMicrosatelliteUnstable = true
-            )
-        )
-    }
-
-    @Test
-    fun `Should extract sequenced deleted genes`() {
-        val result = extractionResult(ProvidedMolecularTestResult(deletedGene = GENE))
-        assertResultContains(
-            result, BASE_SEQUENCING_TEST.copy(
-                deletedGenes = setOf(SequencedDeletedGene(GENE))
-            )
-        )
+        assertThat(result.extracted[0].date).isEqualTo(TEST_DATE)
+        assertThat(result.extracted[0].test).isEqualTo(CURATED_TEST)
     }
 
     @Test
@@ -190,13 +138,6 @@ class StandardSequencingTestExtractorTest {
                 message = "Could not find sequencing test result config for input '$FREE_TEXT'"
             )
         )
-    }
-
-    @Test
-    fun `Should not return curation warnings for uncurated free text when some fields are not null`() {
-        every { testResultCuration.find(FREE_TEXT) } returns emptySet()
-        val result = extractionResult(ProvidedMolecularTestResult(gene = GENE, freeText = FREE_TEXT))
-        assertThat(result.evaluation.warnings).isEmpty()
     }
 
     @Test

--- a/clinical/src/test/resources/curation/sequencing_test_result.tsv
+++ b/clinical/src/test/resources/curation/sequencing_test_result.tsv
@@ -1,2 +1,2 @@
 input	gene	hgvsProteinImpact	hgvsCodingImpact	position	exon	codon	transcript	fusionGeneUp	fusionGeneDown	amplifiedChromosome	amplifiedGene	deletedGene	exonSkipStart	exonSkipEnd	msi	tmb	noMutationsFound
-KRAS G12F	KRAS	p.G12F																
+KRAS c.34G>T	KRAS		c.34G>T															

--- a/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
+++ b/clinical/src/test/resources/feed/standard/input/ACTN01029999.json
@@ -148,8 +148,7 @@
       "date": "2024-07-15",
       "results": [
         {
-          "gene": "KRAS",
-          "hgvsCodingImpact": "c.34G>T"
+          "freeText": "KRAS c.34G>T"
         }
       ]
     }


### PR DESCRIPTION
Exclude tests with only IHC results.
Show sequencing result warnings simultaneously with sequencing test warnings.