### PR TITLE
ACTIN-2139 Provide a way to return external trials unfiltered

### DIFF
--- a/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
+++ b/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
@@ -60,10 +60,14 @@ class TrialsProvider(
     }
 
     fun externalTrials(): ExternalTrials {
-       return externalTrials(internalTrialIds, eligibleCohortsWithSlotsAvailableAndNotIgnore(), isYoungAdult)
+        return externalTrials(internalTrialIds, eligibleCohortsWithSlotsAvailableAndNotIgnore(), isYoungAdult)
     }
 
-    private fun externalTrials(internalTrialIds:Set<String>, internalEvaluatedCohorts: List<InterpretedCohort>, isYoungAdult: Boolean): ExternalTrials {
+    private fun externalTrials(
+        internalTrialIds: Set<String>,
+        internalEvaluatedCohorts: List<InterpretedCohort>,
+        isYoungAdult: Boolean
+    ): ExternalTrials {
         val eligibleExternalTrials = externalTrials.filterInternalTrials(internalTrialIds)
 
         val (nationalTrials, internationalTrials) = partitionByCountry(eligibleExternalTrials, countryOfReference)
@@ -74,8 +78,9 @@ class TrialsProvider(
                 countryOfReference
             )
 
-        val filteredInternationalTrials = internationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(internalEvaluatedCohorts)
-            .filterMolecularCriteriaAlreadyPresentInTrials(filteredNationalTrials)
+        val filteredInternationalTrials =
+            internationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(internalEvaluatedCohorts)
+                .filterMolecularCriteriaAlreadyPresentInTrials(filteredNationalTrials)
 
         return ExternalTrials(
             hideOverlappingTrials(
@@ -103,11 +108,13 @@ class TrialsProvider(
     }
 
     companion object {
-        fun createTrialsProvider(patientRecord: PatientRecord,
-                                 treatmentMatch: TreatmentMatch,
-                                 countryOfReference: Country,
-                                 enableExtendedMode: Boolean,
-                                 filterOnSOCExhaustionAndTumorType: Boolean) : TrialsProvider {
+        fun create(
+            patientRecord: PatientRecord,
+            treatmentMatch: TreatmentMatch,
+            countryOfReference: Country,
+            enableExtendedMode: Boolean,
+            filterOnSOCExhaustionAndTumorType: Boolean
+        ): TrialsProvider {
             val isYoungAdult = (treatmentMatch.referenceDate.year - patientRecord.patient.birthYear) < YOUNG_ADULT_CUT_OFF
             val cohorts = InterpretedCohortFactory.createEvaluableCohorts(
                 treatmentMatch,
@@ -115,9 +122,11 @@ class TrialsProvider(
             )
             val nonEvaluableCohorts = InterpretedCohortFactory.createNonEvaluableCohorts(treatmentMatch)
             val internalTrialIds = treatmentMatch.trialMatches.mapNotNull { it.identification.nctId }.toSet()
-            return TrialsProvider(externalEligibleTrials(patientRecord), cohorts, nonEvaluableCohorts, internalTrialIds, isYoungAdult,
+            return TrialsProvider(
+                externalEligibleTrials(patientRecord), cohorts, nonEvaluableCohorts, internalTrialIds, isYoungAdult,
                 countryOfReference,
-                enableExtendedMode)
+                enableExtendedMode
+            )
         }
 
         private fun externalEligibleTrials(patientRecord: PatientRecord): Set<EventWithExternalTrial> {
@@ -147,7 +156,7 @@ class TrialsProvider(
 }
 
 fun Set<EventWithExternalTrial>.filterInternalTrials(internalTrialIds: Set<String>): Set<EventWithExternalTrial> {
-    return this.filter { it.trial.nctId !in internalTrialIds}.toSet()
+    return this.filter { it.trial.nctId !in internalTrialIds }.toSet()
 }
 
 fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(

--- a/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
+++ b/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
@@ -2,17 +2,17 @@ package com.hartwig.actin.report.trial
 
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.TreatmentMatch
-import com.hartwig.actin.datamodel.algo.TrialMatch
 import com.hartwig.actin.datamodel.molecular.evidence.Country
 import com.hartwig.actin.datamodel.molecular.evidence.ExternalTrial
 import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceFactory
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortFactory
-import java.time.LocalDate
+
+const val YOUNG_ADULT_CUT_OFF = 40
 
 data class EventWithExternalTrial(val event: String, val trial: ExternalTrial)
 
-class MolecularFilteredExternalTrials(private val original: Set<EventWithExternalTrial>, val filtered: Set<EventWithExternalTrial>) {
+class MolecularFilteredExternalTrials(val original: Set<EventWithExternalTrial>, val filtered: Set<EventWithExternalTrial>) {
 
     fun isNotEmpty() = original.isNotEmpty()
 
@@ -31,19 +31,14 @@ class ExternalTrials(val nationalTrials: MolecularFilteredExternalTrials, val in
 }
 
 class TrialsProvider(
-    private val patientRecord: PatientRecord,
-    private val treatmentMatch: TreatmentMatch,
+    private val externalTrials: Set<EventWithExternalTrial>,
+    private val cohorts: List<InterpretedCohort>,
+    private val nonEvaluableCohorts: List<InterpretedCohort>,
+    private val internalTrialIds: Set<String>,
+    private val isYoungAdult: Boolean,
     private val countryOfReference: Country,
-    private val enableExtendedMode: Boolean,
-    filterOnSOCExhaustionAndTumorType: Boolean
+    private val enableExtendedMode: Boolean
 ) {
-
-    private val cohorts: List<InterpretedCohort> = InterpretedCohortFactory.createEvaluableCohorts(
-        treatmentMatch,
-        filterOnSOCExhaustionAndTumorType
-    )
-    private val nonEvaluableCohorts = InterpretedCohortFactory.createNonEvaluableCohorts(treatmentMatch)
-
     fun evaluableCohorts(): List<InterpretedCohort> {
         return cohorts
     }
@@ -60,42 +55,40 @@ class TrialsProvider(
         return filterCohortsAvailable(cohorts.filter { !it.ignore && it.hasSlotsAvailable })
     }
 
-    private fun externalEligibleTrials(): Set<EventWithExternalTrial> {
-        return patientRecord.molecularHistory.molecularTests.flatMap { t ->
-            AggregatedEvidenceFactory.create(t).eligibleTrialsPerEvent.flatMap {
-                it.value.map { trial -> EventWithExternalTrial(it.key, trial) }
-            }
-        }.toSet()
+    fun externalTrialsUnfiltered(): ExternalTrials {
+        return externalTrials(setOf(), listOf(), false)
     }
 
     fun externalTrials(): ExternalTrials {
-        val evaluated = eligibleCohortsWithSlotsAvailableAndNotIgnore()
+       return externalTrials(internalTrialIds, eligibleCohortsWithSlotsAvailableAndNotIgnore(), isYoungAdult)
+    }
 
-        val eligibleExternalTrials = externalEligibleTrials().filterInternalTrials(treatmentMatch.trialMatches)
+    private fun externalTrials(internalTrialIds:Set<String>, internalEvaluatedCohorts: List<InterpretedCohort>, isYoungAdult: Boolean): ExternalTrials {
+        val eligibleExternalTrials = externalTrials.filterInternalTrials(internalTrialIds)
 
         val (nationalTrials, internationalTrials) = partitionByCountry(eligibleExternalTrials, countryOfReference)
 
-        val filteredNationalTrials = nationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(evaluated)
+        val filteredNationalTrials = nationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(internalEvaluatedCohorts)
             .filterExclusivelyInChildrensHospitalsInReferenceCountry(
-                patientRecord.patient.birthYear,
-                treatmentMatch.referenceDate,
+                isYoungAdult,
                 countryOfReference
             )
 
-        val nationalTrialsNotOverlappingHospital =
+        val filteredInternationalTrials = internationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(internalEvaluatedCohorts)
+            .filterMolecularCriteriaAlreadyPresentInTrials(filteredNationalTrials)
+
+        return ExternalTrials(
             hideOverlappingTrials(
                 nationalTrials,
                 filteredNationalTrials,
                 enableExtendedMode
+            ),
+            hideOverlappingTrials(
+                internationalTrials,
+                filteredInternationalTrials,
+                enableExtendedMode
             )
-
-        val internationalTrialsNotOverlappingHospitalOrNational = hideOverlappingTrials(
-            internationalTrials,
-            internationalTrials.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(evaluated)
-                .filterMolecularCriteriaAlreadyPresentInTrials(filteredNationalTrials),
-            enableExtendedMode
         )
-        return ExternalTrials(nationalTrialsNotOverlappingHospital, internationalTrialsNotOverlappingHospitalOrNational)
     }
 
     private fun hideOverlappingTrials(
@@ -104,12 +97,37 @@ class TrialsProvider(
         enableExtendedMode: Boolean
     ): MolecularFilteredExternalTrials {
         return MolecularFilteredExternalTrials(
-            original.toSet(),
-            (if (enableExtendedMode) original else filtered).toSet()
+            original,
+            if (enableExtendedMode) original else filtered
         )
     }
 
     companion object {
+        fun createTrialsProvider(patientRecord: PatientRecord,
+                                 treatmentMatch: TreatmentMatch,
+                                 countryOfReference: Country,
+                                 enableExtendedMode: Boolean,
+                                 filterOnSOCExhaustionAndTumorType: Boolean) : TrialsProvider {
+            val isYoungAdult = (treatmentMatch.referenceDate.year - patientRecord.patient.birthYear) < YOUNG_ADULT_CUT_OFF
+            val cohorts = InterpretedCohortFactory.createEvaluableCohorts(
+                treatmentMatch,
+                filterOnSOCExhaustionAndTumorType
+            )
+            val nonEvaluableCohorts = InterpretedCohortFactory.createNonEvaluableCohorts(treatmentMatch)
+            val internalTrialIds = treatmentMatch.trialMatches.mapNotNull { it.identification.nctId }.toSet()
+            return TrialsProvider(externalEligibleTrials(patientRecord), cohorts, nonEvaluableCohorts, internalTrialIds, isYoungAdult,
+                countryOfReference,
+                enableExtendedMode)
+        }
+
+        private fun externalEligibleTrials(patientRecord: PatientRecord): Set<EventWithExternalTrial> {
+            return patientRecord.molecularHistory.molecularTests.flatMap { t ->
+                AggregatedEvidenceFactory.create(t).eligibleTrialsPerEvent.flatMap {
+                    it.value.map { trial -> EventWithExternalTrial(it.key, trial) }
+                }
+            }.toSet()
+        }
+
         fun filterCohortsAvailable(cohorts: List<InterpretedCohort>): List<InterpretedCohort> {
             return cohorts.filter {
                 it.isPotentiallyEligible && it.isOpen && !it.isMissingMolecularResultForEvaluation
@@ -118,7 +136,7 @@ class TrialsProvider(
 
         private fun countryNames(it: EventWithExternalTrial) = it.trial.countries.map { c -> c.country }
 
-        fun partitionByCountry(
+        private fun partitionByCountry(
             trials: Set<EventWithExternalTrial>,
             country: Country
         ): Pair<Set<EventWithExternalTrial>, Set<EventWithExternalTrial>> {
@@ -128,9 +146,8 @@ class TrialsProvider(
     }
 }
 
-fun Set<EventWithExternalTrial>.filterInternalTrials(internalTrials: List<TrialMatch>): Set<EventWithExternalTrial> {
-    val internalIds = internalTrials.map { it.identification.nctId }.toSet()
-    return this.filter { it.trial.nctId !in internalIds }.toSet()
+fun Set<EventWithExternalTrial>.filterInternalTrials(internalTrialIds: Set<String>): Set<EventWithExternalTrial> {
+    return this.filter { it.trial.nctId !in internalTrialIds}.toSet()
 }
 
 fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(
@@ -144,20 +161,18 @@ fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresentInTrials(tr
     return filterMolecularCriteriaAlreadyPresent(trials.map { it.event }.toSet())
 }
 
-private fun hospitalsNamesForCountry(trial: ExternalTrial, country: Country) =
+private fun hospitalsForCountry(trial: ExternalTrial, country: Country) =
     trial.countries.firstOrNull { it.country == country }?.hospitalsPerCity?.flatMap { it.value }?.toSet()
         ?: throw IllegalArgumentException("Country not found")
 
 
 fun Set<EventWithExternalTrial>.filterExclusivelyInChildrensHospitalsInReferenceCountry(
-    birthYear: Int,
-    referenceDate: LocalDate,
+    isYoungAdult: Boolean,
     countryOfReference: Country
 ): Set<EventWithExternalTrial> {
-    val isYoungAdult = referenceDate.year - birthYear < 40
     return this.filter { ewt ->
         val allHospitalsAreChildrensInReferenceCountry =
-            hospitalsNamesForCountry(ewt.trial, countryOfReference).all { it.isChildrensHospital == true }
+            hospitalsForCountry(ewt.trial, countryOfReference).all { it.isChildrensHospital == true }
         !allHospitalsAreChildrensInReferenceCountry || isYoungAdult
     }.toSet()
 }

--- a/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
+++ b/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
@@ -34,7 +34,15 @@ private val BASE_EXTERNAL_TRIAL = TestExternalTrialFactory.create(
 )
 
 private val INTERNAL_TRIAL_IDS = setOf(NCT_01, NCT_03)
-private val EVALUABLE_COHORTS = listOf(InterpretedCohortTestFactory.interpretedCohort(isPotentiallyEligible = true, isOpen = true, isIgnore = false, hasSlotsAvailable = true, molecularEvents = setOf(EGFR_TARGET)))
+private val EVALUABLE_COHORTS = listOf(
+    InterpretedCohortTestFactory.interpretedCohort(
+        isPotentiallyEligible = true,
+        isOpen = true,
+        isIgnore = false,
+        hasSlotsAvailable = true,
+        molecularEvents = setOf(EGFR_TARGET)
+    )
+)
 
 class TrialsProviderTest {
 
@@ -65,7 +73,7 @@ class TrialsProviderTest {
         assertThat(
             setOf(notFilteredHospital, filteredHospital)
                 .filterExclusivelyInChildrensHospitalsInReferenceCountry(
-                   false,
+                    false,
                     countryOfReference = Country.NETHERLANDS
                 )
         ).containsExactly(notFilteredHospital)
@@ -79,7 +87,7 @@ class TrialsProviderTest {
             )
         )
         val result = setOf(notFilteredHospital).filterExclusivelyInChildrensHospitalsInReferenceCountry(
-           true,
+            true,
             countryOfReference = Country.NETHERLANDS
         )
         assertThat(result).containsExactly(notFilteredHospital)
@@ -109,11 +117,12 @@ class TrialsProviderTest {
 
     @Test
     fun `externalTrialsUnfiltered should not filter external trials`() {
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
-        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_01))
+        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
 
         val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country2Trial1)
-        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, true)
+        val trialsProvider =
+            TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false, Country.NETHERLANDS, true)
         val externalTrials = trialsProvider.externalTrialsUnfiltered()
 
         assertThat(externalTrials.nationalTrials.filtered).isEqualTo(externalTrials.nationalTrials.original)
@@ -125,11 +134,13 @@ class TrialsProviderTest {
     @Test
     fun `externalTrials should filter internal trials and return filtered and original equal with extended mode`() {
         val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
-        val country1Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
-        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+        val country1Trial2 =
+            EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
+        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
 
         val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country1Trial2, country2Trial1)
-        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, true)
+        val trialsProvider =
+            TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false, Country.NETHERLANDS, true)
         val externalTrials = trialsProvider.externalTrials()
 
         assertThat(externalTrials.nationalTrials.filtered).isEqualTo(externalTrials.nationalTrials.original)
@@ -141,19 +152,23 @@ class TrialsProviderTest {
     @Test
     fun `externalTrials should filter internal trials and filtered and original should be different without extended mode`() {
         // Should be filtered based on INTERNAL_TRIAL_IDS
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS, )))
         // Should be filtered based on matching event in evaluable cohorts
-        val country1Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
-        val country1Trial3 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
+        val country1Trial2 =
+            EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
+        val country1Trial3 =
+            EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
         // Should be filtered based on INTERNAL_TRIAL_IDS
-        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
         val country2Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
-        // Should be filtered base on national trials with same molecular criteria
+        // Should be filtered based on national trials with same molecular criteria
         val country2Trial3 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
         val country2Trial4 = EventWithExternalTrial(ROS1_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
 
-        val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country1Trial2, country1Trial3, country2Trial1, country2Trial2, country2Trial3, country2Trial4)
-        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, false)
+        val externalTrialsSet: Set<EventWithExternalTrial> =
+            setOf(country1Trial1, country1Trial2, country1Trial3, country2Trial1, country2Trial2, country2Trial3, country2Trial4)
+        val trialsProvider =
+            TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false, Country.NETHERLANDS, false)
         val externalTrials = trialsProvider.externalTrials()
 
         assertThat(externalTrials.nationalTrials.original).containsExactly(country1Trial2, country1Trial3)

--- a/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
+++ b/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
@@ -117,7 +117,8 @@ class TrialsProviderTest {
 
     @Test
     fun `externalTrialsUnfiltered should not filter external trials`() {
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_01))
+        val country1Trial1 =
+            EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_01))
         val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
 
         val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country2Trial1)
@@ -152,7 +153,7 @@ class TrialsProviderTest {
     @Test
     fun `externalTrials should filter internal trials and filtered and original should be different without extended mode`() {
         // Should be filtered based on INTERNAL_TRIAL_IDS
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS, )))
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
         // Should be filtered based on matching event in evaluable cohorts
         val country1Trial2 =
             EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))

--- a/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
+++ b/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
@@ -1,24 +1,27 @@
 package com.hartwig.actin.report.trial
 
-import com.hartwig.actin.datamodel.algo.TrialMatch
 import com.hartwig.actin.datamodel.molecular.evidence.Country
 import com.hartwig.actin.datamodel.molecular.evidence.CountryDetails
 import com.hartwig.actin.datamodel.molecular.evidence.Hospital
 import com.hartwig.actin.datamodel.molecular.evidence.TestExternalTrialFactory
-import com.hartwig.actin.datamodel.trial.TrialIdentification
 import com.hartwig.actin.report.interpretation.InterpretedCohortTestFactory
-import com.hartwig.actin.report.trial.TrialsProvider.Companion.partitionByCountry
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
-import java.time.LocalDate
 
 private const val NCT_01 = "NCT00000001"
+private const val NCT_02 = "NCT00000002"
+private const val NCT_03 = "NCT00000003"
 private const val URL = "url"
 
 private const val TMB_TARGET = "TMB"
 private const val EGFR_TARGET = "EGFR"
+private const val ROS1_TARGET = "ROS1"
 
-private val NETHERLANDS = CountryDetails(country = Country.NETHERLANDS, hospitalsPerCity = emptyMap())
+private val AMSTERDAM = "Amsterdam"
+private val UTRECHT = "Utrecht"
+private val NKI = Hospital("NKI", isChildrensHospital = false)
+private val PMC = Hospital("PMC", isChildrensHospital = true)
+private val NETHERLANDS = CountryDetails(country = Country.NETHERLANDS, hospitalsPerCity = mapOf(AMSTERDAM to setOf(NKI)))
 private val BELGIUM = CountryDetails(country = Country.BELGIUM, hospitalsPerCity = emptyMap())
 
 private val BASE_EXTERNAL_TRIAL = TestExternalTrialFactory.create(
@@ -30,65 +33,39 @@ private val BASE_EXTERNAL_TRIAL = TestExternalTrialFactory.create(
     url = URL
 )
 
-val TRIAL_MATCHES = setOf(
-    TrialMatch(
-        identification = TrialIdentification("TRIAL-1", open = true, "TR-1", "Different title of same trial 1", NCT_01, null, null, null, emptySet(), null),
-        isPotentiallyEligible = true,
-        evaluations = emptyMap(),
-        cohorts = emptyList(),
-        nonEvaluableCohorts = emptyList()
-    ),
-    TrialMatch(
-        identification = TrialIdentification("TRIAL-3", open = true, "TR-3", "Different trial 3", "NCT00000003", null, null, null, emptySet(), null),
-        isPotentiallyEligible = true,
-        evaluations = emptyMap(),
-        cohorts = emptyList(),
-        nonEvaluableCohorts = emptyList()
-    )
-)
+private val INTERNAL_TRIAL_IDS = setOf(NCT_01, NCT_03)
+private val EVALUABLE_COHORTS = listOf(InterpretedCohortTestFactory.interpretedCohort(isPotentiallyEligible = true, isOpen = true, isIgnore = false, hasSlotsAvailable = true, molecularEvents = setOf(EGFR_TARGET)))
 
 class TrialsProviderTest {
 
     @Test
     fun `Should filter internal trials`() {
-        val notFiltered = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(nctId = "NCT00000002"))
+        val notFiltered = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(NCT_02))
         assertThat(
             setOf(
                 EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(nctId = NCT_01)),
                 notFiltered
-            ).filterInternalTrials(TRIAL_MATCHES.toList())
+            ).filterInternalTrials(setOf(NCT_01, NCT_03))
         ).containsExactly(notFiltered)
-    }
-
-    @Test
-    fun `Should partition by country`() {
-        val country1Trial = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
-        val country2Trial = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
-
-        val (inCountry, otherCountries) = partitionByCountry(setOf(country1Trial, country2Trial), Country.NETHERLANDS)
-
-        assertThat(inCountry).containsExactly(country1Trial)
-        assertThat(otherCountries).containsExactly(country2Trial)
     }
 
     @Test
     fun `Should filter trials exclusively in childrens hospitals in reference country`() {
         val notFilteredHospital = createExternalTrialSummaryWithHospitals(
             NETHERLANDS to mapOf(
-                "Utrecht" to setOf(Hospital("PMC", isChildrensHospital = true)),
-                "Amsterdam" to setOf(Hospital("NKI", isChildrensHospital = false))
+                UTRECHT to setOf(PMC),
+                AMSTERDAM to setOf(NKI)
             )
         )
         val filteredHospital = createExternalTrialSummaryWithHospitals(
             NETHERLANDS to mapOf(
-                "Utrecht" to setOf(Hospital("Sophia KinderZiekenhuis", isChildrensHospital = true))
+                UTRECHT to setOf(Hospital("Sophia KinderZiekenhuis", isChildrensHospital = true))
             )
         )
         assertThat(
             setOf(notFilteredHospital, filteredHospital)
                 .filterExclusivelyInChildrensHospitalsInReferenceCountry(
-                    birthYear = 1960,
-                    referenceDate = LocalDate.of(2021, 1, 1),
+                   false,
                     countryOfReference = Country.NETHERLANDS
                 )
         ).containsExactly(notFilteredHospital)
@@ -98,12 +75,11 @@ class TrialsProviderTest {
     fun `Should not filter trials exclusively in childrens hospitals in reference country when patient is younger than 25 years old`() {
         val notFilteredHospital = createExternalTrialSummaryWithHospitals(
             NETHERLANDS to mapOf(
-                "Utrecht" to setOf(Hospital("PMC", true))
+                UTRECHT to setOf(PMC)
             )
         )
         val result = setOf(notFilteredHospital).filterExclusivelyInChildrensHospitalsInReferenceCountry(
-            birthYear = 2000,
-            referenceDate = LocalDate.of(2021, 1, 1),
+           true,
             countryOfReference = Country.NETHERLANDS
         )
         assertThat(result).containsExactly(notFilteredHospital)
@@ -129,6 +105,61 @@ class TrialsProviderTest {
         val notFiltered = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL)
         val result = setOf(filtered, notFiltered).filterMolecularCriteriaAlreadyPresentInTrials(setOf(otherTrial))
         assertThat(result).containsExactly(notFiltered)
+    }
+
+    @Test
+    fun `externalTrialsUnfiltered should not filter external trials`() {
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+
+        val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country2Trial1)
+        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, true)
+        val externalTrials = trialsProvider.externalTrialsUnfiltered()
+
+        assertThat(externalTrials.nationalTrials.filtered).isEqualTo(externalTrials.nationalTrials.original)
+        assertThat(externalTrials.internationalTrials.filtered).isEqualTo(externalTrials.internationalTrials.original)
+        assertThat(externalTrials.nationalTrials.filtered).containsExactly(country1Trial1)
+        assertThat(externalTrials.internationalTrials.filtered).containsExactly(country2Trial1)
+    }
+
+    @Test
+    fun `externalTrials should filter internal trials and return filtered and original equal with extended mode`() {
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        val country1Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
+        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+
+        val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country1Trial2, country2Trial1)
+        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, true)
+        val externalTrials = trialsProvider.externalTrials()
+
+        assertThat(externalTrials.nationalTrials.filtered).isEqualTo(externalTrials.nationalTrials.original)
+        assertThat(externalTrials.internationalTrials.filtered).isEqualTo(externalTrials.internationalTrials.original)
+        assertThat(externalTrials.nationalTrials.filtered).containsExactly(country1Trial2)
+        assertThat(externalTrials.internationalTrials.filtered).isEmpty()
+    }
+
+    @Test
+    fun `externalTrials should filter internal trials and filtered and original should be different without extended mode`() {
+        // Should be filtered based on INTERNAL_TRIAL_IDS
+        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        // Should be filtered based on matching event in evaluable cohorts
+        val country1Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
+        val country1Trial3 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02 ))
+        // Should be filtered based on INTERNAL_TRIAL_IDS
+        val country2Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+        val country2Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+        // Should be filtered base on national trials with same molecular criteria
+        val country2Trial3 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+        val country2Trial4 = EventWithExternalTrial(ROS1_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+
+        val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country1Trial2, country1Trial3, country2Trial1, country2Trial2, country2Trial3, country2Trial4)
+        val trialsProvider = TrialsProvider(externalTrialsSet, EVALUABLE_COHORTS, listOf(), INTERNAL_TRIAL_IDS, false,Country.NETHERLANDS, false)
+        val externalTrials = trialsProvider.externalTrials()
+
+        assertThat(externalTrials.nationalTrials.original).containsExactly(country1Trial2, country1Trial3)
+        assertThat(externalTrials.internationalTrials.original).containsExactly(country2Trial2, country2Trial3, country2Trial4)
+        assertThat(externalTrials.nationalTrials.filtered).containsExactly(country1Trial3)
+        assertThat(externalTrials.internationalTrials.filtered).containsExactly(country2Trial4)
     }
 
     private fun countrySet(vararg countries: CountryDetails) = sortedSetOf(Comparator.comparing { it.country }, *countries)

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.LogManager
 class ReportContentProvider(private val report: Report, private val enableExtendedMode: Boolean = false) {
 
     private val logger = LogManager.getLogger(ReportContentProvider::class.java)
-    private val trialsProvider = TrialsProvider(
+    private val trialsProvider = TrialsProvider.createTrialsProvider(
         report.patientRecord,
         report.treatmentMatch,
         report.config.countryOfReference,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
@@ -41,7 +41,7 @@ import org.apache.logging.log4j.LogManager
 class ReportContentProvider(private val report: Report, private val enableExtendedMode: Boolean = false) {
 
     private val logger = LogManager.getLogger(ReportContentProvider::class.java)
-    private val trialsProvider = TrialsProvider.createTrialsProvider(
+    private val trialsProvider = TrialsProvider.create(
         report.patientRecord,
         report.treatmentMatch,
         report.config.countryOfReference,


### PR DESCRIPTION
Added a way to return the external trials without any filtering.

Refactored the TrialProvider so it's a bit easier to test

Extended the tests to it covers more scenarios