### PR TITLE
ACTIN-1447: Restructure datamodel to expose it for trial-api

### DIFF
--- a/trial/src/main/kotlin/com/hartwig/actin/trial/TrialCreatorApplication.kt
+++ b/trial/src/main/kotlin/com/hartwig/actin/trial/TrialCreatorApplication.kt
@@ -78,7 +78,7 @@ class TrialCreatorApplication(private val config: TrialCreatorConfig) {
             trialIngestion.ingest(objectMapper.readValue(File(config.trialConfigJsonPath), object : TypeReference<List<TrialConfig>>() {}))
 
         val outputDirectory = config.outputDirectory
-        when (result) {
+        when (result) { 
             is Either.Right -> {
                 LOGGER.info("Writing ${result.value.size} trials to [$outputDirectory]")
                 TrialJson.write(result.value, outputDirectory)


### PR DESCRIPTION
This PR refactors the codebase to use the `datamodel` component from [trial-api](https://github.com/hartwigmedical/actin-trial-api) as a dependency, eliminating code duplication. The `EligibilityRule` extraction logic from `inclusionCriteria`, also used in trial-api, is now reused to avoid redundancy. (new [solution](https://github.com/hartwigmedical/actin-trial-api/pull/39)).

**Key changes:**

- [x] Restructured components for improved modularity.
- [x] Replaced EligibilityFactory class with a simpler object that generates EligibilityFunction from criteria.
- [x] Delegated parameter verification logic to FunctionInputResolver.
- [x] Changed tests according to new structure 

*Note*:
[Pull request](https://github.com/hartwigmedical/actin-trial-api/pull/39) in trial-api depends on this changes.