### PR TITLE
ACTIN-2287: Swap 'text' and 'item' so it's the same for all IHC results

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/interpretation/IhcTestInterpreter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/interpretation/IhcTestInterpreter.kt
@@ -36,7 +36,7 @@ class IhcTestInterpreter {
                 1
             )
 
-            scoreText != null -> interpretationBuilder.addInterpretation(type, scoreText, item, date, 0)
+            scoreText != null -> interpretationBuilder.addInterpretation(type, item, scoreText, date, 0)
             scoreValue != null -> interpretationBuilder.addInterpretation(type, item, formatValueBasedIhcTest(test), date, 1)
             else -> logger.error("IHC test is neither text-based nor value-based: {}", test)
         }


### PR DESCRIPTION
See https://hartwigmedical.atlassian.net/jira/software/projects/ACTIN/boards/45 for an example why this is clearer to me

Also in practice we usually don't have too many per report with equal text so I think this is clearer