### PR TITLE
ACTIN-2351: Add per-location cohort open status and slots

### DIFF
--- a/common/src/test/kotlin/com/hartwig/actin/algo/sort/CohortMatchComparatorTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/algo/sort/CohortMatchComparatorTest.kt
@@ -1,6 +1,7 @@
 package com.hartwig.actin.algo.sort
 
 import com.hartwig.actin.datamodel.algo.CohortMatch
+import com.hartwig.actin.datamodel.trial.CohortAvailability
 import com.hartwig.actin.datamodel.trial.CohortMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -21,8 +22,10 @@ class CohortMatchComparatorTest {
             metadata = CohortMetadata(
                 cohortId = id,
                 evaluable = true,
-                open = true,
-                slotsAvailable = true,
+                cohortAvailability = CohortAvailability(
+                    open = true,
+                    slotsAvailable = true
+                ),
                 ignore = false,
                 description = "",
             ),

--- a/common/src/test/kotlin/com/hartwig/actin/trial/sort/CohortComparatorTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/trial/sort/CohortComparatorTest.kt
@@ -1,6 +1,7 @@
 package com.hartwig.actin.trial.sort
 
 import com.hartwig.actin.datamodel.trial.Cohort
+import com.hartwig.actin.datamodel.trial.CohortAvailability
 import com.hartwig.actin.datamodel.trial.CohortMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -20,12 +21,14 @@ class CohortComparatorTest {
             metadata = CohortMetadata(
                 cohortId = id,
                 evaluable = true,
-                open = true,
-                slotsAvailable = true,
+                cohortAvailability = CohortAvailability(
+                    true,
+                    slotsAvailable = true
+                ),
                 ignore = false,
                 description = ""
             ),
             eligibility = emptyList()
-        ) 
+        )
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/trial/sort/CohortMetadataComparatorTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/trial/sort/CohortMetadataComparatorTest.kt
@@ -1,11 +1,12 @@
 package com.hartwig.actin.trial.sort
 
+import com.hartwig.actin.datamodel.trial.CohortAvailability
 import com.hartwig.actin.datamodel.trial.CohortMetadata
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class CohortMetadataComparatorTest {
-   
+
     @Test
     fun `Should sort cohort metadata`() {
         val metadata1 = metadata("A", "A First", open = true, ignore = false)
@@ -25,10 +26,9 @@ class CohortMetadataComparatorTest {
     private fun metadata(cohortId: String, description: String, open: Boolean, ignore: Boolean): CohortMetadata {
         return CohortMetadata(
             evaluable = true,
-            slotsAvailable = true,
+            cohortAvailability = CohortAvailability(slotsAvailable = true, open = open),
             cohortId = cohortId,
             description = description,
-            open = open,
             ignore = ignore
         )
     }

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/trial/CohortMetadata.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/trial/CohortMetadata.kt
@@ -1,10 +1,15 @@
 package com.hartwig.actin.datamodel.trial
 
+data class CohortAvailability(val open: Boolean, val slotsAvailable: Boolean)
+
 data class CohortMetadata(
     val cohortId: String,
     val evaluable: Boolean,
-    val open: Boolean,
-    val slotsAvailable: Boolean,
+    val cohortAvailability: CohortAvailability,
+    val availabilityByLocation: Map<String, CohortAvailability>? = null,
     val ignore: Boolean,
     val description: String
-)
+) {
+    val open = cohortAvailability.open
+    val slotsAvailable = cohortAvailability.slotsAvailable
+}

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/algo/TestTreatmentMatchFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/algo/TestTreatmentMatchFactory.kt
@@ -10,6 +10,7 @@ import com.hartwig.actin.datamodel.personalization.PersonalizedDataAnalysis
 import com.hartwig.actin.datamodel.personalization.Population
 import com.hartwig.actin.datamodel.personalization.TreatmentAnalysis
 import com.hartwig.actin.datamodel.personalization.TreatmentGroup
+import com.hartwig.actin.datamodel.trial.CohortAvailability
 import com.hartwig.actin.datamodel.trial.CohortMetadata
 import com.hartwig.actin.datamodel.trial.Eligibility
 import com.hartwig.actin.datamodel.trial.EligibilityFunction
@@ -147,8 +148,7 @@ object TestTreatmentMatchFactory {
         return CohortMetadata(
             cohortId = cohortId,
             evaluable = evaluable,
-            open = open,
-            slotsAvailable = slotsAvailable,
+            cohortAvailability = CohortAvailability(open, slotsAvailable),
             ignore = ignore,
             description = "Cohort $cohortId"
         )

--- a/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/trial/TestTrialFactory.kt
+++ b/datamodel/src/test/kotlin/com/hartwig/actin/datamodel/trial/TestTrialFactory.kt
@@ -79,8 +79,10 @@ object TestTrialFactory {
         return CohortMetadata(
             cohortId = cohortId,
             evaluable = evaluable,
-            open = true,
-            slotsAvailable = true,
+            cohortAvailability = CohortAvailability(
+                open = true,
+                slotsAvailable = true
+            ),
             ignore = false,
             description = "Cohort $cohortId"
         )


### PR DESCRIPTION
Added in a backwards compatible way, these fields will be populated by an upcoming actin-trial PR