### PR TITLE
ACTIN-2224: Optionally remove lesions and previous tumor from summary

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -31,6 +31,8 @@ data class ReportConfiguration(
     val molecularSummaryType: MolecularSummaryType = MolecularSummaryType.STANDARD,
     val includeOtherOncologicalHistoryInSummary: Boolean = true,
     val includePatientHeader: Boolean = true,
+    val includeLesionsInTumorSummary: Boolean = true,
+    val includePreviousPrimaryInClinicalSummary: Boolean = true,
     val includeRelevantNonOncologicalHistoryInSummary: Boolean = true,
     val includeApprovedTreatmentsInSummary: Boolean = true,
     val includeTrialMatchingInSummary: Boolean = true,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/SummaryChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/SummaryChapter.kt
@@ -46,9 +46,11 @@ class SummaryChapter(
         addParagraphWithContent(patientDetailFields, document)
 
         val (stageTitle, stages) = stageSummary(report.patientRecord.tumor)
-        val tumorDetailFields = listOf(
+        val tumorDetailFields = listOfNotNull(
             "Tumor: " to report.patientRecord.tumor.name,
-            " | Lesions: " to TumorDetailsInterpreter.lesions(report.patientRecord.tumor),
+            if (report.config.includeLesionsInTumorSummary) {
+                " | Lesions: " to TumorDetailsInterpreter.lesions(report.patientRecord.tumor)
+            } else null,
             " | $stageTitle: " to stages
         )
         addParagraphWithContent(tumorDetailFields, document)

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/PatientClinicalHistoryGenerator.kt
@@ -52,7 +52,9 @@ class PatientClinicalHistoryGenerator(
             if (report.config.includeOtherOncologicalHistoryInSummary || showDetails) {
                 "Relevant other oncological history" to relevantNonSystemicPreTreatmentHistoryTable(record)
             } else null,
-            "Previous primary tumor" to priorPrimaryHistoryTable(record),
+            if (report.config.includePreviousPrimaryInClinicalSummary) {
+                "Previous primary tumor" to priorPrimaryHistoryTable(record)
+            } else null,
             if (report.config.includeRelevantNonOncologicalHistoryInSummary || showDetails) {
                 "Relevant non-oncological history" to relevantNonOncologicalHistoryTable(record)
             } else null


### PR DESCRIPTION
Request from NKI to keep summary lean. And lesions in specific are confusing since we do not capture all (only from questionnaire). 

If lesions or previous primary are relevant for trial matching, warning/fail messages + clinical details will still contain all sufficient data.