### PR TITLE
ACTIN-2094: Remove combined evidence filter from ACTIN

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/ServeVerifier.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/evidence/ServeVerifier.kt
@@ -16,10 +16,9 @@ object ServeVerifier {
     }
 
     private fun verifyNoCombinedMolecularProfiles(serveRecord: ServeRecord) {
-        val hasCombinedEvidence = serveRecord.evidences().any { evidence -> isCombinedProfile(evidence.molecularCriterium()) }
         val hasCombinedTrials = serveRecord.trials().any { trial -> trial.anyMolecularCriteria().any { isCombinedProfile(it) } }
 
-        if (hasCombinedEvidence || hasCombinedTrials) {
+        if (hasCombinedTrials) {
             throw IllegalStateException("SERVE record contains combined profiles")
         }
     }

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/ServeCleanerTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/ServeCleanerTest.kt
@@ -8,18 +8,29 @@ import org.junit.Test
 class ServeCleanerTest {
 
     @Test
-    fun `Should remove evidences with combined criteria`() {
-        val evidence = TestServeEvidenceFactory.create(molecularCriterium = COMBINED_PROFILE)
-        val database = createServeDatabase(evidence, TestServeTrialFactory.createTrialForGene())
+    fun `Should remove combined criteria from trials also containing single criteria`() {
+        val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(COMBINED_PROFILE, SINGLE_PROFILE_1))
+        val evidence = TestServeEvidenceFactory.create()
+        val database = createServeDatabase(evidence, trial)
+
         val cleanDatabase = ServeCleaner.cleanServeDatabase(database)
-        cleanDatabase.records().values.forEach { assertThat(it.evidences()).isEmpty() }
+
+        cleanDatabase.records().values.forEach { record ->
+            assertThat(record.trials().size).isEqualTo(1)
+            assertThat(record.trials().first().anyMolecularCriteria()).containsExactly(SINGLE_PROFILE_1)
+        }
     }
 
     @Test
-    fun `Should retain evidences with simple criteria`() {
-        val evidence = TestServeEvidenceFactory.create(molecularCriterium = SINGLE_PROFILE_1)
-        val database = createServeDatabase(evidence, TestServeTrialFactory.createTrialForGene())
+    fun `Should completely remove trials containing only combined criteria`() {
+        val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(COMBINED_PROFILE))
+        val evidence = TestServeEvidenceFactory.create()
+        val database = createServeDatabase(evidence, trial)
+
         val cleanDatabase = ServeCleaner.cleanServeDatabase(database)
-        assertThat(cleanDatabase).isEqualTo(database)
+
+        cleanDatabase.records().values.forEach { record ->
+            assertThat(record.trials()).isEmpty()
+        }
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/ServeVerifierTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/ServeVerifierTest.kt
@@ -29,17 +29,7 @@ class ServeVerifierTest {
 
         assertThatIllegalStateException().isThrownBy { ServeVerifier.verifyServeDatabase(database) }
     }
-
-    @Test
-    fun `Should throw exception on evidence based on a combined profile`() {
-        val evidence = TestServeEvidenceFactory.create(molecularCriterium = COMBINED_PROFILE)
-        val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(SINGLE_PROFILE_1, SINGLE_PROFILE_2))
-
-        val database = createServeDatabase(evidence, trial)
-
-        assertThatIllegalStateException().isThrownBy { ServeVerifier.verifyServeDatabase(database) }
-    }
-
+    
     @Test
     fun `Should throw exception for hotspot with inconsistent genes in efficacy evidence`() {
         val evidence = TestServeEvidenceFactory.create(


### PR DESCRIPTION
Changed the trial filtering slightly to drop criteria that are multi but keep singles.