### PR TITLE
ACTIN-1494: Remove "profile" from environment config

### DIFF
--- a/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
@@ -10,16 +10,11 @@ class EnvironmentConfigurationTest {
     private val minimalConfigFile = resourceOnClasspath("environment/minimal_config.yaml")
     private val basicConfigFile = resourceOnClasspath("environment/basic_config.yaml")
     private val properConfigFile = resourceOnClasspath("environment/proper_config.yaml")
-
-    @Test
-    fun `Should create with default values`() {
-        assertThat(defaultConfig.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue
-    }
-
+    
     @Test
     fun `Should load proper config from file`() {
         val config = EnvironmentConfiguration.create(properConfigFile)
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isFalse
+        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isFalse()
         assertThat(config.requestingHospital).isEqualTo("Erasmus MC")
     }
 
@@ -27,44 +22,17 @@ class EnvironmentConfigurationTest {
     fun `Should load config from file with requesting hospital only`() {
         val config = EnvironmentConfiguration.create(basicConfigFile)
         assertThat(config.requestingHospital).isEqualTo("Erasmus MC")
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue
+        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue()
     }
 
     @Test
     fun `Should use defaults for fields not provided in file`() {
         val config = EnvironmentConfiguration.create(minimalConfigFile)
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue
+        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue()
     }
 
     @Test
     fun `Should create default configuration when provided file is null`() {
         assertThat(EnvironmentConfiguration.create(null)).isEqualTo(defaultConfig)
-    }
-
-    @Test
-    fun `Should override configuration from file with profile`() {
-        val config = EnvironmentConfiguration.create(properConfigFile, "CRC")
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isFalse
-        assertThat(config.report.includeOverviewWithClinicalHistorySummary).isTrue
-        assertThat(config.report.includeMolecularDetailsChapter).isFalse
-    }
-
-    @Test
-    fun `Should override default configuration with profile when file is null`() {
-        assertThat(EnvironmentConfiguration.create(null, "CRC")).isEqualTo(
-            defaultConfig.copy(
-                report = defaultConfig.report.copy(
-                    includeOverviewWithClinicalHistorySummary = true,
-                    includeMolecularDetailsChapter = false,
-                    includeIneligibleTrialsInSummary = true,
-                    includeApprovedTreatmentsInSummary = false,
-                    includeSOCLiteratureEfficacyEvidence = true,
-                    includeEligibleSOCTreatmentSummary = true,
-                    molecularSummaryType = MolecularSummaryType.NONE,
-                    includePatientHeader = false,
-                    filterOnSOCExhaustionAndTumorType = true
-                )
-            )
-        )
     }
 }

--- a/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
@@ -25,7 +25,7 @@ class ReporterApplication(private val config: ReporterConfig) {
         LOGGER.info("Loading treatment match results from {}", config.treatmentMatchJson)
         val treatmentMatch = TreatmentMatchJson.read(config.treatmentMatchJson)
 
-        val envConfig = EnvironmentConfiguration.create(config.overrideYaml, config.profile)
+        val envConfig = EnvironmentConfiguration.create(config.overrideYaml)
         LOGGER.info(" Loaded config: $envConfig")
 
         val report = ReportFactory.create(LocalDate.now(), patient, treatmentMatch, envConfig)

--- a/report/src/main/kotlin/com/hartwig/actin/report/ReporterConfig.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/ReporterConfig.kt
@@ -1,6 +1,5 @@
 package com.hartwig.actin.report
 
-import com.hartwig.actin.configuration.ConfigurationProfile
 import com.hartwig.actin.configuration.OVERRIDE_YAML_ARGUMENT
 import com.hartwig.actin.configuration.OVERRIDE_YAML_DESCRIPTION
 import com.hartwig.actin.util.ApplicationConfig
@@ -16,8 +15,7 @@ data class ReporterConfig(
     val treatmentMatchJson: String,
     val overrideYaml: String?,
     val outputDirectory: String,
-    val enableExtendedMode: Boolean,
-    val profile: String?
+    val enableExtendedMode: Boolean
 ) {
 
     companion object {
@@ -28,7 +26,6 @@ data class ReporterConfig(
         private const val OUTPUT_DIRECTORY = "output_directory"
         private const val ENABLE_EXTENDED_MODE = "enable_extended_mode"
         private const val LOG_DEBUG = "log_debug"
-        private const val PROFILE = "profile"
 
         fun createOptions(): Options {
             val options = Options()
@@ -37,7 +34,6 @@ data class ReporterConfig(
             options.addOption(OVERRIDE_YAML_ARGUMENT, true, OVERRIDE_YAML_DESCRIPTION)
             options.addOption(OUTPUT_DIRECTORY, true, "Directory where the report will be written to")
             options.addOption(ENABLE_EXTENDED_MODE, false, "If set, includes trial matching details")
-            options.addOption(PROFILE, true, "${ConfigurationProfile.entries.joinToString("|") { it.name }} (optional)")
             options.addOption(LOG_DEBUG, false, "If set, debug logging gets enabled")
             return options
         }
@@ -52,19 +48,13 @@ data class ReporterConfig(
             if (enableExtendedMode) {
                 LOGGER.info("Extended reporting mode has been enabled")
             }
-
-            val configuredProfile = ApplicationConfig.optionalValue(cmd, PROFILE)
-            if (cmd.hasOption(PROFILE)) {
-                LOGGER.info("Profile has been configured as '$configuredProfile'")
-            }
-
+            
             return ReporterConfig(
                 patientJson = ApplicationConfig.nonOptionalFile(cmd, PATIENT_JSON),
                 treatmentMatchJson = ApplicationConfig.nonOptionalFile(cmd, TREATMENT_MATCH_JSON),
                 overrideYaml = ApplicationConfig.optionalFile(cmd, OVERRIDE_YAML_ARGUMENT),
                 outputDirectory = ApplicationConfig.nonOptionalDir(cmd, OUTPUT_DIRECTORY),
-                enableExtendedMode = enableExtendedMode,
-                profile = configuredProfile
+                enableExtendedMode = enableExtendedMode
             )
         }
     }

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/ReportContentProviderTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/ReportContentProviderTest.kt
@@ -1,6 +1,5 @@
 package com.hartwig.actin.report.pdf
 
-import com.hartwig.actin.configuration.EnvironmentConfiguration
 import com.hartwig.actin.datamodel.algo.TestTreatmentMatchFactory
 import com.hartwig.actin.datamodel.clinical.TumorDetails
 import com.hartwig.actin.datamodel.molecular.MolecularHistory
@@ -11,25 +10,18 @@ import com.hartwig.actin.report.datamodel.TestReportFactory
 import com.hartwig.actin.report.interpretation.InterpretedCohortFactory
 import com.hartwig.actin.report.interpretation.TumorDetailsInterpreter
 import com.hartwig.actin.report.pdf.chapters.ClinicalDetailsChapter
-import com.hartwig.actin.report.pdf.chapters.EfficacyEvidenceChapter
-import com.hartwig.actin.report.pdf.chapters.EfficacyEvidenceDetailsChapter
 import com.hartwig.actin.report.pdf.chapters.MolecularDetailsChapter
-import com.hartwig.actin.report.pdf.chapters.PersonalizedEvidenceChapter
-import com.hartwig.actin.report.pdf.chapters.ResistanceEvidenceChapter
 import com.hartwig.actin.report.pdf.chapters.SummaryChapter
 import com.hartwig.actin.report.pdf.chapters.TrialMatchingDetailsChapter
 import com.hartwig.actin.report.pdf.chapters.TrialMatchingOtherResultsChapter
 import com.hartwig.actin.report.pdf.tables.clinical.BloodTransfusionGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.MedicationGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.PatientClinicalHistoryGenerator
-import com.hartwig.actin.report.pdf.tables.clinical.PatientClinicalHistoryWithOverviewGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.PatientCurrentDetailsGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.TumorDetailsGenerator
 import com.hartwig.actin.report.pdf.tables.molecular.MolecularSummaryGenerator
-import com.hartwig.actin.report.pdf.tables.soc.SOCEligibleApprovedTreatmentGenerator
 import com.hartwig.actin.report.pdf.tables.trial.EligibleApprovedTreatmentGenerator
 import com.hartwig.actin.report.pdf.tables.trial.EligibleTrialGenerator
-import com.hartwig.actin.report.pdf.tables.trial.IneligibleTrialGenerator
 import com.hartwig.actin.report.pdf.tables.trial.TrialTableGenerator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -92,43 +84,6 @@ class ReportContentProviderTest {
             SummaryChapter::class,
             MolecularDetailsChapter::class,
             ClinicalDetailsChapter::class,
-            TrialMatchingOtherResultsChapter::class,
-            TrialMatchingDetailsChapter::class
-        )
-    }
-
-    @Test
-    fun `Should omit molecular chapter and include efficacy chapter and resistance evidence chapter when CRC profile is provided`() {
-        val report = proper.copy(
-            config = EnvironmentConfiguration.create(null, "CRC").report
-        )
-        val enableExtendedMode = false
-        val chapters = ReportContentProvider(report, enableExtendedMode).provideChapters()
-        assertThat(chapters.map { it::class }).containsExactly(
-            SummaryChapter::class,
-            PersonalizedEvidenceChapter::class,
-            ResistanceEvidenceChapter::class,
-            EfficacyEvidenceChapter::class,
-            ClinicalDetailsChapter::class,
-            EfficacyEvidenceDetailsChapter::class,
-            TrialMatchingOtherResultsChapter::class
-        )
-    }
-
-    @Test
-    fun `Should omit molecular chapter and include both efficacy chapters and resistance evidence chapter when CRC profile is provided in extended mode`() {
-        val report = proper.copy(
-            config = EnvironmentConfiguration.create(null, "CRC").report
-        )
-        val enableExtendedMode = true
-        val chapters = ReportContentProvider(report, enableExtendedMode).provideChapters()
-        assertThat(chapters.map { it::class }).containsExactly(
-            SummaryChapter::class,
-            PersonalizedEvidenceChapter::class,
-            ResistanceEvidenceChapter::class,
-            EfficacyEvidenceChapter::class,
-            ClinicalDetailsChapter::class,
-            EfficacyEvidenceDetailsChapter::class,
             TrialMatchingOtherResultsChapter::class,
             TrialMatchingDetailsChapter::class
         )
@@ -217,23 +172,7 @@ class ReportContentProviderTest {
             EligibleTrialGenerator::class
         )
     }
-
-    @Test
-    fun `Should omit molecular table summary and include SOC treatments in summary when using CRC profile`() {
-        val report = TestReportFactory.createExhaustiveTestReport().copy(
-            config = EnvironmentConfiguration.create(null, "CRC").report
-        )
-        val tables = ReportContentProvider(report).provideSummaryTables(KEY_WIDTH, VALUE_WIDTH, emptyList())
-
-        assertThat(tables.map { it::class }).containsExactly(
-            PatientClinicalHistoryWithOverviewGenerator::class,
-            SOCEligibleApprovedTreatmentGenerator::class,
-            EligibleTrialGenerator::class,
-            EligibleTrialGenerator::class,
-            IneligibleTrialGenerator::class
-        )
-    }
-
+    
     private fun assertReportCohortSizeMatchesInput(report: Report, eligibleTrialGenerators: List<EligibleTrialGenerator>) {
         val trialMatchingOtherResultsChapter =
             ReportContentProvider(report).provideChapters().filterIsInstance<TrialMatchingOtherResultsChapter>().first()

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/ReportWriterTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/ReportWriterTest.kt
@@ -1,6 +1,5 @@
 package com.hartwig.actin.report.pdf
 
-import com.hartwig.actin.configuration.EnvironmentConfiguration
 import com.hartwig.actin.report.datamodel.TestReportFactory
 import org.junit.Test
 
@@ -15,13 +14,7 @@ class ReportWriterTest {
     private val memoryWriter = ReportWriterFactory.createInMemoryReportWriter()
 
     @Test
-    fun `Should generate in-memory trial matching reports`() {
+    fun `Should generate in-memory reports`() {
         reports.forEach(memoryWriter::write)
-    }
-
-    @Test
-    fun `Should generate in-memory CRC reports`() {
-        val crcConfig = EnvironmentConfiguration.create(null, "CRC").report
-        reports.forEach { memoryWriter.write(it.copy(config = crcConfig)) }
     }
 }


### PR DESCRIPTION
To make sure @pauldwolfe cannot test us anymore :)

This removal was on my list for a while, decided today's bug is a good trigger to actually do it! 

I couldn't find any usage of the `profile` param in either pipelines or infra so assume change be merged without risk.