### PR TITLE
ACTIN-1600 Refactor redudent logic in previous version

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLine.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLine.kt
@@ -4,7 +4,6 @@ import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
-import com.hartwig.actin.datamodel.clinical.treatment.history.StopReason
 
 
 class HasHadProgressionFollowingLatestTreatmentLine(
@@ -46,7 +45,7 @@ class HasHadProgressionFollowingLatestTreatmentLine(
             }
 
             else -> {
-                EvaluationFactory.undetermined("Radiological progression following latest treatment line undetermined.");
+                EvaluationFactory.undetermined("Radiological progression following latest treatment line undetermined.")
             }
         }
     }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLine.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLine.kt
@@ -24,28 +24,28 @@ class HasHadProgressionFollowingLatestTreatmentLine(
 
         return when {
             systemicTreatments.isEmpty() -> {
-                EvaluationFactory.fail("No systemic treatments found in treatment history.")
+                EvaluationFactory.fail("No systemic treatments found in treatment history")
             }
 
             systemicTreatments.all { ProgressiveDiseaseFunctions.treatmentResultedInPD(it) == true } -> {
-                EvaluationFactory.pass("All systemic treatments resulted in progressive disease.")
+                EvaluationFactory.pass("All systemic treatments resulted in progressive disease")
             }
 
             treatmentWithoutDateDiffersInPDStatusFromLastTreatment -> {
-                EvaluationFactory.undetermined("Unable to determine radiological progression following latest treatment line due to treatments without start date.")
+                EvaluationFactory.undetermined("Unable to determine radiological progression following latest treatment line due to treatments without start date")
             }
 
             lastTreatmentResultedInPD == true -> {
                 val radiologicalNote = if (mustBeRadiological) " (assumed PD is radiological)" else ""
-                EvaluationFactory.pass("Last systemic treatment resulted in PD$radiologicalNote.")
+                EvaluationFactory.pass("Last systemic treatment resulted in PD$radiologicalNote")
             }
 
             lastTreatmentResultedInPD == false -> {
-                EvaluationFactory.fail("Last systemic treatment did not result in progressive disease.")
+                EvaluationFactory.fail("Last systemic treatment did not result in progressive disease")
             }
 
             else -> {
-                EvaluationFactory.undetermined("Radiological progression following latest treatment line undetermined.")
+                EvaluationFactory.undetermined("Radiological progression following latest treatment line undetermined")
             }
         }
     }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
@@ -191,4 +191,19 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
         assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Unable to determine radiological progression following latest treatment line due to treatments without start date.")
     }
+
+    @Test
+    fun `Should be undetermined when last treatment has no stop reason and not long enough to assume PD`(){
+        val treatments = listOf(
+            TreatmentTestFactory.treatmentHistoryEntry(setOf(TreatmentTestFactory.treatment("1", true)),
+                startYear = 2025,
+                startMonth = 10,
+                stopYear = 2025,
+                stopMonth = 11
+            )
+        )
+        val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
+        assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Radiological progression following latest treatment line undetermined.")
+    }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
@@ -20,7 +20,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         val treatments = TreatmentTestFactory.withTreatmentHistory(emptyList())
         val evaluation = function.evaluate(treatments)
         assertEvaluation(EvaluationResult.FAIL, evaluation)
-        assertThat(evaluation.failMessagesStrings()).containsExactly("No systemic treatments found in treatment history.")
+        assertThat(evaluation.failMessagesStrings()).containsExactly("No systemic treatments found in treatment history")
     }
 
     @Test
@@ -28,7 +28,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         val treatments = listOf(TreatmentTestFactory.treatmentHistoryEntry(setOf(TreatmentTestFactory.treatment("1", false))))
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.FAIL, evaluation)
-        assertThat(evaluation.failMessagesStrings()).containsExactly("No systemic treatments found in treatment history.")
+        assertThat(evaluation.failMessagesStrings()).containsExactly("No systemic treatments found in treatment history")
     }
 
     @Test
@@ -48,7 +48,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
             )
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
-        assertThat(evaluation.passMessagesStrings()).containsExactly("All systemic treatments resulted in progressive disease.")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("All systemic treatments resulted in progressive disease")
         assertEvaluation(EvaluationResult.PASS, evaluation)
     }
 
@@ -74,7 +74,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological).")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological)")
     }
 
     @Test
@@ -99,7 +99,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.FAIL, evaluation)
-        assertThat(evaluation.failMessagesStrings()).containsExactly("Last systemic treatment did not result in progressive disease.")
+        assertThat(evaluation.failMessagesStrings()).containsExactly("Last systemic treatment did not result in progressive disease")
     }
 
     @Test
@@ -122,7 +122,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological).")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological)")
     }
 
     @Test
@@ -147,7 +147,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = functionPDMustBeRadiological.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD.")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD")
     }
 
     @Test
@@ -168,7 +168,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
-        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Unable to determine radiological progression following latest treatment line due to treatments without start date.")
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Unable to determine radiological progression following latest treatment line due to treatments without start date")
     }
 
     @Test
@@ -189,7 +189,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
-        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Unable to determine radiological progression following latest treatment line due to treatments without start date.")
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Unable to determine radiological progression following latest treatment line due to treatments without start date")
     }
 
     @Test
@@ -204,6 +204,6 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
-        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Radiological progression following latest treatment line undetermined.")
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly("Radiological progression following latest treatment line undetermined")
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadProgressionFollowingLatestTreatmentLineTest.kt
@@ -13,7 +13,6 @@ import org.junit.Test
 class HasHadProgressionFollowingLatestTreatmentLineTest {
 
     private val function = HasHadProgressionFollowingLatestTreatmentLine()
-    private val functionCannotAssumePDIfStopYearProvided = HasHadProgressionFollowingLatestTreatmentLine(canAssumePDIfStopYearProvided = false)
     private val functionPDMustBeRadiological = HasHadProgressionFollowingLatestTreatmentLine(mustBeRadiological = false)
 
     @Test
@@ -75,7 +74,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological)")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological).")
     }
 
     @Test
@@ -98,9 +97,9 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
                 stopMonth = null
             )
         )
-        val evaluation = functionCannotAssumePDIfStopYearProvided.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
+        val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.FAIL, evaluation)
-        assertThat(evaluation.failMessagesStrings()).containsExactly("Last systemic treament did not result in progressive disease.")
+        assertThat(evaluation.failMessagesStrings()).containsExactly("Last systemic treatment did not result in progressive disease.")
     }
 
     @Test
@@ -117,13 +116,13 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
             TreatmentTestFactory.treatmentHistoryEntry(setOf(TreatmentTestFactory.treatment("2", true)),
                 startYear = 2025,
                 startMonth = 10,
-                stopYear = 2025,
+                stopYear = 2026,
                 stopMonth = 11
             )
         )
         val evaluation = function.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment stopped and radiological progression is assumed.")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD (assumed PD is radiological).")
     }
 
     @Test
@@ -148,7 +147,7 @@ class HasHadProgressionFollowingLatestTreatmentLineTest {
         )
         val evaluation = functionPDMustBeRadiological.evaluate(TreatmentTestFactory.withTreatmentHistory(treatments))
         assertEvaluation(EvaluationResult.PASS, evaluation)
-        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD")
+        assertThat(evaluation.passMessagesStrings()).containsExactly("Last systemic treatment resulted in PD.")
     }
 
     @Test


### PR DESCRIPTION
Simplify the logic as suggested in #1183. Instead of trying to infer status for stopped treatments, we will reuse results from `treatmentResultedInPD` function.