### PR TITLE
ACTIN-2058: Remove tumor (sub)location and tumor (sub)type from prior primary data model

### DIFF
--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/priortumor/PriorTumorTestFactory.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/priortumor/PriorTumorTestFactory.kt
@@ -17,10 +17,7 @@ internal object PriorTumorTestFactory {
         status: TumorStatus = TumorStatus.INACTIVE
     ): PriorPrimary {
         return PriorPrimary(
-            tumorLocation = "",
-            tumorSubLocation = "",
-            tumorType = "",
-            tumorSubType = "",
+            name = "",
             doids = setOfNotNull(doid),
             diagnosedYear = diagnosedYear,
             diagnosedMonth = diagnosedMonth,

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasLimitedCumulativeAnthracyclineExposureTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasLimitedCumulativeAnthracyclineExposureTest.kt
@@ -91,11 +91,8 @@ class HasLimitedCumulativeAnthracyclineExposureTest {
 
         private fun priorPrimary(treatmentHistory: String = ""): PriorPrimary {
             return PriorPrimary(
+                name = "",
                 doids = setOf(SUSPICIOUS_CANCER_TYPE),
-                tumorLocation = "",
-                tumorSubLocation = "",
-                tumorType = "",
-                tumorSubType = "",
                 treatmentHistory = treatmentHistory,
                 status = TumorStatus.INACTIVE
             )

--- a/clinical/README.md
+++ b/clinical/README.md
@@ -19,11 +19,6 @@ java -cp actin.jar com.hartwig.actin.clinical.ClinicalIngestionApplicationKt \
    -output_directory /path/to/where/clinical_json_files/are/written
 ```
 
-## ACTIN clinical model for providers
-
-Data providers can provide clinical data in JSON adhering to
-the [following format](src/main/resources/json_schema/provided_clinical_data.schema.json)
-
 ## ACTIN clinical datamodel used internally
 
 In ACTIN, the clinical feed as described above, is mapped onto the ACTIN clinical data model.
@@ -140,10 +135,7 @@ The details may include multiple treatment stages representing switches from the
 
 | Field            | Origin                                     |
 |------------------|--------------------------------------------|
-| tumorLocation    | Previous primary tumors: Tumor location    |
-| tumorSubLocation | Previous primary tumors: Tumor location    |
-| tumorType        | Previous primary tumors: Tumor type        |
-| tumorSubType     | Previous primary tumors: Tumor type        |
+| name             | Added in curation                          |
 | doids            | Added in curation                          |
 | diagnosedYear    | Previous primary tumors: Diagnosis date    |
 | diagnosedMonth   | Previous primary tumors: Diagnosis date    |

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/PriorPrimaryConfigFactory.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/curation/config/PriorPrimaryConfigFactory.kt
@@ -44,10 +44,7 @@ class PriorPrimaryConfigFactory(private val curationDoidValidator: CurationDoidV
         tumorStatus: TumorStatus, fields: Map<String, Int>, parts: Array<String>, doids: Set<String>
     ): PriorPrimary {
         return PriorPrimary(
-            tumorLocation = parts[fields["tumorLocation"]!!],
-            tumorSubLocation = parts[fields["tumorSubLocation"]!!],
-            tumorType = parts[fields["tumorType"]!!],
-            tumorSubType = parts[fields["tumorSubType"]!!],
+            name = parts[fields["name"]!!],
             doids = doids,
             diagnosedYear = ResourceFile.optionalInteger(parts[fields["diagnosedYear"]!!]),
             diagnosedMonth = ResourceFile.optionalInteger(parts[fields["diagnosedMonth"]!!]),

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/config/PriorPrimaryConfigFactoryTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/curation/config/PriorPrimaryConfigFactoryTest.kt
@@ -22,10 +22,6 @@ class PriorPrimaryConfigFactoryTest {
             arrayOf(
                 "input",
                 "name",
-                "tumorLocation",
-                "tumorSubLocation",
-                "tumorType",
-                "tumorSubType",
                 "123",
                 "2023",
                 "12",
@@ -39,10 +35,7 @@ class PriorPrimaryConfigFactoryTest {
         assertThat(config.config.input).isEqualTo("input")
         assertThat(config.config.ignore).isFalse()
         val priorPrimary = config.config.curated!!
-        assertThat(priorPrimary.tumorLocation).isEqualTo("tumorLocation")
-        assertThat(priorPrimary.tumorSubLocation).isEqualTo("tumorSubLocation")
-        assertThat(priorPrimary.tumorType).isEqualTo("tumorType")
-        assertThat(priorPrimary.tumorSubType).isEqualTo("tumorSubType")
+        assertThat(priorPrimary.name).isEqualTo("name")
         assertThat(priorPrimary.doids).containsExactly("123")
         assertThat(priorPrimary.diagnosedYear).isEqualTo(2023)
         assertThat(priorPrimary.diagnosedMonth).isEqualTo(12)
@@ -60,10 +53,6 @@ class PriorPrimaryConfigFactoryTest {
             arrayOf(
                 "input",
                 "name",
-                "tumorLocation",
-                "tumorSubLocation",
-                "tumorType",
-                "tumorSubType",
                 "123",
                 "2023",
                 "12",
@@ -94,10 +83,6 @@ class PriorPrimaryConfigFactoryTest {
             arrayOf(
                 "input",
                 "name",
-                "tumorLocation",
-                "tumorSubLocation",
-                "tumorType",
-                "tumorSubType",
                 "123",
                 "2023",
                 "12",
@@ -128,10 +113,6 @@ class PriorPrimaryConfigFactoryTest {
             arrayOf(
                 "input",
                 "<ignore>",
-                "",
-                "",
-                "",
-                "",
                 "",
                 "",
                 "",

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/extraction/PriorPrimaryExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/emc/extraction/PriorPrimaryExtractorTest.kt
@@ -17,7 +17,7 @@ private const val CANNOT_CURATE = "cannot curate"
 
 private const val SECOND_PRIMARY_INPUT = "Second primary input"
 
-private const val TUMOR_LOCATION_INTERPRETATION = "Tumor location interpretation"
+private const val NAME_INTERPRETATION = "Name interpretation"
 
 private const val TREATMENT_HISTORY_INPUT = "Treatment history input"
 
@@ -28,12 +28,9 @@ class PriorPrimaryExtractorTest {
                 input = SECOND_PRIMARY_INPUT,
                 ignore = false,
                 curated = PriorPrimary(
-                    status = TumorStatus.ACTIVE,
-                    tumorType = "tumorType",
-                    tumorSubType = "tumorSubType",
+                    name = NAME_INTERPRETATION,
                     treatmentHistory = "treatmentHistory",
-                    tumorLocation = TUMOR_LOCATION_INTERPRETATION,
-                    tumorSubLocation = "tumorSubLocation"
+                    status = TumorStatus.ACTIVE,
                 )
             )
         ),
@@ -50,7 +47,7 @@ class PriorPrimaryExtractorTest {
         val questionnaire = emptyQuestionnaire().copy(secondaryPrimaries = inputs)
         val (priorPrimaries, evaluation) = extractor.extract(PATIENT_ID, questionnaire)
         assertThat(priorPrimaries).hasSize(1)
-        assertThat(priorPrimaries[0].tumorLocation).isEqualTo(TUMOR_LOCATION_INTERPRETATION)
+        assertThat(priorPrimaries[0].name).isEqualTo(NAME_INTERPRETATION)
 
         assertThat(evaluation.warnings).containsOnly(
             CurationWarning(

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardPriorPrimariesExtractorTest.kt
@@ -19,14 +19,11 @@ private const val BRAIN_LOCATION = "brain"
 private const val TYPE = "type"
 
 private val BRAIN_PRIOR_SECOND_PRIMARY = PriorPrimary(
-    tumorLocation = BRAIN_LOCATION,
-    tumorType = TYPE,
-    status = TumorStatus.ACTIVE,
+    name = "$BRAIN_LOCATION $TYPE",
     diagnosedYear = null,
     diagnosedMonth = null,
-    tumorSubLocation = "",
-    tumorSubType = "",
-    treatmentHistory = ""
+    treatmentHistory = "",
+    status = TumorStatus.ACTIVE,
 )
 
 private val DIAGNOSIS_DATE = LocalDate.of(2024, 2, 23)
@@ -70,8 +67,8 @@ class StandardPriorPrimariesExtractorTest {
     @Test
     fun `Should curate and extract multiple prior primaries for one input when defined`() {
         val input = "brain | type | prior primaries in kidney and liver"
-        val kidneyPrior = PriorPrimary("kidney", "", "Carcinoma", "", treatmentHistory = "", status = TumorStatus.INACTIVE)
-        val liverPrior = kidneyPrior.copy(tumorLocation = "liver")
+        val kidneyPrior = PriorPrimary(name = "kidney", doids = setOf("1000"), treatmentHistory = "", status = TumorStatus.INACTIVE)
+        val liverPrior = kidneyPrior.copy(name = "liver")
 
         every { priorPrimaryConfigCurationDatabase.find(input) } returns setOf(
             PriorPrimaryConfig(ignore = false, input = input, curated = kidneyPrior),
@@ -88,7 +85,7 @@ class StandardPriorPrimariesExtractorTest {
             lastTreatmentYear = LAST_TREATMENT_DATE.year,
             lastTreatmentMonth = LAST_TREATMENT_DATE.monthValue
         )
-        val expectedLiverPrior = expectedKidneyPrior.copy(tumorLocation = "liver")
+        val expectedLiverPrior = expectedKidneyPrior.copy(name = "liver")
         assertThat(result.extracted).containsExactly(expectedKidneyPrior, expectedLiverPrior)
         assertThat(result.evaluation).isEqualTo(CurationExtractionEvaluation(priorPrimaryEvaluatedInputs = setOf(input)))
         assertThat(result.evaluation.warnings).isEmpty()

--- a/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
@@ -123,14 +123,11 @@
   ],
   "priorPrimaries": [
     {
-      "tumorLocation": "Prostate",
-      "tumorSubLocation": "",
-      "tumorType": "Carcinoma",
-      "tumorSubType": "",
+      "name": "Prostate carcinoma",
       "doids": [
         "10286"
       ],
-      "diagnosedYear": 2019,
+      "diagnosedYear": null,
       "diagnosedMonth": null,
       "treatmentHistory": "",
       "lastTreatmentYear": 2019,

--- a/clinical/src/test/resources/curation/prior_primary.tsv
+++ b/clinical/src/test/resources/curation/prior_primary.tsv
@@ -1,2 +1,2 @@
-input	name	tumorLocation	tumorSubLocation	tumorType	tumorSubType	doids	diagnosedYear	diagnosedMonth	treatmentHistory	lastTreatmentYear	lastTreatmentMonth	status
-Prostate carconoma | last treatment date: 2019	Prostate carcinoma	Prostate		Carcinoma		10286	2019			2019		ACTIVE
+input	name	doids	diagnosedYear	diagnosedMonth	treatmentHistory	lastTreatmentYear	lastTreatmentMonth	status
+Prostate carconoma | last treatment date: 2019	Prostate carcinoma	10286				2019		ACTIVE

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/sort/PriorPrimaryDiagnosedDateComparator.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/sort/PriorPrimaryDiagnosedDateComparator.kt
@@ -7,7 +7,7 @@ class PriorPrimaryDiagnosedDateComparator : Comparator<PriorPrimary> {
     private val nullSafeComparator = Comparator.nullsLast(Comparator.naturalOrder<Int?>())
     private val comparator = Comparator.comparing(PriorPrimary::diagnosedYear, nullSafeComparator)
         .thenComparing(PriorPrimary::diagnosedMonth, nullSafeComparator)
-        .thenComparing(PriorPrimary::tumorLocation)
+        .thenComparing(PriorPrimary::name)
 
     override fun compare(priorPrimary1: PriorPrimary, priorPrimary2: PriorPrimary): Int {
         return comparator.compare(priorPrimary1, priorPrimary2)

--- a/common/src/test/resources/clinical/records/patient.clinical.json
+++ b/common/src/test/resources/clinical/records/patient.clinical.json
@@ -75,10 +75,7 @@
   ],
   "priorPrimaries": [
     {
-      "tumorLocation": "Skin",
-      "tumorSubLocation": "",
-      "tumorType": "Melanoma",
-      "tumorSubType": "",
+      "name": "Skin melanoma",
       "doids": [
         "162"
       ],

--- a/database/src/main/kotlin/com/hartwig/actin/database/dao/ClinicalDAO.kt
+++ b/database/src/main/kotlin/com/hartwig/actin/database/dao/ClinicalDAO.kt
@@ -271,10 +271,7 @@ internal class ClinicalDAO(private val context: DSLContext) {
             context.insertInto(
                 Tables.PRIORPRIMARY,
                 Tables.PRIORPRIMARY.PATIENTID,
-                Tables.PRIORPRIMARY.TUMORLOCATION,
-                Tables.PRIORPRIMARY.TUMORSUBLOCATION,
-                Tables.PRIORPRIMARY.TUMORTYPE,
-                Tables.PRIORPRIMARY.TUMORSUBTYPE,
+                Tables.PRIORPRIMARY.NAME,
                 Tables.PRIORPRIMARY.DOIDS,
                 Tables.PRIORPRIMARY.DIAGNOSEDYEAR,
                 Tables.PRIORPRIMARY.DIAGNOSEDMONTH,
@@ -285,10 +282,7 @@ internal class ClinicalDAO(private val context: DSLContext) {
             )
                 .values(
                     patientId,
-                    priorPrimary.tumorLocation,
-                    priorPrimary.tumorSubLocation,
-                    priorPrimary.tumorType,
-                    priorPrimary.tumorSubType,
+                    priorPrimary.name,
                     DataUtil.concat(priorPrimary.doids),
                     priorPrimary.diagnosedYear,
                     priorPrimary.diagnosedMonth,

--- a/database/src/main/resources/generate_database.sql
+++ b/database/src/main/resources/generate_database.sql
@@ -102,10 +102,7 @@ DROP TABLE IF EXISTS `priorPrimary`;
 CREATE TABLE `priorPrimary`
 (   `id` int NOT NULL AUTO_INCREMENT,
     `patientId` varchar(50) NOT NULL,
-    `tumorLocation` varchar(50) NOT NULL,
-    `tumorSubLocation` varchar(50) NOT NULL,
-    `tumorType` varchar(50) NOT NULL,
-    `tumorSubType` varchar(50) NOT NULL,
+    `name` varchar(100) NOT NULL,
     `doids` varchar(50) NOT NULL,
     `diagnosedYear` int,
     `diagnosedMonth` int,

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorPrimary.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/PriorPrimary.kt
@@ -1,10 +1,7 @@
 package com.hartwig.actin.datamodel.clinical
 
 data class PriorPrimary(
-    val tumorLocation: String,
-    val tumorSubLocation: String,
-    val tumorType: String,
-    val tumorSubType: String,
+    val name: String,
     val doids: Set<String> = emptySet(),
     val diagnosedYear: Int? = null,
     val diagnosedMonth: Int? = null,

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestClinicalFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestClinicalFactory.kt
@@ -271,17 +271,14 @@ object TestClinicalFactory {
     private fun createTestPriorPrimaries(): List<PriorPrimary> {
         return listOf(
             PriorPrimary(
-                tumorLocation = "Lung",
-                tumorSubLocation = "",
-                tumorType = "Carcinoma",
-                tumorSubType = "Adenocarcinoma",
+                name = "Lung adenocarcinoma",
                 doids = setOf("3905"),
                 diagnosedYear = FIXED_DATE.year - YEARS_SINCE_SECOND_PRIMARY_DIAGNOSIS,
                 diagnosedMonth = FIXED_DATE.monthValue,
                 treatmentHistory = "Surgery",
-                status = TumorStatus.INACTIVE,
                 lastTreatmentYear = null,
-                lastTreatmentMonth = null
+                lastTreatmentMonth = null,
+                status = TumorStatus.INACTIVE
             )
         )
     }

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestPriorPrimaryFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/clinical/TestPriorPrimaryFactory.kt
@@ -4,10 +4,7 @@ object TestPriorPrimaryFactory {
 
     fun createMinimal(): PriorPrimary {
         return PriorPrimary(
-            tumorLocation = "",
-            tumorSubLocation = "",
-            tumorType = "",
-            tumorSubType = "",
+            name = "",
             treatmentHistory = "",
             status = TumorStatus.INACTIVE
         )

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -197,19 +197,6 @@ class PatientClinicalHistoryGenerator(
     }
 
     private fun toPriorPrimaryString(priorPrimary: PriorPrimary): String {
-        val tumorSubLocation = priorPrimary.tumorSubLocation
-        val tumorLocation = priorPrimary.tumorLocation + if (tumorSubLocation.isNotEmpty()) " ($tumorSubLocation)" else ""
-        val tumorDetails = when {
-            priorPrimary.tumorSubType.isNotEmpty() -> {
-                tumorLocation + " " + priorPrimary.tumorSubType.lowercase()
-            }
-
-            priorPrimary.tumorType.isNotEmpty() -> {
-                tumorLocation + " " + priorPrimary.tumorType.lowercase()
-            }
-
-            else -> tumorLocation
-        }
         val dateAdditionDiagnosis: String = toDateString(priorPrimary.diagnosedYear, priorPrimary.diagnosedMonth)
             ?.let { "diagnosed $it, " } ?: ""
 
@@ -222,7 +209,7 @@ class PatientClinicalHistoryGenerator(
             TumorStatus.EXPECTATIVE -> "considered expectative"
             TumorStatus.UNKNOWN -> "unknown if active"
         }
-        return "$tumorDetails ($dateAdditionDiagnosis$dateAdditionLastTreatment$status)"
+        return "${priorPrimary.name} ($dateAdditionDiagnosis$dateAdditionLastTreatment$status)"
     }
 
     private fun toOtherConditionString(otherCondition: OtherCondition): String {


### PR DESCRIPTION
See title

Upon merge I'll fix the curation sheets (only deleting 4 columns, we have the 'name' column already).