### PR TITLE
ACTIN-2115: Populate effects on canonical transcript based off paver

### DIFF
--- a/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/actionability/ActionabilityMatcherTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/evidence/actionability/ActionabilityMatcherTest.kt
@@ -14,7 +14,6 @@ import com.hartwig.actin.datamodel.molecular.driver.GeneRole
 import com.hartwig.actin.datamodel.molecular.driver.TestFusionFactory
 import com.hartwig.actin.datamodel.molecular.driver.TestTranscriptCopyNumberImpactFactory
 import com.hartwig.actin.datamodel.molecular.driver.TestVariantFactory
-import com.hartwig.actin.datamodel.molecular.driver.TranscriptVariantImpact
 import com.hartwig.actin.datamodel.molecular.driver.VirusType
 import com.hartwig.actin.datamodel.molecular.evidence.ClinicalEvidence
 import com.hartwig.actin.datamodel.molecular.evidence.TestClinicalEvidenceFactory
@@ -121,7 +120,9 @@ class ActionabilityMatcherTest {
         val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(molecularCriterium))
         val matcher = matcherFactory(listOf(evidence), listOf(trial))
 
-        val variant = brafMolecularTestVariant.copy(canonicalImpact = minimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE))
+        val variant = brafMolecularTestVariant.copy(
+            canonicalImpact = TestMolecularFactory.createMinimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)
+        )
         val molecularTest = TestMolecularFactory.createMinimalTestPanelRecord().copy(
             drivers = TestMolecularFactory.createMinimalTestDrivers().copy(
                 variants = listOf(
@@ -146,7 +147,8 @@ class ActionabilityMatcherTest {
         val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(molecularCriterium))
 
         val variantOnInapplicableGene = TestVariantFactory.createMinimal().copy(
-            gene = inapplicableGene, canonicalImpact = minimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)
+            gene = inapplicableGene,
+            canonicalImpact = TestMolecularFactory.createMinimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)
         )
 
         val matcher = matcherFactory(listOf(evidence), listOf(trial))
@@ -482,7 +484,9 @@ class ActionabilityMatcherTest {
         val trial = TestServeTrialFactory.create(anyMolecularCriteria = setOf(evidence.molecularCriterium()))
         val matcher = matcherFactory(listOf(evidence), listOf(trial))
 
-        val variant = brafMolecularTestVariant.copy(canonicalImpact = minimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE))
+        val variant = brafMolecularTestVariant.copy(
+            canonicalImpact = TestMolecularFactory.createMinimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)
+        )
         val molecularTest = TestMolecularFactory.createMinimalTestPanelRecord().copy(
             drivers = TestMolecularFactory.createMinimalTestDrivers().copy(
                 variants = listOf(variant)
@@ -502,7 +506,11 @@ class ActionabilityMatcherTest {
 
         val molecularTest = TestMolecularFactory.createMinimalTestPanelRecord().copy(
             drivers = TestMolecularFactory.createMinimalTestDrivers().copy(
-                variants = listOf(brafMolecularTestVariant.copy(canonicalImpact = minimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)))
+                variants = listOf(
+                    brafMolecularTestVariant.copy(
+                        canonicalImpact = TestMolecularFactory.createMinimalTranscriptImpact().copy(codingEffect = CodingEffect.MISSENSE)
+                    )
+                )
             )
         )
 
@@ -687,19 +695,6 @@ class ActionabilityMatcherTest {
                     microsatelliteIndelsPerMb = 0.0, isUnstable = isUnstable, evidence = TestClinicalEvidenceFactory.createEmpty()
                 )
             )
-        )
-    }
-
-    private fun minimalTranscriptImpact(): TranscriptVariantImpact {
-        return TranscriptVariantImpact(
-            transcriptId = "",
-            hgvsCodingImpact = "",
-            hgvsProteinImpact = "",
-            affectedCodon = 0,
-            inSpliceRegion = false,
-            effects = emptySet(),
-            codingEffect = CodingEffect.NONE,
-            affectedExon = null
         )
     }
 

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/driver/TranscriptVariantImpact.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/driver/TranscriptVariantImpact.kt
@@ -4,8 +4,8 @@ data class TranscriptVariantImpact(
     val transcriptId: String,
     val hgvsCodingImpact: String,
     val hgvsProteinImpact: String,
-    val affectedCodon: Int? = null,
-    val affectedExon: Int? = null,
+    val affectedCodon: Int?,
+    val affectedExon: Int?,
     val inSpliceRegion: Boolean?,
     val effects: Set<VariantEffect>,
     val codingEffect: CodingEffect?

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/driver/TranscriptVariantImpact.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/driver/TranscriptVariantImpact.kt
@@ -7,8 +7,8 @@ data class TranscriptVariantImpact(
     val affectedCodon: Int? = null,
     val affectedExon: Int? = null,
     val inSpliceRegion: Boolean?,
-    val effects: Set<VariantEffect> = emptySet(),
-    val codingEffect: CodingEffect? = null
+    val effects: Set<VariantEffect>,
+    val codingEffect: CodingEffect?
 ) : Comparable<TranscriptVariantImpact> {
 
     override fun compareTo(other: TranscriptVariantImpact): Int {

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/TestMolecularFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/TestMolecularFactory.kt
@@ -369,10 +369,10 @@ object TestMolecularFactory {
             hgvsCodingImpact = "c.1799T>A",
             hgvsProteinImpact = "p.V600E",
             affectedCodon = 600,
+            affectedExon = 15,
             inSpliceRegion = false,
             effects = setOf(VariantEffect.MISSENSE),
-            codingEffect = CodingEffect.MISSENSE,
-            affectedExon = null
+            codingEffect = CodingEffect.MISSENSE
         ),
         otherImpacts = emptySet(),
         extendedVariantDetails = ExtendedVariantDetails(

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/TestMolecularFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/TestMolecularFactory.kt
@@ -351,11 +351,11 @@ object TestMolecularFactory {
         transcriptId = "",
         hgvsCodingImpact = "",
         hgvsProteinImpact = "",
-        affectedCodon = 0,
+        affectedCodon = null,
         affectedExon = null,
         inSpliceRegion = null,
         effects = emptySet(),
-        codingEffect = CodingEffect.NONE,
+        codingEffect = null,
     )
 
     fun createProperVariant() = Variant(

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/driver/TestTranscriptVariantImpactFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/molecular/driver/TestTranscriptVariantImpactFactory.kt
@@ -1,17 +1,11 @@
 package com.hartwig.actin.datamodel.molecular.driver
 
+import com.hartwig.actin.datamodel.molecular.TestMolecularFactory
+
 object TestTranscriptVariantImpactFactory {
 
     fun createMinimal(): TranscriptVariantImpact {
-        return TranscriptVariantImpact(
-            transcriptId = "",
-            hgvsCodingImpact = "",
-            hgvsProteinImpact = "",
-            affectedCodon = null,
-            affectedExon = null,
-            inSpliceRegion = false,
-            effects = emptySet(),
-            codingEffect = null
-        )
+        // TODO (KD): Simplify test factories for molecular objects
+        return TestMolecularFactory.createMinimalTranscriptImpact()
     }
 }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/cancerassociatedvariantcomparison/CancerAssociatedVariantEvaluator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/cancerassociatedvariantcomparison/CancerAssociatedVariantEvaluator.kt
@@ -1,6 +1,5 @@
 package com.hartwig.actin.molecular.cancerassociatedvariantcomparison
 
-import com.hartwig.actin.datamodel.molecular.driver.CodingEffect
 import com.hartwig.actin.datamodel.molecular.driver.GeneRole
 import com.hartwig.actin.datamodel.molecular.driver.ProteinEffect
 import com.hartwig.actin.datamodel.molecular.driver.TranscriptVariantImpact
@@ -57,11 +56,11 @@ object CancerAssociatedVariantEvaluator {
                 transcriptId = "",
                 hgvsCodingImpact = "",
                 hgvsProteinImpact = "",
-                affectedCodon = 0,
+                affectedCodon = null,
+                affectedExon = null,
                 inSpliceRegion = false,
                 effects = emptySet(),
-                codingEffect = CodingEffect.NONE,
-                affectedExon = null
+                codingEffect = null
             ),
             otherImpacts = emptySet(),
             extendedVariantDetails = null,

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/PaveImpact.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/PaveImpact.kt
@@ -2,8 +2,8 @@ package com.hartwig.actin.molecular.paver
 
 data class PaveImpact(
     val gene: String,
-    val transcript: String,
-    val canonicalEffect: String,
+    val canonicalTranscript: String,
+    val canonicalEffects: List<PaveVariantEffect>,
     val canonicalCodingEffect: PaveCodingEffect,
     val spliceRegion: Boolean,
     val hgvsCodingImpact: String,

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/PaveResponse.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/PaveResponse.kt
@@ -3,5 +3,5 @@ package com.hartwig.actin.molecular.paver
 data class PaveResponse(
     val id: String,
     val impact: PaveImpact,
-    val transcriptImpact: List<PaveTranscriptImpact>,
+    val transcriptImpacts: List<PaveTranscriptImpact>,
 )

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/Paver.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/paver/Paver.kt
@@ -138,8 +138,8 @@ fun parsePaveImpact(impact: List<String>?): PaveImpact {
 
     return PaveImpact(
         gene = impact[0],
-        transcript = impact[1],
-        canonicalEffect = impact[2],
+        canonicalTranscript = impact[1],
+        canonicalEffects = interpretVariantEffects(impact[2]),
         canonicalCodingEffect = PaveCodingEffect.valueOf(impact[3]),
         spliceRegion = interpretSpliceRegion(impact[4]),
         hgvsCodingImpact = impact[5],

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelVariantAnnotatorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelVariantAnnotatorTest.kt
@@ -49,8 +49,8 @@ private val PAVE_ANNOTATION = PaveResponse(
     id = "0",
     impact = PaveImpact(
         gene = GENE,
-        transcript = TRANSCRIPT,
-        canonicalEffect = "canonicalEffect",
+        canonicalTranscript = TRANSCRIPT,
+        canonicalEffects = listOf(PaveVariantEffect.MISSENSE),
         canonicalCodingEffect = PaveCodingEffect.MISSENSE,
         spliceRegion = false,
         hgvsCodingImpact = HGVS_CODING,
@@ -59,10 +59,11 @@ private val PAVE_ANNOTATION = PaveResponse(
         worstCodingEffect = PaveCodingEffect.MISSENSE,
         genesAffected = 1
     ),
-    transcriptImpact = emptyList()
+    transcriptImpacts = emptyList()
 )
 
 class PanelVariantAnnotatorTest {
+    
     private val transvarAnnotator = mockk<VariantAnnotator> {
         every { resolve(any(), null, HGVS_CODING) } returns TRANSCRIPT_ANNOTATION
     }
@@ -111,7 +112,7 @@ class PanelVariantAnnotatorTest {
     @Test
     fun `Should exclude other transcript impacts from non canonical gene`() {
         val complexPaveAnnotation = PAVE_ANNOTATION.copy(
-            transcriptImpact = listOf(
+            transcriptImpacts = listOf(
                 paveTranscriptImpact(OTHER_GENE_ID, OTHER_GENE, OTHER_GENE_TRANSCRIPT)
             )
         )
@@ -122,7 +123,7 @@ class PanelVariantAnnotatorTest {
 
     @Test
     fun `Should annotate valid other transcripts with paveLite`() {
-        val complexPaveAnnotation = PAVE_ANNOTATION.copy(transcriptImpact = listOf(paveTranscriptImpact()))
+        val complexPaveAnnotation = PAVE_ANNOTATION.copy(transcriptImpacts = listOf(paveTranscriptImpact()))
 
         every { paveLite.run(GENE, OTHER_TRANSCRIPT, POSITION) } returns PAVE_LITE_ANNOTATION
 
@@ -133,7 +134,7 @@ class PanelVariantAnnotatorTest {
     @Test
     fun `Should retain all effects data and have complete annotation of variants`() {
         val complexPaveAnnotation = PAVE_ANNOTATION.copy(
-            transcriptImpact = listOf(
+            transcriptImpacts = listOf(
                 paveTranscriptImpact(
                     effects = listOf(PaveVariantEffect.OTHER, PaveVariantEffect.MISSENSE, PaveVariantEffect.INTRONIC)
                 )
@@ -206,7 +207,7 @@ class PanelVariantAnnotatorTest {
             eventString(
                 PAVE_ANNOTATION.copy(
                     impact = minimalPaveImpact().copy(
-                        canonicalEffect = "upstream_gene_variant",
+                        canonicalEffects = listOf(PaveVariantEffect.UPSTREAM_GENE),
                         canonicalCodingEffect = PaveCodingEffect.NONE,
                         hgvsCodingImpact = "",
                         hgvsProteinImpact = "",
@@ -219,20 +220,20 @@ class PanelVariantAnnotatorTest {
             eventString(
                 PAVE_ANNOTATION.copy(
                     impact = minimalPaveImpact().copy(
-                        canonicalEffect = "something&another_thing",
+                        canonicalEffects = listOf(PaveVariantEffect.INTRONIC, PaveVariantEffect.OTHER),
                         canonicalCodingEffect = PaveCodingEffect.NONE,
                         hgvsCodingImpact = "",
                         hgvsProteinImpact = "",
                     )
                 )
             )
-        ).isEqualTo("something&another_thing")
+        ).isEqualTo("INTRONIC&OTHER")
     }
 
     private fun minimalPaveImpact() = PaveImpact(
         gene = "",
-        transcript = "",
-        canonicalEffect = "",
+        canonicalTranscript = "",
+        canonicalEffects = emptyList(),
         canonicalCodingEffect = PaveCodingEffect.NONE,
         spliceRegion = false,
         hgvsCodingImpact = "",

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelVariantAnnotatorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelVariantAnnotatorTest.kt
@@ -63,7 +63,7 @@ private val PAVE_ANNOTATION = PaveResponse(
 )
 
 class PanelVariantAnnotatorTest {
-    
+
     private val transvarAnnotator = mockk<VariantAnnotator> {
         every { resolve(any(), null, HGVS_CODING) } returns TRANSCRIPT_ANNOTATION
     }
@@ -258,17 +258,15 @@ class PanelVariantAnnotatorTest {
         hgvsProteinImpact = HGVS_PROTEIN_3LETTER
     )
 
-    private fun transcriptVariantImpact(
-        effects: Set<VariantEffect>,
-        codingEffect: CodingEffect
-    ): TranscriptVariantImpact = TranscriptVariantImpact(
-        transcriptId = OTHER_TRANSCRIPT,
-        hgvsCodingImpact = HGVS_CODING,
-        hgvsProteinImpact = HGVS_PROTEIN_1LETTER,
-        affectedCodon = 1,
-        affectedExon = 1,
-        inSpliceRegion = false,
-        effects = effects,
-        codingEffect = codingEffect
-    )
+    private fun transcriptVariantImpact(effects: Set<VariantEffect>, codingEffect: CodingEffect): TranscriptVariantImpact =
+        TranscriptVariantImpact(
+            transcriptId = OTHER_TRANSCRIPT,
+            hgvsCodingImpact = HGVS_CODING,
+            hgvsProteinImpact = HGVS_PROTEIN_1LETTER,
+            affectedCodon = 1,
+            affectedExon = 1,
+            inSpliceRegion = false,
+            effects = effects,
+            codingEffect = codingEffect
+        )
 }

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/paver/PaverTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/paver/PaverTest.kt
@@ -46,8 +46,8 @@ class PaverTest {
                 id = "1",
                 impact = PaveImpact(
                     gene = "gene1",
-                    transcript = "trans1",
-                    canonicalEffect = "missense_variant",
+                    canonicalTranscript = "trans1",
+                    canonicalEffects = listOf(PaveVariantEffect.MISSENSE),
                     canonicalCodingEffect = PaveCodingEffect.MISSENSE,
                     spliceRegion = false,
                     hgvsCodingImpact = "c.6A>C",
@@ -56,7 +56,7 @@ class PaverTest {
                     worstCodingEffect = PaveCodingEffect.MISSENSE,
                     genesAffected = 1
                 ),
-                transcriptImpact = listOf(PaveTranscriptImpact(
+                transcriptImpacts = listOf(PaveTranscriptImpact(
                     geneId = "gene_id1",
                     gene = "gene1",
                     transcript = "trans1",
@@ -74,8 +74,8 @@ class PaverTest {
                 id = "2",
                 impact = PaveImpact(
                     gene = "gene1",
-                    transcript = "trans1",
-                    canonicalEffect = "splice_donor_variant&synonymous_variant",
+                    canonicalTranscript = "trans1",
+                    canonicalEffects = listOf(PaveVariantEffect.SPLICE_DONOR, PaveVariantEffect.SYNONYMOUS),
                     canonicalCodingEffect = PaveCodingEffect.SPLICE,
                     spliceRegion = true,
                     hgvsCodingImpact = "c.18A>G",
@@ -84,7 +84,7 @@ class PaverTest {
                     worstCodingEffect = PaveCodingEffect.SPLICE,
                     genesAffected = 1
                 ),
-                transcriptImpact = listOf(PaveTranscriptImpact(
+                transcriptImpacts = listOf(PaveTranscriptImpact(
                     geneId = "gene_id1",
                     gene = "gene1",
                     transcript = "trans1",
@@ -98,7 +98,7 @@ class PaverTest {
     }
 
     @Test
-    fun `Should error if missing PAVE Impact field`() {
+    fun `Should error if missing PAVE impact field`() {
         assertThatThrownBy { parsePaveImpact(emptyList()) }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessage("Missing PAVE impact field")
@@ -111,15 +111,15 @@ class PaverTest {
     @Test
     fun `Should parse PAVE impact field`() {
         val parsed = parsePaveImpact(listOf(
-            "gene_id", "transcript", "canonical_effect", "MISSENSE", "false", "c.coding", "p.protein",
+            "gene_id", "transcript", "missense_variant&inframe_deletion", "MISSENSE", "false", "c.coding", "p.protein",
             "other_reportable_effects", "MISSENSE", "1",
         ))
 
         assertThat(parsed).isEqualTo(
             PaveImpact(
                 gene = "gene_id",
-                transcript = "transcript",
-                canonicalEffect = "canonical_effect",
+                canonicalTranscript = "transcript",
+                canonicalEffects = listOf(PaveVariantEffect.MISSENSE, PaveVariantEffect.INFRAME_DELETION),
                 canonicalCodingEffect = PaveCodingEffect.MISSENSE,
                 spliceRegion = false,
                 hgvsCodingImpact = "c.coding",
@@ -131,7 +131,7 @@ class PaverTest {
     }
 
     @Test
-    fun `Should error if missing PAVE Transcript Impact field`() {
+    fun `Should error if missing PAVE transcript impact field`() {
         assertThatThrownBy { parsePaveTranscriptImpact(emptyList()) }
             .isInstanceOf(RuntimeException::class.java)
             .hasMessage("Missing PAVE_TI field")


### PR DESCRIPTION
Note:
 - @pauldwolfe One of the causes of this bug imo was the fact that some properties in `TranscriptVariantImpact` had defaults, I consistently remove these when I run into them, they are dodgy since it doesn't force people to set every field.
 - @beracira if reviewing this PR doesn't fit in your agenda no worries, I assume @spdeleeuw  will review tomorrow when he is back! 
 
Finally, I noticed there is some room for cleanup in molecular test factories but left it out of this change. 