### PR TITLE
ACTIN-2088: Fix bug filtering trials with molecular criteria from cohorts with no slots available from interational trials

### DIFF
--- a/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
+++ b/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
@@ -57,7 +57,7 @@ class TrialsProvider(
     }
 
     private fun eligibleCohortsWithSlotsAvailableAndNotIgnore(): List<InterpretedCohort> {
-        return filterCohortsAvailable(cohorts.filter { !it.ignore })
+        return filterCohortsAvailable(cohorts.filter { !it.ignore && it.hasSlotsAvailable })
     }
 
     private fun externalEligibleTrials(): Set<EventWithExternalTrial> {


### PR DESCRIPTION
Code doesn't match function name. Resulting in international trials with same molecular criterium as a national trial with cohort _without slots_ being filtered (though you only want to filter if the cohort has slots available).

Tested on vm -> issue solved