### PR TITLE
ACTIN-1983: Refactor + fix bug in exon being curated as codon & vice versa

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/extraction/SequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/extraction/SequencingTestExtractor.kt
@@ -10,7 +10,7 @@ import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluati
 import com.hartwig.actin.clinical.feed.emc.questionnaire.Questionnaire
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.amplifications
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.fusions
-import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.geneDeletions
+import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.deletions
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.msi
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.skippedExons
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.tmb
@@ -66,10 +66,10 @@ class SequencingTestExtractor(
                             SequencingTest(
                                 test = name,
                                 variants = variants(curatedSequencingResults),
-                                fusions = fusions(curatedSequencingResults),
                                 amplifications = amplifications(curatedSequencingResults),
+                                deletions = deletions(curatedSequencingResults),
+                                fusions = fusions(curatedSequencingResults),
                                 skippedExons = skippedExons(curatedSequencingResults),
-                                deletedGenes = geneDeletions(curatedSequencingResults),
                                 isMicrosatelliteUnstable = msi(curatedSequencingResults),
                                 tumorMutationalBurden = tmb(curatedSequencingResults)
                             )

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
@@ -8,7 +8,7 @@ import com.hartwig.actin.clinical.curation.config.SequencingTestResultConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.amplifications
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.fusions
-import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.geneDeletions
+import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.deletions
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.msi
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.skippedExons
 import com.hartwig.actin.clinical.feed.standard.extraction.StandardSequencingTestExtractorFunctions.tmb
@@ -53,12 +53,12 @@ class StandardSequencingTestExtractor(
                                     test = testCuration.curatedName,
                                     date = test.date,
                                     variants = variants(allResults),
-                                    fusions = fusions(allResults),
                                     amplifications = amplifications(allResults),
+                                    deletions = deletions(allResults),
+                                    fusions = fusions(allResults),
                                     skippedExons = skippedExons(allResults),
-                                    deletedGenes = geneDeletions(allResults),
+                                    tumorMutationalBurden = tmb(allResults),
                                     isMicrosatelliteUnstable = msi(allResults),
-                                    tumorMutationalBurden = tmb(allResults)
                                 )
                             ),
                             mandatoryCurationTestResults.map { curated -> curated.extractionEvaluation }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractorTest.kt
@@ -156,7 +156,7 @@ class StandardSequencingTestExtractorTest {
         val result = extractionResult(ProvidedMolecularTestResult(deletedGene = GENE))
         assertResultContains(
             result, BASE_SEQUENCING_TEST.copy(
-                deletedGenes = setOf(SequencedDeletedGene(GENE))
+                deletions = setOf(SequencedDeletedGene(GENE))
             )
         )
     }

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -193,10 +193,10 @@
           "hgvsCodingImpact": "c.34G>T"
         }
       ],
-      "fusions": [],
       "amplifications": [],
-      "skippedExons": [],
-      "deletedGenes": []
+      "deletions": [],
+      "fusions": [],
+      "skippedExons": []
     }
   ],
   "labValues": [

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/SequencingTest.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/SequencingTest.kt
@@ -4,11 +4,11 @@ import com.hartwig.actin.datamodel.Displayable
 import java.time.LocalDate
 
 data class SequencedVariant(
-    val variantAlleleFrequency: Double? = null,
     val gene: String,
     val hgvsCodingImpact: String? = null,
     val hgvsProteinImpact: String? = null,
     val transcript: String? = null,
+    val variantAlleleFrequency: Double? = null,
     val exon: Int? = null,
     val codon: Int? = null
 ) {
@@ -51,11 +51,11 @@ data class SequencedDeletedGene(val gene: String, val transcript: String? = null
 data class SequencingTest(
     val test: String,
     val date: LocalDate? = null,
-    val tumorMutationalBurden: Double? = null,
-    val isMicrosatelliteUnstable: Boolean? = null,
     val variants: Set<SequencedVariant> = emptySet(),
     val amplifications: Set<SequencedAmplification> = emptySet(),
-    val skippedExons: Set<SequencedSkippedExons> = emptySet(),
+    val deletions: Set<SequencedDeletedGene> = emptySet(),
     val fusions: Set<SequencedFusion> = emptySet(),
-    val deletedGenes: Set<SequencedDeletedGene> = emptySet()
+    val skippedExons: Set<SequencedSkippedExons> = emptySet(),
+    val tumorMutationalBurden: Double? = null,
+    val isMicrosatelliteUnstable: Boolean? = null,
 ) 

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/provided/ProvidedClinicalDatamodel.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/provided/ProvidedClinicalDatamodel.kt
@@ -159,6 +159,12 @@ data class ProvidedMolecularTestResult(
     val hgvsCodingImpact: String? = null,
     @Description("Transcript referenced in other positional attributes (eg. NM_004304.5)")
     val transcript: String? = null,
+    @Description("Variant allele frequency as a fraction (eg. 0.01 is interpreted as 1%)")
+    val vaf: Double? = null,
+    @Description("Exon involved in this result (eg. 19)")
+    val exon: Int? = null,
+    @Description("Codon involved in this result (eg. 1)")
+    val codon: Int? = null,
     @Description("Upstream gene of a fusion (eg. EML4)")
     val fusionGeneUp: String? = null,
     @Description("Downstream gene of a fusion (eg. ALK)")
@@ -171,10 +177,6 @@ data class ProvidedMolecularTestResult(
     val fusionExonUp: Int? = null,
     @Description("Downstream exon of a  fusion (eg. 20)")
     val fusionExonDown: Int? = null,
-    @Description("Exon involved in this result (eg. 19)")
-    val exon: Int? = null,
-    @Description("Codon involved in this result (eg. 1)")
-    val codon: Int? = null,
     @Description("Exons skipped in a structural variant start (eg. 18)")
     val exonSkipStart: Int? = null,
     @Description("Exons skipped in a structural variant end (eg. 20)")
@@ -183,16 +185,14 @@ data class ProvidedMolecularTestResult(
     val amplifiedGene: String? = null,
     @Description("Gene detected as fully deleted (eg. MET)")
     val deletedGene: String? = null,
-    @Description("Flag should be set to indicate a negative result for a gene (ie. nothing was found)")
-    val noMutationsFound: Boolean? = null,
-    @Description("Free text for a test result which does not fit into any of the other fields. This value will be curated")
-    val freeText: String? = null,
     @Description("Result of microsatellite instability test")
     val msi: Boolean? = null,
     @Description("Tumor mutational burden in m/MB (eg. 8.0)")
     val tmb: Double? = null,
-    @Description("Variant allele frequency as a fraction (eg. 0.01 is interpreted as 1%)")
-    val vaf: Double? = null
+    @Description("Flag should be set to indicate a negative result for a gene (ie. nothing was found)")
+    val noMutationsFound: Boolean? = null,
+    @Description("Free text for a test result which does not fit into any of the other fields. This value will be curated")
+    val freeText: String? = null,
 )
 
 @JacksonSerializable

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
@@ -26,7 +26,7 @@ class PanelAnnotator(
     override fun annotate(input: SequencingTest): PanelRecord {
         val annotatedVariants = panelVariantAnnotator.annotate(input.variants)
         val annotatedAmplifications = panelCopyNumberAnnotator.annotate(input.amplifications)
-        val annotatedDeletions = panelCopyNumberAnnotator.annotate(input.deletedGenes)
+        val annotatedDeletions = panelCopyNumberAnnotator.annotate(input.deletions)
         val annotatedFusions = panelFusionAnnotator.annotate(input.fusions, input.skippedExons)
 
         return PanelRecord(


### PR DESCRIPTION
Hi, I wanted to make a start with allowing curation of amplification copy nr (ACTIN-1982), but after start I thought I'd refactor a bit first, as I also saw a small bug.

Changes:
- Exon was curated as codon and vice versa (StandardSequencingTestExtractorFunctions) (so I now specifically listed the variables too to prevent this)
- Renamed deletedGenes to deletions for more consistency in StandardSequencingTestExtractor
- Reordered SequencingTest & SequencedVariant data classes for more logical order
- Made everything consistent also across ProvidedClinicalDataModel
- I already adjusted the Sheet for curation (I was unaware I could already configure VAF because it was not on the sheet!)

Please let me know if I should make more changes somewhere or if this somehow also relates to ACTIN-feed?