### PR TITLE
ACTIN-2078: Message formatting

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAdjuvantTreatmentWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAdjuvantTreatmentWithCategoryOfTypes.kt
@@ -37,7 +37,7 @@ class HasHadAdjuvantTreatmentWithCategoryOfTypes(private val types: Set<Treatmen
             }
 
             else -> {
-                val namesString = Format.concatItemsWithAnd(types)
+                val namesString = Format.concatWithCommaAndOr(types.map { it.display() })
                 EvaluationFactory.fail("Not received adjuvant $namesString")
             }
         }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAdjuvantTreatmentWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAdjuvantTreatmentWithCategoryOfTypes.kt
@@ -37,7 +37,7 @@ class HasHadAdjuvantTreatmentWithCategoryOfTypes(private val types: Set<Treatmen
             }
 
             else -> {
-                val namesString = Format.concatWithCommaAndOr(types.map { it.display() })
+                val namesString = Format.concatItemsWithOr(types)
                 EvaluationFactory.fail("Not received adjuvant $namesString")
             }
         }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
@@ -62,7 +62,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes(
     }
 
     private fun treatment(): String {
-        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
+        return "${Format.concatItemsWithOr(types)} ${category.display()} treatment"
     }
 
     private enum class TreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes.kt
@@ -62,7 +62,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypes(
     }
 
     private fun treatment(): String {
-        return "${Format.concatItemsWithAnd(types)} ${category.display()} treatment"
+        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
     }
 
     private enum class TreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -90,7 +90,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
     }
 
     private fun treatment(): String {
-        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
+        return "${Format.concatItemsWithOr(types)} ${category.display()} treatment"
     }
 
     private enum class PDFollowingTreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -90,7 +90,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
     }
 
     private fun treatment(): String {
-        return "${Format.concatItemsWithAnd(types)} ${category.display()} treatment"
+        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
     }
 
     private enum class PDFollowingTreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -102,7 +102,7 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
     }
 
     private fun treatment(): String {
-        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
+        return "${Format.concatItemsWithOr(types)} ${category.display()} treatment"
     }
 
     private enum class PDFollowingTreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -102,7 +102,7 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
     }
 
     private fun treatment(): String {
-        return "${Format.concatItemsWithAnd(types)} ${category.display()} treatment"
+        return "${Format.concatWithCommaAndOr(types.map { it.display() })} ${category.display()} treatment"
     }
 
     private enum class PDFollowingTreatmentEvaluation {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
@@ -20,7 +20,7 @@ class HasHadSomeTreatmentsWithCategoryOfTypes(
             effectiveTreatmentHistory, category, { historyEntry -> historyEntry.matchesTypeFromSet(types) }
         )
 
-        val typesList = Format.concatWithCommaAndOr(types.map { it.display() })
+        val typesList = Format.concatItemsWithOr(types)
         return when {
             treatmentSummary.numSpecificMatches() >= minTreatmentLines -> {
                 EvaluationFactory.pass("Has received at least $minTreatmentLines line(s) of $typesList ${category.display()}")

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
@@ -20,7 +20,7 @@ class HasHadSomeTreatmentsWithCategoryOfTypes(
             effectiveTreatmentHistory, category, { historyEntry -> historyEntry.matchesTypeFromSet(types) }
         )
 
-        val typesList = Format.concatItemsWithAnd(types)
+        val typesList = Format.concatWithCommaAndOr(types.map { it.display() })
         return when {
             treatmentSummary.numSpecificMatches() >= minTreatmentLines -> {
                 EvaluationFactory.pass("Has received at least $minTreatmentLines line(s) of $typesList ${category.display()}")

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
@@ -4,7 +4,7 @@ import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.DateComparison.isAfterDate
-import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithAnd
+import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithOr
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpretation
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpreter
 import com.hartwig.actin.datamodel.PatientRecord
@@ -37,7 +37,7 @@ class HasHadTreatmentWithCategoryOfTypesRecently(
             )
         }.fold(TreatmentAssessment()) { acc, element -> acc.combineWith(element) }
 
-        val typesList = concatItemsWithAnd(types)
+        val typesList = concatItemsWithOr(types)
 
         return when {
             treatmentAssessment.hasHadValidTreatment -> {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/util/Format.kt
@@ -80,7 +80,7 @@ object Format {
     }
 
     private fun concatDisplayables(items: Iterable<Displayable>, separator: String) =
-        concatStrings(items.map(Displayable::display), separator)
+        concatWithCommaAndSeparator(items.map(Displayable::display), separator, false)
 
     private fun concatStrings(strings: Iterable<String>, separator: String) =
         strings.distinct().sortedWith(String.CASE_INSENSITIVE_ORDER).joinToString(separator)


### PR DESCRIPTION
- There were some occurrences of using "and" although should be "or" (since e.g. you don't need to have had all types, one of the list is enough, so 'or' instead of 'and').
- The messages were ugly formatted with ".. or .. or .. or .. or .." changed to ".. , .. , .. or .."