### PR TITLE
ACTIN-527: Improve 'within X months' algo rules by adding logic for selecting treatment lines by ordering on treatment dates

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/CurrentlyGetsChemoradiotherapyWithSpecificChemotherapyTypeAndMinimumCycles.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/CurrentlyGetsChemoradiotherapyWithSpecificChemotherapyTypeAndMinimumCycles.kt
@@ -48,7 +48,8 @@ class CurrentlyGetsChemoradiotherapyWithSpecificChemotherapyTypeAndMinimumCycles
         val treatmentHistoryDetails = treatmentHistoryEntry.treatmentHistoryDetails
         return treatmentHistoryDetails?.cycles?.let { cycles ->
             val appearsOngoing = with(treatmentHistoryDetails) {
-                val treatmentNotStopped = DateComparison.isAfterDate(referenceDate, stopYear, stopMonth)
+                val treatmentNotStopped =
+                    DateComparison.isAfterDate(referenceDate, treatmentHistoryEntry.stopYear(), treatmentHistoryEntry.stopMonth())
                 treatmentNotStopped == true ||
                     (treatmentNotStopped == null && latestStart?.let {
                         DateComparison.isAfterDate(latestStart, treatmentHistoryEntry.startYear, treatmentHistoryEntry.startMonth)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
@@ -26,8 +26,8 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes(
                 val durationWeeks: Long? = DateComparison.minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.stopYear(), //checken
-                    matchingPortionOfEntry.stopMonth() //checken
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
                 )
 
                 TreatmentEvaluation.create(

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
@@ -26,8 +26,8 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes(
                 val durationWeeks: Long? = DateComparison.minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
+                    matchingPortionOfEntry.stopYear(), //checken
+                    matchingPortionOfEntry.stopMonth() //checken
                 )
 
                 TreatmentEvaluation.create(

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -27,8 +27,8 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
                 val durationWeeks: Long? = DateComparison.minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
+                    matchingPortionOfEntry.stopYear(), //checken
+                    matchingPortionOfEntry.stopMonth() //checken
                 )
                 val meetsMaxWeeks = if (maxWeeks != null) durationWeeks != null && durationWeeks <= maxWeeks else true
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -30,14 +30,23 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
                     matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
                     matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
                 )
-                val meetsMaxWeeks = if (maxWeeks != null) durationWeeks != null && durationWeeks <= maxWeeks else true
+                val durationWeeksMax: Long? = DateComparison.minWeeksBetweenDates(
+                    matchingPortionOfEntry.startYear,
+                    matchingPortionOfEntry.startMonth,
+                    matchingPortionOfEntry.stopYear(),
+                    matchingPortionOfEntry.stopMonth()
+                )
+
+                val meetsMaxWeeks = if (maxWeeks != null) durationWeeksMax != null && durationWeeksMax <= maxWeeks else true
+                val meetsUnclearWeeks =
+                    if (maxWeeks != null) durationWeeks == null && ((durationWeeksMax != null && durationWeeksMax > maxWeeks) || durationWeeksMax == null) else false
 
                 PDFollowingTreatmentEvaluation.create(
                     hadTreatment = true,
                     hadTrial = mayMatchAsTrial,
                     hadPD = treatmentResultedInPD,
                     lessThanMaxWeeks = meetsMaxWeeks,
-                    hadUnclearWeeks = if (maxWeeks != null) durationWeeks == null else false
+                    hadUnclearWeeks = meetsUnclearWeeks
                 )
             } ?: PDFollowingTreatmentEvaluation.create(
                 hadTreatment = if (categoryMatches && !treatmentHistoryEntry.hasTypeConfigured()) null else false,

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -27,8 +27,8 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
                 val durationWeeks: Long? = DateComparison.minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.stopYear(), //checken
-                    matchingPortionOfEntry.stopMonth() //checken
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
                 )
                 val meetsMaxWeeks = if (maxWeeks != null) durationWeeks != null && durationWeeks <= maxWeeks else true
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSomeSystemicTreatments.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSomeSystemicTreatments.kt
@@ -42,9 +42,7 @@ class HasHadPDFollowingSomeSystemicTreatments(
                 EvaluationFactory.pass("Last systemic treatment resulted in PD$radiologicalNote")
             }
 
-            lastTreatment?.let {
-                it.treatmentHistoryDetails?.stopReason == StopReason.TOXICITY || it.treatmentHistoryDetails?.stopYear == null
-            } == true -> {
+            lastTreatment?.let { it.treatmentHistoryDetails?.stopReason == StopReason.TOXICITY || it.stopYear() == null } == true -> {
                 EvaluationFactory.undetermined(undeterminedMessage)
             }
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -31,8 +31,8 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
                 val durationWeeks: Long? = minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.stopYear(), //checken
-                    matchingPortionOfEntry.stopMonth() //checken
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
+                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
                 )
                 val meetsMinCycles = minCycles == null || (cycles != null && cycles >= minCycles)
                 val meetsMinWeeks = minWeeks == null || (durationWeeks != null && durationWeeks >= minWeeks)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -31,8 +31,8 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
                 val durationWeeks: Long? = minWeeksBetweenDates(
                     matchingPortionOfEntry.startYear,
                     matchingPortionOfEntry.startMonth,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopYear,
-                    matchingPortionOfEntry.treatmentHistoryDetails?.stopMonth
+                    matchingPortionOfEntry.stopYear(), //checken
+                    matchingPortionOfEntry.stopMonth() //checken
                 )
                 val meetsMinCycles = minCycles == null || (cycles != null && cycles >= minCycles)
                 val meetsMinWeeks = minWeeks == null || (durationWeeks != null && durationWeeks >= minWeeks)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSystemicTreatmentInAdvancedOrMetastaticSetting.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSystemicTreatmentInAdvancedOrMetastaticSetting.kt
@@ -19,7 +19,7 @@ class HasHadSystemicTreatmentInAdvancedOrMetastaticSetting(private val reference
         val (curativeTreatments, nonCurativeTreatments) = priorSystemicTreatments.partition { it.intents?.contains(Intent.CURATIVE) == true }
         val (recentNonCurativeTreatments, nonRecentNonCurativeTreatments) = partitionRecentTreatments(nonCurativeTreatments, false)
         val (recentNonCurativeTreatmentsIncludingUnknown, _) = partitionRecentTreatments(nonCurativeTreatments, true)
-        val nonCurativeTreatmentsWithUnknownStopDate = nonCurativeTreatments.filter { it.treatmentHistoryDetails?.stopYear == null }
+        val nonCurativeTreatmentsWithUnknownStopDate = nonCurativeTreatments.filter { it.stopYear() == null }
         val palliativeIntentTreatments = priorSystemicTreatments.filter { it.intents?.contains(Intent.PALLIATIVE) == true }
 
         return when {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/ProgressiveDiseaseFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/ProgressiveDiseaseFunctions.kt
@@ -18,8 +18,8 @@ object ProgressiveDiseaseFunctions {
         val treatmentDuration = DateComparison.minWeeksBetweenDates(
             treatment.startYear,
             treatment.startMonth,
-            treatment.treatmentHistoryDetails?.stopYear,
-            treatment.treatmentHistoryDetails?.stopMonth
+            treatment.stopYear(),
+            treatment.stopMonth()
         )
 
         return when {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/SystemicTreatmentAnalyser.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/SystemicTreatmentAnalyser.kt
@@ -19,8 +19,8 @@ object SystemicTreatmentAnalyser {
                     compareBy(
                         TreatmentHistoryEntry::startYear,
                         TreatmentHistoryEntry::startMonth,
-                        { it.treatmentHistoryDetails?.stopYear },
-                        { it.treatmentHistoryDetails?.stopMonth },
+                        { it.stopYear() },
+                        { it.stopMonth() },
                         TreatmentHistoryEntry::treatmentName
                     )
                 )

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
@@ -33,14 +33,14 @@ object TreatmentVersusDateFunctions {
     }
 
     fun treatmentSinceMinDate(treatment: TreatmentHistoryEntry, minDate: LocalDate, includeUnknown: Boolean): Boolean {
-        return DateComparison.isAfterDate(
-            minDate, treatment.treatmentHistoryDetails?.stopYear, treatment.treatmentHistoryDetails?.stopMonth
-        )
+        return DateComparison.isAfterDate(minDate, treatment.stopYear(), treatment.stopMonth())
             ?: DateComparison.isAfterDate(minDate, treatment.startYear, treatment.startMonth)
             ?: includeUnknown
     }
 
     fun treatmentBeforeMaxDate(treatment: TreatmentHistoryEntry, maxDate: LocalDate, includeUnknown: Boolean): Boolean {
+        // will remove this comment, but to explain: I don't use treatment.stopYear() here because it could be that this maxStopDate
+        // is too high, and the real stopDate is actually earlier on. This would lead to false evaluation although it is true.
         return DateComparison.isBeforeDate(
             maxDate, treatment.treatmentHistoryDetails?.stopYear, treatment.treatmentHistoryDetails?.stopMonth
         )

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/emc/EmcClinicalFeedIngestor.kt
@@ -27,6 +27,7 @@ import com.hartwig.actin.clinical.feed.emc.questionnaire.Questionnaire
 import com.hartwig.actin.clinical.feed.emc.questionnaire.QuestionnaireExtraction
 import com.hartwig.actin.clinical.feed.emc.vitalfunction.VitalFunctionEntry
 import com.hartwig.actin.clinical.feed.emc.vitalfunction.VitalFunctionExtraction
+import com.hartwig.actin.clinical.feed.treatment.TreatmentHistoryEntryFunctions
 import com.hartwig.actin.clinical.feed.tumor.TumorStageDeriver
 import com.hartwig.actin.datamodel.clinical.BodyWeight
 import com.hartwig.actin.datamodel.clinical.ClinicalRecord
@@ -85,7 +86,7 @@ class EmcClinicalFeedIngestor(
                 tumor = tumorExtraction.extracted,
                 comorbidities = comorbidities,
                 clinicalStatus = clinicalStatus,
-                oncologicalHistory = oncologicalHistoryExtraction.extracted,
+                oncologicalHistory = TreatmentHistoryEntryFunctions.setMaxStopDate(oncologicalHistoryExtraction.extracted),
                 priorPrimaries = priorPrimaryExtraction.extracted,
                 ihcTests = ihcTestsExtraction.extracted,
                 sequencingTests = sequencingTestExtraction.extracted,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardOncologicalHistoryExtractor.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/standard/extraction/StandardOncologicalHistoryExtractor.kt
@@ -5,6 +5,7 @@ import com.hartwig.actin.clinical.curation.CurationDatabase
 import com.hartwig.actin.clinical.curation.CurationResponse
 import com.hartwig.actin.clinical.curation.config.TreatmentHistoryEntryConfig
 import com.hartwig.actin.clinical.curation.extraction.CurationExtractionEvaluation
+import com.hartwig.actin.clinical.feed.treatment.TreatmentHistoryEntryFunctions
 import com.hartwig.actin.datamodel.clinical.ingestion.CurationCategory
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryDetails
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
@@ -22,7 +23,12 @@ class StandardOncologicalHistoryExtractor(
         val oncologicalTreatmentHistory = convertFeedEntriesToOncologicalHistory(feedPatientRecord.treatmentHistory, patientId)
 
         return ExtractionResult(
-            merge(oncologicalTreatmentHistory.extracted, oncologicalPreviousConditions.extracted),
+            TreatmentHistoryEntryFunctions.setMaxStopDate(
+                merge(
+                    oncologicalTreatmentHistory.extracted,
+                    oncologicalPreviousConditions.extracted
+                )
+            ),
             oncologicalTreatmentHistory.evaluation
         )
     }
@@ -58,8 +64,7 @@ class StandardOncologicalHistoryExtractor(
                             intents = curatedTreatment.intents,
                             treatmentHistoryDetails = TreatmentHistoryDetails(
                                 stopYear = curatedTreatment.treatmentHistoryDetails?.stopYear ?: ehrEntry.endDate?.year,
-                                stopMonth = curatedTreatment.treatmentHistoryDetails?.stopMonth
-                                    ?: ehrEntry.endDate?.monthValue,
+                                stopMonth = curatedTreatment.treatmentHistoryDetails?.stopMonth ?: ehrEntry.endDate?.monthValue,
                                 stopReason = curatedTreatment.treatmentHistoryDetails?.stopReason,
                                 bestResponse = curatedTreatment.treatmentHistoryDetails?.bestResponse,
                                 switchToTreatments = curatedTreatment.treatmentHistoryDetails?.switchToTreatments,

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctions.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctions.kt
@@ -1,0 +1,29 @@
+package com.hartwig.actin.clinical.feed.treatment
+
+import com.hartwig.actin.clinical.sort.TreatmentHistoryAscendingDateComparator
+import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryDetails
+import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
+
+object TreatmentHistoryEntryFunctions {
+
+    fun setMaxStopDate(treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
+        val (systemic, nonSystemic) = treatmentHistory.sortedWith(TreatmentHistoryAscendingDateComparator()).partition {
+            it.categories().all(TreatmentCategory.SYSTEMIC_CANCER_TREATMENT_CATEGORIES::contains)
+        }
+
+        val systemicWithStopDate = systemic.mapIndexed { index, current ->
+            if (current.treatmentHistoryDetails?.stopYear == null && index < systemic.size - 1) {
+                val next = systemic[index + 1]
+                current.copy(
+                    treatmentHistoryDetails = TreatmentHistoryDetails(
+                        maxStopYear = next.startYear,
+                        maxStopMonth = next.startMonth
+                    )
+                )
+            } else current
+        }
+
+        return systemicWithStopDate + nonSystemic
+    }
+}

--- a/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctions.kt
+++ b/clinical/src/main/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctions.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.clinical.sort.TreatmentHistoryAscendingDateComparator
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryDetails
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
+import java.time.LocalDate
 
 object TreatmentHistoryEntryFunctions {
 
@@ -13,14 +14,14 @@ object TreatmentHistoryEntryFunctions {
         }
 
         val systemicWithStopDate = systemic.mapIndexed { index, current ->
-            if (current.treatmentHistoryDetails?.stopYear == null && index < systemic.size - 1) {
-                val next = systemic[index + 1]
-                current.copy(
-                    treatmentHistoryDetails = TreatmentHistoryDetails(
-                        maxStopYear = next.startYear,
-                        maxStopMonth = next.startMonth
-                    )
-                )
+            if (current.treatmentHistoryDetails?.stopYear == null) {
+                val treatmentDetails = if (index < systemic.size - 1) {
+                    val next = systemic[index + 1]
+                    TreatmentHistoryDetails(maxStopYear = next.startYear, maxStopMonth = next.startMonth)
+                } else {
+                    TreatmentHistoryDetails(maxStopYear = LocalDate.now().year, maxStopMonth = LocalDate.now().monthValue)
+                }
+                current.copy(treatmentHistoryDetails = treatmentDetails)
             } else current
         }
 

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -1,0 +1,44 @@
+package com.hartwig.actin.clinical.feed.treatment
+
+import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
+import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentHistoryEntry
+import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class TreatmentHistoryEntryFunctionsTest {
+
+    @Test
+    fun `Should set stop date`() {
+        val test = listOf(
+            treatmentHistoryEntry(
+                treatments = setOf(
+                    TreatmentTestFactory.treatment(
+                        "",
+                        true,
+                        setOf(TreatmentCategory.CHEMOTHERAPY)
+                    )
+                ), startYear = 2020, startMonth = 6
+            ),
+            treatmentHistoryEntry(
+                treatments = setOf(
+                    TreatmentTestFactory.treatment(
+                        "",
+                        true,
+                        setOf(TreatmentCategory.RADIOTHERAPY)
+                    )
+                ), startYear = 2020, startMonth = 7
+            ),
+            treatmentHistoryEntry(
+                treatments = setOf(TreatmentTestFactory.treatment("", true, setOf(TreatmentCategory.CHEMOTHERAPY))),
+                startYear = 2020,
+                startMonth = 9
+            )
+        )
+        val output = TreatmentHistoryEntryFunctions.setMaxStopDate(test)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isEqualTo(2020)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isEqualTo(9)
+        assertThat(output[1].treatmentHistoryDetails?.maxStopYear).isNull()
+        assertThat(output[1].treatmentHistoryDetails?.maxStopMonth).isNull()
+    }
+}

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -3,42 +3,70 @@ package com.hartwig.actin.clinical.feed.treatment
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class TreatmentHistoryEntryFunctionsTest {
 
     @Test
-    fun `Should set stop date`() {
-        val test = listOf(
-            treatmentHistoryEntry(
-                treatments = setOf(
-                    TreatmentTestFactory.treatment(
-                        "",
-                        true,
-                        setOf(TreatmentCategory.CHEMOTHERAPY)
-                    )
-                ), startYear = 2020, startMonth = 6
-            ),
-            treatmentHistoryEntry(
-                treatments = setOf(
-                    TreatmentTestFactory.treatment(
-                        "",
-                        true,
-                        setOf(TreatmentCategory.RADIOTHERAPY)
-                    )
-                ), startYear = 2020, startMonth = 7
-            ),
-            treatmentHistoryEntry(
-                treatments = setOf(TreatmentTestFactory.treatment("", true, setOf(TreatmentCategory.CHEMOTHERAPY))),
-                startYear = 2020,
-                startMonth = 9
-            )
-        )
-        val output = TreatmentHistoryEntryFunctions.setMaxStopDate(test)
+    fun `Should set stop date for systemic treatment followed by systemic treatment`() {
+        val treatmentHistoryEntries = listOf(createChemotherapy(2020, 6), createChemotherapy(2020, 9))
+        val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
         assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isEqualTo(2020)
         assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isEqualTo(9)
         assertThat(output[1].treatmentHistoryDetails?.maxStopYear).isNull()
         assertThat(output[1].treatmentHistoryDetails?.maxStopMonth).isNull()
+    }
+
+    @Test
+    fun `Should not set stop date for systemic treatment followed by non-systemic treatments`() {
+        val treatmentHistoryEntries = listOf(
+            createChemotherapy(2020, 6),
+            treatmentHistoryEntry(
+                treatments = setOf(
+                    TreatmentTestFactory.treatment(
+                        "radiotherapy",
+                        false,
+                        setOf(TreatmentCategory.RADIOTHERAPY)
+                    )
+                ), startYear = 2020, startMonth = 7
+            )
+        )
+        val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isNull()
+        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isNull()
+    }
+
+    @Test
+    fun `Should not set stop date for systemic treatment followed by systemic treatment combined with non-systemic treatment`() {
+        val treatmentHistoryEntries = listOf(
+            createChemotherapy(2020, 6),
+            treatmentHistoryEntry(
+                treatments = setOf(
+                    TreatmentTestFactory.treatment(
+                        "radiotherapy",
+                        false,
+                        setOf(TreatmentCategory.RADIOTHERAPY)
+                    ),
+                    TreatmentTestFactory.treatment(
+                        "chemotherapy",
+                        true,
+                        setOf(TreatmentCategory.CHEMOTHERAPY)
+                    )
+                ), startYear = 2020, startMonth = 7
+            )
+        )
+        val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isNull()
+        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isNull()
+    }
+
+    private fun createChemotherapy(startYear: Int, startMonth: Int): TreatmentHistoryEntry {
+        return treatmentHistoryEntry(
+            treatments = setOf(TreatmentTestFactory.treatment("chemotherapy", true, setOf(TreatmentCategory.CHEMOTHERAPY))),
+            startYear = startYear,
+            startMonth = startMonth
+        )
     }
 }

--- a/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/clinical/src/test/kotlin/com/hartwig/actin/clinical/feed/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -6,6 +6,9 @@ import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import java.time.LocalDate
+
+private val CURRENT_DATE = LocalDate.now()
 
 class TreatmentHistoryEntryFunctionsTest {
 
@@ -15,8 +18,8 @@ class TreatmentHistoryEntryFunctionsTest {
         val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
         assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isEqualTo(2020)
         assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isEqualTo(9)
-        assertThat(output[1].treatmentHistoryDetails?.maxStopYear).isNull()
-        assertThat(output[1].treatmentHistoryDetails?.maxStopMonth).isNull()
+        assertThat(output[1].treatmentHistoryDetails?.maxStopYear).isEqualTo(CURRENT_DATE.year)
+        assertThat(output[1].treatmentHistoryDetails?.maxStopMonth).isEqualTo(CURRENT_DATE.monthValue)
     }
 
     @Test
@@ -34,14 +37,14 @@ class TreatmentHistoryEntryFunctionsTest {
             )
         )
         val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
-        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isNull()
-        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isNull()
+        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isEqualTo(CURRENT_DATE.year)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isEqualTo(CURRENT_DATE.monthValue)
     }
 
     @Test
     fun `Should not set stop date for systemic treatment followed by systemic treatment combined with non-systemic treatment`() {
         val treatmentHistoryEntries = listOf(
-            createChemotherapy(2020, 6),
+            createChemotherapy(2021, 6),
             treatmentHistoryEntry(
                 treatments = setOf(
                     TreatmentTestFactory.treatment(
@@ -54,12 +57,12 @@ class TreatmentHistoryEntryFunctionsTest {
                         true,
                         setOf(TreatmentCategory.CHEMOTHERAPY)
                     )
-                ), startYear = 2020, startMonth = 7
+                ), startYear = 2021, startMonth = 7
             )
         )
         val output = TreatmentHistoryEntryFunctions.setMaxStopDate(treatmentHistoryEntries)
-        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isNull()
-        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isNull()
+        assertThat(output[0].treatmentHistoryDetails?.maxStopYear).isEqualTo(CURRENT_DATE.year)
+        assertThat(output[0].treatmentHistoryDetails?.maxStopMonth).isEqualTo(CURRENT_DATE.monthValue)
     }
 
     private fun createChemotherapy(startYear: Int, startMonth: Int): TreatmentHistoryEntry {

--- a/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
@@ -74,6 +74,8 @@
       "treatmentHistoryDetails": {
         "stopYear": null,
         "stopMonth": null,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": null,
@@ -108,6 +110,8 @@
       "treatmentHistoryDetails": {
         "stopYear": null,
         "stopMonth": null,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": null,

--- a/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/clinical_record/ACTN01029999.clinical.json
@@ -74,8 +74,8 @@
       "treatmentHistoryDetails": {
         "stopYear": null,
         "stopMonth": null,
-        "maxStopYear": null,
-        "maxStopMonth": null,
+        "maxStopYear": 2025,
+        "maxStopMonth": 6,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": null,

--- a/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
+++ b/clinical/src/test/resources/feed/standard/output/ACTN01029999.clinical.json
@@ -80,6 +80,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2020,
         "stopMonth": 1,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": 5,
         "bestResponse": null,

--- a/common/src/test/resources/clinical/records/patient.clinical.json
+++ b/common/src/test/resources/clinical/records/patient.clinical.json
@@ -62,6 +62,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2020,
         "stopMonth": null,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "PROGRESSIVE_DISEASE",

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentHistoryDetails.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentHistoryDetails.kt
@@ -7,6 +7,8 @@ import java.time.LocalDate
 data class TreatmentHistoryDetails(
     val stopYear: Int? = null,
     val stopMonth: Int? = null,
+    val maxStopYear: Int? = null,
+    val maxStopMonth: Int? = null,
     val ongoingAsOf: LocalDate? = null,
     val cycles: Int? = null,
     val bestResponse: TreatmentResponse? = null,

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentHistoryEntry.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentHistoryEntry.kt
@@ -16,6 +16,14 @@ data class TreatmentHistoryEntry(
     val treatmentHistoryDetails: TreatmentHistoryDetails? = null
 ) {
 
+    fun stopYear(): Int? {
+        return treatmentHistoryDetails?.stopYear ?: treatmentHistoryDetails?.maxStopYear
+    }
+
+    fun stopMonth(): Int? {
+        return treatmentHistoryDetails?.stopMonth ?: treatmentHistoryDetails?.maxStopMonth
+    }
+
     fun allTreatments(): Set<Treatment> {
         val switchToTreatments = treatmentHistoryDetails?.switchToTreatments?.map(TreatmentStage::treatment)?.toSet() ?: emptySet()
         return treatments + setOfNotNull(treatmentHistoryDetails?.maintenanceTreatment?.treatment) + switchToTreatments

--- a/system/src/test/resources/example_patient_data/EXAMPLE-LUNG-01.patient_record.json
+++ b/system/src/test/resources/example_patient_data/EXAMPLE-LUNG-01.patient_record.json
@@ -76,6 +76,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2025,
         "stopMonth": 1,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "PARTIAL_RESPONSE",

--- a/system/src/test/resources/example_patient_data/TEST-NSCLC-NGS.patient_record.json
+++ b/system/src/test/resources/example_patient_data/TEST-NSCLC-NGS.patient_record.json
@@ -96,6 +96,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2024,
         "stopMonth": 6,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "PARTIAL_RESPONSE",
@@ -162,6 +164,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2024,
         "stopMonth": 8,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "STABLE_DISEASE",

--- a/system/src/test/resources/example_patient_data/TEST-NSCLC-WGS.patient_record.json
+++ b/system/src/test/resources/example_patient_data/TEST-NSCLC-WGS.patient_record.json
@@ -89,6 +89,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2024,
         "stopMonth": 9,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "PARTIAL_RESPONSE",

--- a/system/src/test/resources/example_patient_data/TEST-SCLC-NGS.patient_record.json
+++ b/system/src/test/resources/example_patient_data/TEST-SCLC-NGS.patient_record.json
@@ -96,6 +96,8 @@
       "treatmentHistoryDetails": {
         "stopYear": 2024,
         "stopMonth": 9,
+        "maxStopYear": null,
+        "maxStopMonth": null,
         "ongoingAsOf": null,
         "cycles": null,
         "bestResponse": "PARTIAL_RESPONSE",


### PR DESCRIPTION
@spdeleeuw @ninajacobs : of course enough if one of you reviews, but maybe you both have feedback.

ISSUE:
- Many treatments have stopYear and stopMonth `null`, this leads to many undetermined messages for rules like e.g. HAS_HAD_ANY_ANTI_CANCER_THERAPY_WITHIN_X_WEEKS and HAS_HAD_CATEGORY_X_TREATMENT_OF_TYPES_Y_FOR_AT_MOST_Z_WEEKS

DONE:
- Add a `maxStopYear` and `maxStopMonth`, which is equal to the start date of the next systemic treatment. Or for the last treatment this is equal to Today's date
- In algo make use of this maxStopYear/maxStopMonth if the stopYear/stopMonth is null