### PR TITLE
ACTIN-2286: Use sample TMB to calculate estimate SNV and INDEL counts in driver likelihood

### DIFF
--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/CurationCategory.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/CurationCategory.kt
@@ -5,7 +5,11 @@ enum class CurationCategory(val categoryName: String) {
     ADMINISTRATION_ROUTE_TRANSLATION("Administration Route Translation"),
     BLOOD_TRANSFUSION_TRANSLATION("Blood Transfusion Translation"),
     COMORBIDITY("Comorbidity"),
+    COMPLICATION("Complication"),
     DOSAGE_UNIT_TRANSLATION("Dosage Unit Translation"),
+    ECG("ECG"),
+    INFECTION("Infection"),
+    INTOLERANCE("Intolerance"),
     LAB_MEASUREMENT("Lab Measurement"),
     LESION_LOCATION("Lesion Location"),
     MEDICATION_DOSAGE("Medication Dosage"),
@@ -18,6 +22,7 @@ enum class CurationCategory(val categoryName: String) {
     PERIOD_BETWEEN_UNIT_INTERPRETATION("Period Between Unit Interpretation"),
     QUESTIONNAIRE_MAPPING("Questionnaire mapping"),
     PRIOR_PRIMARY("Prior Primary"),
+    TOXICITY("Toxicity"),
     TOXICITY_TRANSLATION("Toxicity Translation"),
     SURGERY("Surgery")
 }

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/CurationCategory.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/ingestion/CurationCategory.kt
@@ -5,11 +5,7 @@ enum class CurationCategory(val categoryName: String) {
     ADMINISTRATION_ROUTE_TRANSLATION("Administration Route Translation"),
     BLOOD_TRANSFUSION_TRANSLATION("Blood Transfusion Translation"),
     COMORBIDITY("Comorbidity"),
-    COMPLICATION("Complication"),
     DOSAGE_UNIT_TRANSLATION("Dosage Unit Translation"),
-    ECG("ECG"),
-    INFECTION("Infection"),
-    INTOLERANCE("Intolerance"),
     LAB_MEASUREMENT("Lab Measurement"),
     LESION_LOCATION("Lesion Location"),
     MEDICATION_DOSAGE("Medication Dosage"),
@@ -22,7 +18,6 @@ enum class CurationCategory(val categoryName: String) {
     PERIOD_BETWEEN_UNIT_INTERPRETATION("Period Between Unit Interpretation"),
     QUESTIONNAIRE_MAPPING("Questionnaire mapping"),
     PRIOR_PRIMARY("Prior Primary"),
-    TOXICITY("Toxicity"),
     TOXICITY_TRANSLATION("Toxicity Translation"),
     SURGERY("Surgery")
 }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterApplication.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterApplication.kt
@@ -10,7 +10,6 @@ import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.PanelRecord
 import com.hartwig.actin.datamodel.molecular.PanelSpecifications
 import com.hartwig.actin.datamodel.molecular.RefGenomeVersion
-import com.hartwig.actin.molecular.driverlikelihood.GeneDriverLikelihoodModel
 import com.hartwig.actin.molecular.evidence.EvidenceAnnotator
 import com.hartwig.actin.molecular.evidence.EvidenceAnnotatorFactory
 import com.hartwig.actin.molecular.evidence.ServeLoader
@@ -34,6 +33,7 @@ import com.hartwig.actin.tools.transvar.TransvarVariantAnnotatorFactory
 import com.hartwig.hmftools.datamodel.orange.OrangeRefGenomeVersion
 import com.hartwig.serve.datamodel.ServeDatabase
 import com.hartwig.serve.datamodel.ServeRecord
+import kotlin.system.exitProcess
 import kotlinx.coroutines.runBlocking
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
@@ -41,7 +41,6 @@ import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
-import kotlin.system.exitProcess
 import com.hartwig.actin.tools.ensemblcache.RefGenome as EnsemblRefGenome
 
 private val CLINICAL_TESTS_REF_GENOME_VERSION = RefGenomeVersion.V37
@@ -107,7 +106,6 @@ class MolecularInterpreterApplication(private val config: MolecularInterpreterCo
         val serveRecord = selectForRefGenomeVersion(inputData.serveDatabase, CLINICAL_TESTS_REF_GENOME_VERSION)
 
         LOGGER.info("Interpreting {} prior sequencing test(s)", clinical.sequencingTests.size)
-        val geneDriverLikelihoodModel = GeneDriverLikelihoodModel(inputData.dndsDatabase)
         val variantAnnotator = TransvarVariantAnnotatorFactory.withRefGenome(
             toEnsemblRefGenomeVersion(CLINICAL_TESTS_REF_GENOME_VERSION), config.referenceGenomeFastaPath, inputData.ensemblDataCache
         )
@@ -122,7 +120,7 @@ class MolecularInterpreterApplication(private val config: MolecularInterpreterCo
         val panelCopyNumberAnnotator = PanelCopyNumberAnnotator(inputData.ensemblDataCache)
         val panelVirusAnnotator = PanelVirusAnnotator()
         val panelDriverAttributeAnnotator =
-            PanelDriverAttributeAnnotator(KnownEventResolverFactory.create(serveRecord.knownEvents()), geneDriverLikelihoodModel)
+            PanelDriverAttributeAnnotator(KnownEventResolverFactory.create(serveRecord.knownEvents()), inputData.dndsDatabase)
         val evidenceAnnotator = EvidenceAnnotatorFactory.createPanelRecordAnnotator(serveRecord, inputData.doidEntry, tumorDoids)
 
         val sequencingMolecularTests = interpretSequencingMolecularTests(

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterInputData.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/MolecularInterpreterInputData.kt
@@ -7,6 +7,7 @@ import com.hartwig.actin.datamodel.molecular.RefGenomeVersion
 import com.hartwig.actin.doid.datamodel.DoidEntry
 import com.hartwig.actin.doid.serialization.DoidJson
 import com.hartwig.actin.molecular.driverlikelihood.DndsDatabase
+import com.hartwig.actin.molecular.driverlikelihood.DndsModel
 import com.hartwig.actin.molecular.evidence.ServeLoader
 import com.hartwig.actin.molecular.panel.PanelSpecificationsFile
 import com.hartwig.actin.tools.ensemblcache.EnsemblDataCache
@@ -17,7 +18,6 @@ import com.hartwig.hmftools.datamodel.orange.OrangeRecord
 import com.hartwig.serve.datamodel.ServeDatabase
 import com.hartwig.serve.datamodel.serialization.ServeJson
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/driverlikelihood/DndsModel.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/driverlikelihood/DndsModel.kt
@@ -1,12 +1,12 @@
 package com.hartwig.actin.molecular.driverlikelihood
 
-import com.fasterxml.jackson.databind.ObjectReader
 import com.fasterxml.jackson.dataformat.csv.CsvMapper
 import com.fasterxml.jackson.dataformat.csv.CsvSchema
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.hartwig.actin.datamodel.molecular.characteristics.TumorMutationalBurden
 import com.hartwig.actin.datamodel.molecular.driver.GeneRole
-import org.apache.commons.math3.distribution.PoissonDistribution
 import java.io.File
+import org.apache.commons.math3.distribution.PoissonDistribution
 
 enum class DndsDriverType {
     INDEL, NONSENSE, MISSENSE, SPLICE
@@ -29,10 +29,35 @@ data class DndsGeneEntry(
     val indelPassengersPerMutation: Double
 )
 
-private const val ESTIMATED_MUTATION_COUNT_SNV = 30000
-private const val ESTIMATED_MUTATION_COUNT_FRAMESHIFT = 1000
+data class DndsDatabase(val oncoDndsGeneEntries: List<DndsGeneEntry>, val tsgDndsGeneEntries: List<DndsGeneEntry>) {
+    companion object {
+        fun create(oncoDndsPath: String, tsgDndsPath: String): DndsDatabase {
+            val reader =
+                CsvMapper().apply { registerModule(KotlinModule.Builder().build()) }.readerFor(DndsGeneEntry::class.java)
+                    .with(CsvSchema.emptySchema().withHeader().withColumnSeparator('\t'))
+            return DndsDatabase(
+                reader.readValues<DndsGeneEntry>(File(oncoDndsPath)).readAll(),
+                reader.readValues<DndsGeneEntry>(File(tsgDndsPath)).readAll()
+            )
+        }
+    }
+}
 
-class DndsDatabase(
+private const val ESTIMATED_TMB = 10.0
+private const val ESTIMATED_SNV_TO_INDEL_RATIO = 30
+private const val MB_PER_GENOME = 2859
+
+data class VariantEstimates(val snvCount: Int, val indelCount: Int)
+
+fun estimateVariants(tmb: Double, snvToIndelRatio: Int = ESTIMATED_SNV_TO_INDEL_RATIO): VariantEstimates {
+    val estimatedTotalVariants = tmb * MB_PER_GENOME
+    val indelCount = estimatedTotalVariants / (snvToIndelRatio + 1)
+    val snvCount = estimatedTotalVariants - indelCount
+
+    return VariantEstimates(snvCount.toInt(), indelCount.toInt())
+}
+
+class DndsModel(
     private val oncoGeneLookup: Map<String, Map<DndsDriverType, DndsDatabaseEntry>>,
     private val tsgGeneLookup: Map<String, Map<DndsDriverType, DndsDatabaseEntry>>,
 ) {
@@ -46,40 +71,39 @@ class DndsDatabase(
     }
 
     companion object {
-        fun create(oncoDndsFilePath: String, tsgDndsFilePath: String): DndsDatabase {
-            val reader =
-                CsvMapper().apply { registerModule(KotlinModule.Builder().build()) }.readerFor(DndsGeneEntry::class.java)
-                    .with(CsvSchema.emptySchema().withHeader().withColumnSeparator('\t'))
-            val oncoGeneLookup = geneLookup(reader, oncoDndsFilePath)
-            val tsgGeneLookup = geneLookup(reader, tsgDndsFilePath)
-            return DndsDatabase(oncoGeneLookup, tsgGeneLookup)
+        fun create(dndsDatabase: DndsDatabase, tumorMutationalBurden: TumorMutationalBurden?): DndsModel {
+            val estimates = estimateVariants(tumorMutationalBurden?.score ?: ESTIMATED_TMB)
+            return DndsModel(
+                geneLookup(dndsDatabase.oncoDndsGeneEntries, estimates),
+                geneLookup(dndsDatabase.tsgDndsGeneEntries, estimates)
+            )
         }
 
         private fun geneLookup(
-            reader: ObjectReader,
-            oncoDndFilePath: String
-        ) = reader.readValues<DndsGeneEntry>(File(oncoDndFilePath)).readAll().groupBy { it.gene }.mapValues {
+            entries: List<DndsGeneEntry>,
+            estimates: VariantEstimates
+        ) = entries.groupBy { it.gene }.mapValues {
             it.value.flatMap { geneEntry ->
                 listOf(
                     DndsDriverType.NONSENSE to createEntry(
                         geneEntry.nonsenseVusDriversPerSample,
                         geneEntry.nonsensePassengersPerMutation,
-                        ESTIMATED_MUTATION_COUNT_SNV
+                        estimates.snvCount
                     ),
                     DndsDriverType.INDEL to createEntry(
                         geneEntry.indelVusDriversPerSample,
                         geneEntry.indelPassengersPerMutation,
-                        ESTIMATED_MUTATION_COUNT_FRAMESHIFT,
+                        estimates.indelCount,
                     ),
                     DndsDriverType.MISSENSE to createEntry(
                         geneEntry.missenseVusDriversPerSample,
                         geneEntry.missensePassengersPerMutation,
-                        ESTIMATED_MUTATION_COUNT_SNV,
+                        estimates.snvCount,
                     ),
                     DndsDriverType.SPLICE to createEntry(
                         geneEntry.spliceVusDriversPerSample,
                         geneEntry.splicePassengersPerMutation,
-                        ESTIMATED_MUTATION_COUNT_SNV
+                        estimates.snvCount
                     )
                 )
             }.groupBy { databaseEntries -> databaseEntries.first }.mapValues { entry -> entry.value.first().second }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/driverlikelihood/GeneDriverLikelihoodModel.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/driverlikelihood/GeneDriverLikelihoodModel.kt
@@ -6,7 +6,7 @@ import com.hartwig.actin.datamodel.molecular.driver.Variant
 import com.hartwig.actin.datamodel.molecular.driver.VariantType
 import kotlin.math.max
 
-class GeneDriverLikelihoodModel(private val dndsDatabase: DndsDatabase) {
+class GeneDriverLikelihoodModel(private val dndsModel: DndsModel) {
 
     fun evaluate(gene: String, geneRole: GeneRole, variants: List<Variant>): Double? {
         val hasCancerAssociatedVariant = variants.any { it.isCancerAssociatedVariant }
@@ -19,7 +19,11 @@ class GeneDriverLikelihoodModel(private val dndsDatabase: DndsDatabase) {
         }
     }
 
-    private fun handleVariantsOfUnknownSignificance(gene: String, geneRole: GeneRole, variants: List<Variant>): Double? {
+    private fun handleVariantsOfUnknownSignificance(
+        gene: String,
+        geneRole: GeneRole,
+        variants: List<Variant>
+    ): Double? {
         return when (geneRole) {
             GeneRole.ONCO -> oncoLikelihood(lookupDndsPerVariant(variants, gene, geneRole))
 
@@ -63,7 +67,7 @@ class GeneDriverLikelihoodModel(private val dndsDatabase: DndsDatabase) {
             DndsDriverType.MISSENSE -> 4
         }
     }.mapNotNull {
-        dndsDatabase.find(gene, geneRole, it)
+        dndsModel.find(gene, geneRole, it)
     }
 
     private fun oncoLikelihood(dndsEntries: List<DndsDatabaseEntry>): Double? {

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/driverlikelihood/DndsModelTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/driverlikelihood/DndsModelTest.kt
@@ -1,6 +1,8 @@
 package com.hartwig.actin.molecular.driverlikelihood
 
+import com.hartwig.actin.datamodel.molecular.characteristics.TumorMutationalBurden
 import com.hartwig.actin.datamodel.molecular.driver.GeneRole
+import com.hartwig.actin.datamodel.molecular.evidence.ClinicalEvidence
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Test
@@ -8,31 +10,41 @@ import org.junit.Test
 val TEST_ONCO_DNDS_TSV = System.getProperty("user.dir") + "/src/test/resources/interpretation/dnds_driver_likelihood_onco.tsv"
 val TEST_TSG_DNDS_TSV = System.getProperty("user.dir") + "/src/test/resources/interpretation/dnds_driver_likelihood_tsg.tsv"
 
-class DndsDatabaseTest {
+class DndsModelTest {
 
-    private val database = DndsDatabase.create(TEST_ONCO_DNDS_TSV, TEST_TSG_DNDS_TSV)
+    private val database = DndsModel.create(DndsDatabase.create(TEST_ONCO_DNDS_TSV, TEST_TSG_DNDS_TSV), tumorMutationalBurden = null)
 
     @Test
-    fun `Should load database from onco and tsg dnd TSVs and calculate probability of non-driver`() {
-        assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.INDEL)).isEqualTo(DndsDatabaseEntry(0.0, 8.308359783759656E-5))
+    fun `Should load database from onco and tsg dnd TSVs and calculate probability of non-driver with a default TMB of 10`() {
+        assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.INDEL)).isEqualTo(DndsDatabaseEntry(0.0, 7.660332542758219E-5))
         assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.NONSENSE)).isEqualTo(
             DndsDatabaseEntry(
                 9.26041369655672E-5,
-                4.0949897767694754E-4
+                3.776596213239669E-4
             )
         )
         assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.MISSENSE)).isEqualTo(
             DndsDatabaseEntry(
                 0.00524550351936585,
-                0.005617584377687335
+                0.005181857483946728
             )
         )
         assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.SPLICE)).isEqualTo(
             DndsDatabaseEntry(
                 1.38906205448351E-4,
-                6.141855786931938E-4
+                5.664359435727517E-4
             )
         )
+    }
+
+    @Test
+    fun `Should use estimated variant counts based on TMB when given`() {
+        val database = DndsModel.create(
+            DndsDatabase.create(TEST_ONCO_DNDS_TSV, TEST_TSG_DNDS_TSV), tumorMutationalBurden = TumorMutationalBurden(
+                6.4, false, ClinicalEvidence(emptySet(), emptySet())
+            )
+        )
+        assertThat(database.find("BRAF", GeneRole.ONCO, DndsDriverType.INDEL)).isEqualTo(DndsDatabaseEntry(0.0, 4.9020157660617514E-5))
     }
 
     @Test

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelDriverAttributeAnnotatorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelDriverAttributeAnnotatorTest.kt
@@ -12,7 +12,6 @@ import com.hartwig.actin.datamodel.molecular.driver.TestVariantAlterationFactory
 import com.hartwig.actin.datamodel.molecular.driver.Variant
 import com.hartwig.actin.datamodel.molecular.evidence.TestClinicalEvidenceFactory
 import com.hartwig.actin.molecular.driverlikelihood.DndsDatabase
-import com.hartwig.actin.molecular.driverlikelihood.GeneDriverLikelihoodModel
 import com.hartwig.actin.molecular.driverlikelihood.TEST_ONCO_DNDS_TSV
 import com.hartwig.actin.molecular.driverlikelihood.TEST_TSG_DNDS_TSV
 import com.hartwig.actin.molecular.evidence.known.KnownEventResolver
@@ -40,8 +39,10 @@ private val NON_CANCER_ASSOCIATED_VARIANT =
 class PanelDriverAttributeAnnotatorTest {
 
     private val knownEventResolver = mockk<KnownEventResolver>()
-    private val geneDriverLikelihoodModel = GeneDriverLikelihoodModel(DndsDatabase.create(TEST_ONCO_DNDS_TSV, TEST_TSG_DNDS_TSV))
-    private val panelDriverAttributeAnnotator = PanelDriverAttributeAnnotator(knownEventResolver, geneDriverLikelihoodModel)
+    private val panelDriverAttributeAnnotator = PanelDriverAttributeAnnotator(
+        knownEventResolver,
+        DndsDatabase.create(TEST_ONCO_DNDS_TSV, TEST_TSG_DNDS_TSV)
+    )
 
     @Test
     fun `Should annotate variant that is a cancer-associated variant`() {


### PR DESCRIPTION
Assumed a fixed mb per genome of 2859 and a 30/1 ration of snv to indel. The reduced mb per genome causes small differences in the results, hence changes to test values are expected.