### PR TITLE
ACTIN-2014: Only consider prior primary inputs for extraction

### DIFF
--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/PathologyReportsExtractor.kt
@@ -6,9 +6,9 @@ import com.hartwig.actin.datamodel.clinical.PathologyReport
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class PathologyReportsExtractor : StandardDataExtractor<List<PathologyReport>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<PathologyReport>> {
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<PathologyReport>> {
         return ExtractionResult(
-            ehrPatientRecord.tumorDetails.pathology.takeIf { it.isNotEmpty() }?.map {
+            feedPatientRecord.tumorDetails.pathology.takeIf { it.isNotEmpty() }?.map {
                 PathologyReport(
                     tissueId = it.tissueId,
                     lab = it.lab,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBloodTransfusionExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBloodTransfusionExtractor.kt
@@ -7,8 +7,8 @@ import com.hartwig.actin.datamodel.clinical.BloodTransfusion
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardBloodTransfusionExtractor : StandardDataExtractor<List<BloodTransfusion>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<BloodTransfusion>> {
-        return ExtractionResult(ehrPatientRecord.bloodTransfusions.map {
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<BloodTransfusion>> {
+        return ExtractionResult(feedPatientRecord.bloodTransfusions.map {
             BloodTransfusion(
                 date = it.evaluationDate,
                 product = mapTransfusionProduct(it.name)

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBodyHeightExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBodyHeightExtractor.kt
@@ -8,8 +8,8 @@ import com.hartwig.actin.datamodel.clinical.BodyHeight
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardBodyHeightExtractor : StandardDataExtractor<List<BodyHeight>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<BodyHeight>> {
-        return ExtractionResult(ehrPatientRecord.measurements
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<BodyHeight>> {
+        return ExtractionResult(feedPatientRecord.measurements
             .filter {
                 enumeratedInput<ProvidedMeasurementCategory>(it.category) == ProvidedMeasurementCategory.BODY_HEIGHT
             }.map {

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBodyWeightExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardBodyWeightExtractor.kt
@@ -10,8 +10,8 @@ import com.hartwig.feed.datamodel.FeedPatientRecord
 
 
 class StandardBodyWeightExtractor : StandardDataExtractor<List<BodyWeight>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<BodyWeight>> {
-        return ExtractionResult(ehrPatientRecord.measurements
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<BodyWeight>> {
+        return ExtractionResult(feedPatientRecord.measurements
             .filter {
                 enumeratedInput<ProvidedMeasurementCategory>(it.category) == ProvidedMeasurementCategory.BODY_WEIGHT
             }.map {

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardClinicalStatusExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardClinicalStatusExtractor.kt
@@ -6,11 +6,11 @@ import com.hartwig.actin.datamodel.clinical.ClinicalStatus
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardClinicalStatusExtractor() : StandardDataExtractor<ClinicalStatus> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<ClinicalStatus> {
-        val mostRecentWho = ehrPatientRecord.whoEvaluations.maxByOrNull { who -> who.evaluationDate }
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<ClinicalStatus> {
+        val mostRecentWho = feedPatientRecord.whoEvaluations.maxByOrNull { who -> who.evaluationDate }
         val clinicalStatus = ClinicalStatus(
             who = mostRecentWho?.status,
-            hasComplications = ehrPatientRecord.complications.isNotEmpty()
+            hasComplications = feedPatientRecord.complications.isNotEmpty()
         )
         return ExtractionResult(clinicalStatus, CurationExtractionEvaluation())
     }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardComorbidityExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardComorbidityExtractor.kt
@@ -20,8 +20,8 @@ import com.hartwig.feed.datamodel.FeedToxicity
 class StandardComorbidityExtractor(
     private val comorbidityCuration: CurationDatabase<ComorbidityConfig>
 ) : StandardDataExtractor<List<Comorbidity>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<Comorbidity>> {
-        return with(ehrPatientRecord) {
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<Comorbidity>> {
+        return with(feedPatientRecord) {
             val patientId = patientDetails.patientId
             listOf(
                 extractCategory(otherConditions, CurationCategory.NON_ONCOLOGICAL_HISTORY, "non-oncological history", patientId),

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardDataExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardDataExtractor.kt
@@ -4,5 +4,5 @@ import com.hartwig.actin.clinical.ExtractionResult
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 interface StandardDataExtractor<T> {
-    fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<T>
+    fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<T>
 }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardIhcTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardIhcTestExtractor.kt
@@ -13,12 +13,12 @@ import java.time.LocalDate
 class StandardIhcTestExtractor(
     private val molecularTestCuration: CurationDatabase<IhcTestConfig>
 ) : StandardDataExtractor<List<IhcTest>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<IhcTest>> {
-        return ehrPatientRecord.ihcTests
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<IhcTest>> {
+        return feedPatientRecord.ihcTests
             .asSequence()
             .mapNotNull { test ->
-                val curations = listOf(test.name, "${ehrPatientRecord.patientDetails.patientId} | ${test.name}").map { curationString ->
-                    curate(curationString, ehrPatientRecord.patientDetails.patientId, test.startDate)
+                val curations = listOf(test.name, "${feedPatientRecord.patientDetails.patientId} | ${test.name}").map { curationString ->
+                    curate(curationString, feedPatientRecord.patientDetails.patientId, test.startDate)
                 }
                 if (curations.any { it.config()?.ignore == true }) {
                     null

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardLabValuesExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardLabValuesExtractor.kt
@@ -15,12 +15,12 @@ import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardLabValuesExtractor(private val labMeasurementCuration: CurationDatabase<LabMeasurementConfig>) :
     StandardDataExtractor<List<LabValue>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<LabValue>> {
-        return ehrPatientRecord.labValues.map { providedLabValue ->
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<LabValue>> {
+        return feedPatientRecord.labValues.map { providedLabValue ->
             val inputText = "${providedLabValue.measureCode} | ${providedLabValue.measure}"
             val curationResponse = CurationResponse.createFromConfigs(
                 labMeasurementCuration.find(inputText),
-                ehrPatientRecord.patientDetails.patientId,
+                feedPatientRecord.patientDetails.patientId,
                 CurationCategory.LAB_MEASUREMENT,
                 inputText,
                 "lab measurement",

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardMedicationExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardMedicationExtractor.kt
@@ -21,14 +21,14 @@ class StandardMedicationExtractor(
     private val treatmentDatabase: TreatmentDatabase
 ) : StandardDataExtractor<List<Medication>?> {
 
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<Medication>?> {
-        return ehrPatientRecord.medications?.map { feedMedication ->
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<Medication>?> {
+        return feedPatientRecord.medications?.map { feedMedication ->
             val isTrialMedication = feedMedication.isTrial || feedMedication.name.contains("(studie)", ignoreCase = true)
             val isUnspecifiedTrialMedication = feedMedication.name.contains("studiemedicatie", ignoreCase = true) && !isTrialMedication
             val atcClassification = if (!isTrialMedication && !isUnspecifiedTrialMedication && !feedMedication.isSelfCare) {
                 if (feedMedication.atcCode == null) {
                     logger.error(
-                        "Patient '${ehrPatientRecord.patientDetails.patientId}' had medication '${feedMedication.name}' with null atc code, " +
+                        "Patient '${feedPatientRecord.patientDetails.patientId}' had medication '${feedMedication.name}' with null atc code, " +
                                 "but is not a trial or self care"
                     )
                 }
@@ -41,7 +41,7 @@ class StandardMedicationExtractor(
 
             val atcWarning = if (isAntiCancerMedication && drug == null && !isUnspecifiedTrialMedication) {
                 CurationWarning(
-                    ehrPatientRecord.patientDetails.patientId,
+                    feedPatientRecord.patientDetails.patientId,
                     CurationCategory.MEDICATION_NAME,
                     atcNameOrInput,
                     "Anti cancer medication or supportive trial medication $atcNameOrInput with ATC code $atcCode found which is not " +

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardOncologicalHistoryExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardOncologicalHistoryExtractor.kt
@@ -16,10 +16,10 @@ private const val TREATMENT_HISTORY = "treatment history"
 class StandardOncologicalHistoryExtractor(
     private val treatmentCuration: CurationDatabase<TreatmentHistoryEntryConfig>
 ) : StandardDataExtractor<List<TreatmentHistoryEntry>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<TreatmentHistoryEntry>> {
-        val patientId = ehrPatientRecord.patientDetails.patientId
-        val oncologicalPreviousConditions = convertFeedEntriesToOncologicalHistory(ehrPatientRecord.otherConditions, patientId)
-        val oncologicalTreatmentHistory = convertFeedEntriesToOncologicalHistory(ehrPatientRecord.treatmentHistory, patientId)
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<TreatmentHistoryEntry>> {
+        val patientId = feedPatientRecord.patientDetails.patientId
+        val oncologicalPreviousConditions = convertFeedEntriesToOncologicalHistory(feedPatientRecord.otherConditions, patientId)
+        val oncologicalTreatmentHistory = convertFeedEntriesToOncologicalHistory(feedPatientRecord.treatmentHistory, patientId)
 
         return ExtractionResult(
             merge(oncologicalTreatmentHistory.extracted, oncologicalPreviousConditions.extracted),

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPatientDetailsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPatientDetailsExtractor.kt
@@ -8,14 +8,14 @@ import com.hartwig.actin.datamodel.clinical.provided.ProvidedGender
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardPatientDetailsExtractor : StandardDataExtractor<PatientDetails> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<PatientDetails> {
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<PatientDetails> {
         return ExtractionResult(
             PatientDetails(
-                gender = Gender.valueOf(enumeratedInput<ProvidedGender>(ehrPatientRecord.patientDetails.gender).toString()),
-                birthYear = ehrPatientRecord.patientDetails.birthYear,
-                registrationDate = ehrPatientRecord.patientDetails.registrationDate,
-                hasHartwigSequencing = ehrPatientRecord.patientDetails.hartwigMolecularDataExpected,
-                sourceId = ehrPatientRecord.patientDetails.sourceId
+                gender = Gender.valueOf(enumeratedInput<ProvidedGender>(feedPatientRecord.patientDetails.gender).toString()),
+                birthYear = feedPatientRecord.patientDetails.birthYear,
+                registrationDate = feedPatientRecord.patientDetails.registrationDate,
+                hasHartwigSequencing = feedPatientRecord.patientDetails.hartwigMolecularDataExpected,
+                sourceId = feedPatientRecord.patientDetails.sourceId
             ), CurationExtractionEvaluation()
         )
     }

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractor.kt
@@ -7,45 +7,30 @@ import com.hartwig.actin.clinical.curation.config.PriorPrimaryConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
 import com.hartwig.actin.datamodel.clinical.PriorPrimary
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
-import com.hartwig.feed.datamodel.DatedEntry
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardPriorPrimariesExtractor(private val priorPrimaryCuration: CurationDatabase<PriorPrimaryConfig>) :
     StandardDataExtractor<List<PriorPrimary>> {
     override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<PriorPrimary>> {
-        val priorPrimaries = fromPriorPrimaries(ehrPatientRecord)
-        val patientId = ehrPatientRecord.patientDetails.patientId
-        val priorPrimariesFromOtherConditions = extractFromSecondarySource(ehrPatientRecord.otherConditions, patientId)
-        val priorPrimariesFromTreatmentHistory = extractFromSecondarySource(ehrPatientRecord.treatmentHistory, patientId)
-        return (priorPrimaries + priorPrimariesFromOtherConditions + priorPrimariesFromTreatmentHistory).fold(
-            ExtractionResult(emptyList(), CurationExtractionEvaluation())
-        ) { acc, extractionResult ->
-            ExtractionResult(acc.extracted + extractionResult.extracted, acc.evaluation + extractionResult.evaluation)
-        }
-    }
-
-    private fun extractFromSecondarySource(sourceList: List<DatedEntry>, patientId: String): List<ExtractionResult<List<PriorPrimary>>> {
-        return sourceList.map { curate(patientId, it.name) }
-            .filter { it.configs.isNotEmpty() }
-            .map {
-                ExtractionResult(it.configs.mapNotNull { c -> c.curated }, it.extractionEvaluation)
-            }
-    }
-
-    private fun fromPriorPrimaries(ehrPatientRecord: FeedPatientRecord): List<ExtractionResult<List<PriorPrimary>>> =
-        ehrPatientRecord.priorPrimaries.map { feedPriorPrimary ->
+        return ehrPatientRecord.priorPrimaries.map { feedPriorPrimary ->
             val curatedPriorPrimary = curate(ehrPatientRecord.patientDetails.patientId, feedPriorPrimary.name)
             ExtractionResult(
-                listOfNotNull(
-                    curatedPriorPrimary.config()?.takeUnless { it.ignore }?.curated?.copy(
+                curatedPriorPrimary.configs.filterNot { it.ignore }.mapNotNull {
+                    it.curated?.copy(
                         diagnosedMonth = feedPriorPrimary.startDate?.monthValue,
                         diagnosedYear = feedPriorPrimary.startDate?.year,
                         lastTreatmentYear = feedPriorPrimary.endDate?.year,
                         lastTreatmentMonth = feedPriorPrimary.endDate?.monthValue,
                     )
-                ), curatedPriorPrimary.extractionEvaluation
+                },
+                curatedPriorPrimary.extractionEvaluation
             )
+        }.fold(
+            ExtractionResult(emptyList(), CurationExtractionEvaluation())
+        ) { acc, extractionResult ->
+            ExtractionResult(acc.extracted + extractionResult.extracted, acc.evaluation + extractionResult.evaluation)
         }
+    }
 
     private fun curate(patientId: String, input: String) = CurationResponse.createFromConfigs(
         priorPrimaryCuration.find(input),

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractor.kt
@@ -11,9 +11,9 @@ import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardPriorPrimariesExtractor(private val priorPrimaryCuration: CurationDatabase<PriorPrimaryConfig>) :
     StandardDataExtractor<List<PriorPrimary>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<PriorPrimary>> {
-        return ehrPatientRecord.priorPrimaries.map { feedPriorPrimary ->
-            val curatedPriorPrimary = curate(ehrPatientRecord.patientDetails.patientId, feedPriorPrimary.name)
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<PriorPrimary>> {
+        return feedPatientRecord.priorPrimaries.map { feedPriorPrimary ->
+            val curatedPriorPrimary = curate(feedPatientRecord.patientDetails.patientId, feedPriorPrimary.name)
             ExtractionResult(
                 curatedPriorPrimary.configs.filterNot { it.ignore }.mapNotNull {
                     it.curated?.copy(

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSequencingTestExtractor.kt
@@ -25,11 +25,11 @@ class StandardSequencingTestExtractor(
 ) :
     StandardDataExtractor<List<SequencingTest>> {
 
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<SequencingTest>> {
-        return ehrPatientRecord.sequencingTests.map { test ->
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<SequencingTest>> {
+        return feedPatientRecord.sequencingTests.map { test ->
             val testCurationResponse = CurationResponse.createFromConfigs(
                 testCuration.find(test.name),
-                ehrPatientRecord.patientDetails.patientId,
+                feedPatientRecord.patientDetails.patientId,
                 CurationCategory.SEQUENCING_TEST,
                 test.name,
                 "sequencing test",
@@ -39,7 +39,7 @@ class StandardSequencingTestExtractor(
             if (testCurationResponse.config()?.ignore == true) {
                 ExtractionResult(emptyList(), testCurationResponse.extractionEvaluation)
             } else {
-                extractTestResults(test, testCurationResponse, ehrPatientRecord.patientDetails.patientId)
+                extractTestResults(test, testCurationResponse, feedPatientRecord.patientDetails.patientId)
             }
         }
             .fold(ExtractionResult(emptyList(), CurationExtractionEvaluation())) { acc, extractionResult ->

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSurgeryExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardSurgeryExtractor.kt
@@ -14,14 +14,14 @@ class StandardSurgeryExtractor(
     private val surgeryNameCuration: CurationDatabase<SurgeryNameConfig>
 ) : StandardDataExtractor<List<Surgery>> {
 
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<Surgery>> {
-        return ehrPatientRecord.surgeries.map { providedSurgery ->
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<Surgery>> {
+        return feedPatientRecord.surgeries.map { providedSurgery ->
             val status = providedSurgery.status?.let(SurgeryStatus::valueOf) ?: SurgeryStatus.UNKNOWN
 
             providedSurgery.name?.takeIf { it.isNotBlank() }?.let { surgeryName ->
                 val curationResponse = CurationResponse.createFromConfigs(
                     surgeryNameCuration.find(surgeryName),
-                    ehrPatientRecord.patientDetails.patientId,
+                    feedPatientRecord.patientDetails.patientId,
                     CurationCategory.SURGERY_NAME,
                     surgeryName,
                     "surgery"

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardTumorDetailsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardTumorDetailsExtractor.kt
@@ -16,22 +16,22 @@ class StandardTumorDetailsExtractor(
     private val tumorStageDeriver: TumorStageDeriver
 ) : StandardDataExtractor<TumorDetails> {
 
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<TumorDetails> {
-        val input = "${ehrPatientRecord.tumorDetails.tumorLocation} | ${ehrPatientRecord.tumorDetails.tumorType}"
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<TumorDetails> {
+        val input = "${feedPatientRecord.tumorDetails.tumorLocation} | ${feedPatientRecord.tumorDetails.tumorType}"
 
-        val curatedTumorResponseFromOtherConditions = ehrPatientRecord.otherConditions.map {
+        val curatedTumorResponseFromOtherConditions = feedPatientRecord.otherConditions.map {
             CurationResponse.createFromConfigs(
                 primaryTumorConfigCurationDatabase.find(it.name),
-                ehrPatientRecord.patientDetails.patientId, CurationCategory.PRIMARY_TUMOR, input, "primary tumor"
+                feedPatientRecord.patientDetails.patientId, CurationCategory.PRIMARY_TUMOR, input, "primary tumor"
             )
         }.firstNotNullOfOrNull { it.config() }
 
         val curatedTumorResponse = CurationResponse.createFromConfigs(
             primaryTumorConfigCurationDatabase.find(input),
-            ehrPatientRecord.patientDetails.patientId, CurationCategory.PRIMARY_TUMOR, input, "primary tumor", true
+            feedPatientRecord.patientDetails.patientId, CurationCategory.PRIMARY_TUMOR, input, "primary tumor", true
         )
 
-        val tumorDetailsFromEhr = tumorDetails(ehrPatientRecord)
+        val tumorDetailsFromEhr = tumorDetails(feedPatientRecord)
         val combinedTumorResponse = combinedTumorResponse(curatedTumorResponse, curatedTumorResponseFromOtherConditions)
         return combinedTumorResponse.config()?.let {
             val curatedTumorDetails = tumorDetailsFromEhr.copy(

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardVitalFunctionsExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardVitalFunctionsExtractor.kt
@@ -10,8 +10,8 @@ import com.hartwig.feed.datamodel.FeedMeasurement
 import com.hartwig.feed.datamodel.FeedPatientRecord
 
 class StandardVitalFunctionsExtractor : StandardDataExtractor<List<VitalFunction>> {
-    override fun extract(ehrPatientRecord: FeedPatientRecord): ExtractionResult<List<VitalFunction>> {
-        return ExtractionResult(ehrPatientRecord.measurements.filter {
+    override fun extract(feedPatientRecord: FeedPatientRecord): ExtractionResult<List<VitalFunction>> {
+        return ExtractionResult(feedPatientRecord.measurements.filter {
             !setOf(
                 ProvidedMeasurementCategory.BMI,
                 ProvidedMeasurementCategory.BODY_HEIGHT,

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
@@ -4,8 +4,6 @@ import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.config.PriorPrimaryConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
 import com.hartwig.actin.clinical.feed.standard.FeedTestData
-import com.hartwig.actin.clinical.feed.standard.OTHER_CONDITION_INPUT
-import com.hartwig.actin.clinical.feed.standard.TREATMENT_HISTORY_INPUT
 import com.hartwig.actin.datamodel.clinical.PriorPrimary
 import com.hartwig.actin.datamodel.clinical.TumorStatus
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
@@ -40,16 +38,6 @@ private val PATIENT_RECORD = FeedTestData.FEED_PATIENT_RECORD.copy(
     priorPrimaries = listOf(DatedEntry(name = PRIOR_PRIMARY_INPUT, startDate = DIAGNOSIS_DATE, endDate = LAST_TREATMENT_DATE))
 )
 
-private val FEED_OTHER_CONDITION = DatedEntry(name = OTHER_CONDITION_INPUT, startDate = LocalDate.of(2023, 1, 1))
-
-private val SECOND_PRIMARY_CONFIG = PriorPrimaryConfig(
-    ignore = false,
-    input = TREATMENT_HISTORY_INPUT,
-    curated = BRAIN_PRIOR_SECOND_PRIMARY
-)
-
-private val LUNG_PRIOR_SECOND_PRIMARY = BRAIN_PRIOR_SECOND_PRIMARY.copy(tumorLocation = "lung")
-
 class StandardPriorPrimariesExtractorTest {
 
     private val priorPrimaryConfigCurationDatabase = mockk<CurationDatabase<PriorPrimaryConfig>> {
@@ -80,6 +68,33 @@ class StandardPriorPrimariesExtractorTest {
     }
 
     @Test
+    fun `Should curate and extract multiple prior primaries for one input when defined`() {
+        val input = "brain | type | prior primaries in kidney and liver"
+        val kidneyPrior = PriorPrimary("kidney", "", "Carcinoma", "", treatmentHistory = "", status = TumorStatus.INACTIVE)
+        val liverPrior = kidneyPrior.copy(tumorLocation = "liver")
+
+        every { priorPrimaryConfigCurationDatabase.find(input) } returns setOf(
+            PriorPrimaryConfig(ignore = false, input = input, curated = kidneyPrior),
+            PriorPrimaryConfig(ignore = false, input = input, curated = liverPrior)
+        )
+        val patientWithMultiplePrimaries = FeedTestData.FEED_PATIENT_RECORD.copy(
+            priorPrimaries = listOf(DatedEntry(name = input, startDate = DIAGNOSIS_DATE, endDate = LAST_TREATMENT_DATE))
+        )
+
+        val result = extractor.extract(patientWithMultiplePrimaries)
+        val expectedKidneyPrior = kidneyPrior.copy(
+            diagnosedMonth = DIAGNOSIS_DATE.monthValue,
+            diagnosedYear = DIAGNOSIS_DATE.year,
+            lastTreatmentYear = LAST_TREATMENT_DATE.year,
+            lastTreatmentMonth = LAST_TREATMENT_DATE.monthValue
+        )
+        val expectedLiverPrior = expectedKidneyPrior.copy(tumorLocation = "liver")
+        assertThat(result.extracted).containsExactly(expectedKidneyPrior, expectedLiverPrior)
+        assertThat(result.evaluation).isEqualTo(CurationExtractionEvaluation(priorPrimaryEvaluatedInputs = setOf(input)))
+        assertThat(result.evaluation.warnings).isEmpty()
+    }
+
+    @Test
     fun `Should return curation warning when input not found`() {
         every { priorPrimaryConfigCurationDatabase.find(PRIOR_PRIMARY_INPUT) } returns emptySet()
         val result = extractor.extract(PATIENT_RECORD)
@@ -104,52 +119,6 @@ class StandardPriorPrimariesExtractorTest {
         )
         val result = extractor.extract(PATIENT_RECORD)
         assertThat(result.extracted).isEmpty()
-        assertThat(result.evaluation.warnings).isEmpty()
-    }
-
-    @Test
-    fun `Should curate and extract prior primaries from other conditions, supporting multiple configs per input, ignoring warnings`() {
-        every { priorPrimaryConfigCurationDatabase.find(OTHER_CONDITION_INPUT) } returns setOf(
-            SECOND_PRIMARY_CONFIG.copy(input = OTHER_CONDITION_INPUT),
-            SECOND_PRIMARY_CONFIG.copy(
-                input = OTHER_CONDITION_INPUT,
-                curated = LUNG_PRIOR_SECOND_PRIMARY
-            )
-        )
-        val result = extractor.extract(
-            PATIENT_RECORD.copy(
-                priorPrimaries = emptyList(),
-                otherConditions = listOf(
-                    FEED_OTHER_CONDITION,
-                    FEED_OTHER_CONDITION.copy(name = "another prior condition")
-                )
-            )
-        )
-        assertThat(result.extracted).containsExactly(BRAIN_PRIOR_SECOND_PRIMARY, LUNG_PRIOR_SECOND_PRIMARY)
-        assertThat(result.evaluation).isEqualTo(CurationExtractionEvaluation(priorPrimaryEvaluatedInputs = setOf(OTHER_CONDITION_INPUT)))
-        assertThat(result.evaluation.warnings).isEmpty()
-    }
-
-    @Test
-    fun `Should curate and extract prior primaries from treatment history but ignore curation warnings, supporting multiple configs per input, ignoring warnings`() {
-        every { priorPrimaryConfigCurationDatabase.find(TREATMENT_HISTORY_INPUT) } returns setOf(
-            SECOND_PRIMARY_CONFIG.copy(input = TREATMENT_HISTORY_INPUT),
-            SECOND_PRIMARY_CONFIG.copy(
-                input = TREATMENT_HISTORY_INPUT,
-                curated = LUNG_PRIOR_SECOND_PRIMARY
-            )
-        )
-        val result = extractor.extract(
-            PATIENT_RECORD.copy(
-                priorPrimaries = emptyList(),
-                treatmentHistory = listOf(
-                    FeedTestData.FEED_TREATMENT_HISTORY.copy(name = TREATMENT_HISTORY_INPUT),
-                    FeedTestData.FEED_TREATMENT_HISTORY.copy(name = "another treatment")
-                )
-            )
-        )
-        assertThat(result.extracted).containsExactly(BRAIN_PRIOR_SECOND_PRIMARY, LUNG_PRIOR_SECOND_PRIMARY)
-        assertThat(result.evaluation).isEqualTo(CurationExtractionEvaluation(priorPrimaryEvaluatedInputs = setOf(TREATMENT_HISTORY_INPUT)))
         assertThat(result.evaluation.warnings).isEmpty()
     }
 

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
@@ -123,7 +123,7 @@ class StandardPriorPrimariesExtractorTest {
     }
 
     @Test
-    fun `Should always use diagnosis year and month from feed, even when in curation data `() {
+    fun `Should always use diagnosis year and month from feed, even when in curation data`() {
         every { priorPrimaryConfigCurationDatabase.find(PRIOR_PRIMARY_INPUT) } returns setOf(
             PriorPrimaryConfig(
                 ignore = false,


### PR DESCRIPTION
Allow one input to be curated into multiple prior primaries.