### PR TITLE
ACTIN-2378: Add all "noMutationsFound" is true genes to 'tested genes'

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
@@ -24,7 +24,11 @@ class PanelSpecifications(panelSpecifications: Map<PanelTestSpecification, List<
                 "Panel [${testSpec.testName}${testSpec.versionDate?.let { " version $it" } ?: ""}] is not found in panel specifications. Check curation and map to one " +
                         "of [${molecularTargetsPerTest.keys.joinToString()}] or add this panel to the specification TSV."
             )
-        val mergedTargets = baseTargets + (negativeResults?.associate { it.gene to listOf(it.molecularTestTarget) } ?: emptyMap())
+        val negativeTargets = (negativeResults?.associate { it.gene to listOf(it.molecularTestTarget) } ?: emptyMap())
+        val mergedTargets = (baseTargets.keys + negativeTargets.keys)
+            .associateWith { gene ->
+                (baseTargets[gene] ?: emptyList()) + (negativeTargets[gene] ?: emptyList())
+            }
         return PanelTargetSpecification(mergedTargets)
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
@@ -1,22 +1,30 @@
 package com.hartwig.actin.molecular.panel
 
+import com.hartwig.actin.datamodel.clinical.SequencedNegativeResult
+import com.hartwig.actin.datamodel.molecular.MolecularTestTarget
 import com.hartwig.actin.datamodel.molecular.panel.PanelTargetSpecification
 import com.hartwig.actin.datamodel.molecular.panel.PanelTestSpecification
 
 class PanelSpecifications(panelSpecifications: Map<PanelTestSpecification, List<PanelGeneSpecification>>) {
 
-    private val molecularTargetsPerTest: Map<PanelTestSpecification, PanelTargetSpecification> = panelSpecifications.mapValues { (_, geneSpecs) ->
-        PanelTargetSpecification(
-            geneSpecs.groupBy(PanelGeneSpecification::geneName).mapValues { it.value.flatMap(PanelGeneSpecification::targets) })
+    private val molecularTargetsPerTest: Map<PanelTestSpecification, Map<String, List<MolecularTestTarget>>> =
+        panelSpecifications.mapValues { (_, geneSpecs) ->
+            geneSpecs.groupBy(PanelGeneSpecification::geneName).mapValues { it.value.flatMap(PanelGeneSpecification::targets) }
     }
 
     val panelTestSpecifications: Set<PanelTestSpecification>
         get() = molecularTargetsPerTest.keys
 
-    fun panelTargetSpecification(testSpec: PanelTestSpecification): PanelTargetSpecification {
-        return molecularTargetsPerTest[testSpec] ?: throw IllegalStateException(
-            "Panel [${testSpec.testName}${testSpec.versionDate?.let { " version $it" } ?: ""}] is not found in panel specifications. Check curation and map to one " +
-                    "of [${molecularTargetsPerTest.keys.joinToString()}] or add this panel to the specification TSV."
-        )
+    fun panelTargetSpecification(
+        testSpec: PanelTestSpecification,
+        negativeResults: Set<SequencedNegativeResult>?
+    ): PanelTargetSpecification {
+        val baseTargets = molecularTargetsPerTest[testSpec]
+            ?: throw IllegalStateException(
+                "Panel [${testSpec.testName}${testSpec.versionDate?.let { " version $it" } ?: ""}] is not found in panel specifications. Check curation and map to one " +
+                        "of [${molecularTargetsPerTest.keys.joinToString()}] or add this panel to the specification TSV."
+            )
+        val mergedTargets = baseTargets + (negativeResults?.associate { it.gene to listOf(it.molecularTestTarget) } ?: emptyMap())
+        return PanelTargetSpecification(mergedTargets)
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelGeneSpecificationsFileTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelGeneSpecificationsFileTest.kt
@@ -12,12 +12,12 @@ class PanelGeneSpecificationsFileTest {
     @Test
     fun `Should read from panel gene list TSV and match gene lists on test name regex`() {
         val geneList = PanelGeneSpecificationsFile.create(ResourceLocator.resourceOnClasspath("panel_specifications/panel_specifications.tsv"))
-        val oncoPanel = geneList.panelTargetSpecification(PanelTestSpecification("oncopanel", LocalDate.of(2022, 1, 1)))
+        val oncoPanel = geneList.panelTargetSpecification(PanelTestSpecification("oncopanel", LocalDate.of(2022, 1, 1)), null)
         Assertions.assertThat(oncoPanel.testsGene("ABCB1") { it == listOf(MolecularTestTarget.MUTATION) }).isTrue()
         Assertions.assertThat(oncoPanel.testsGene("EGFR") { it == listOf(MolecularTestTarget.MUTATION) }).isFalse()
         Assertions.assertThat(oncoPanel.testsGene("ALK") { it == listOf(MolecularTestTarget.MUTATION) }).isFalse()
         Assertions.assertThat(oncoPanel.testsGene("ABCB1") { it == listOf(MolecularTestTarget.FUSION) }).isFalse()
-        val archer = geneList.panelTargetSpecification(PanelTestSpecification("archer"))
+        val archer = geneList.panelTargetSpecification(PanelTestSpecification("archer"), null)
         Assertions.assertThat(archer.testsGene("ALK") { it == MolecularTestTarget.entries }).isTrue()
         Assertions.assertThat(archer.testsGene("ROS1") { it == listOf(MolecularTestTarget.MUTATION, MolecularTestTarget.FUSION) }).isTrue()
         Assertions.assertThat(archer.testsGene("ABCB1") { it == MolecularTestTarget.entries }).isFalse()
@@ -27,7 +27,7 @@ class PanelGeneSpecificationsFileTest {
     fun `Should group genes correctly by test specification`() {
         val geneList = PanelGeneSpecificationsFile.create(ResourceLocator.resourceOnClasspath("panel_specifications/panel_specifications.tsv"))
         val (oldOncoPanel, newOncoPanel) = listOf(LocalDate.of(2022, 1, 1), LocalDate.of(2023, 1, 1)).map {
-            geneList.panelTargetSpecification(PanelTestSpecification("oncopanel", it))
+            geneList.panelTargetSpecification(PanelTestSpecification("oncopanel", it), null)
         }
         Assertions.assertThat(oldOncoPanel.testsGene("ABCB1") { it == listOf(MolecularTestTarget.MUTATION) }).isTrue()
         Assertions.assertThat(oldOncoPanel.testsGene("EGFR") { it == listOf(MolecularTestTarget.MUTATION) }).isFalse()

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
@@ -32,13 +32,13 @@ class PanelSpecificationsTest {
     @Test
     fun `Should return false if gene is not in specification`() {
         val specification = PanelTargetSpecification(mapOf(GENE to emptyList()))
-        assertThat(specification.testsGene(ANOTHER_GENE) { true })
+        assertThat(specification.testsGene(ANOTHER_GENE) { true }).isFalse()
     }
 
     @Test
     fun `Should resolve a panels specification from the set of all specification by name and negative results`() {
         val panelSpec = PanelTestSpecification("panel", null)
-        val negativeResults = setOf(SequencedNegativeResult(ANOTHER_GENE, MolecularTestTarget.FUSION))
+        val negativeResults = setOf(SequencedNegativeResult(GENE, MolecularTestTarget.FUSION))
         val specification = PanelSpecifications(
             mapOf(
                 panelSpec to listOf(
@@ -49,8 +49,7 @@ class PanelSpecificationsTest {
                 )
             )
         ).panelTargetSpecification(panelSpec, negativeResults)
-        assertThat(specification.testsGene(GENE) { it == listOf(MolecularTestTarget.MUTATION) })
-        assertThat(specification.testsGene(ANOTHER_GENE) { it == listOf(MolecularTestTarget.FUSION) })
+        assertThat(specification.testsGene(GENE) { it == listOf(MolecularTestTarget.MUTATION, MolecularTestTarget.FUSION) }).isTrue()
     }
 
     @Test
@@ -71,21 +70,28 @@ class PanelSpecificationsTest {
     }
 
     @Test
-    fun `Should return true when specifications derived from test and fusion is on gene`() {
+    fun `Should return true when specifications derived from test and fusion and amplification is on gene`() {
         val geneDown = "gene down"
         val derivedSpecification =
             PanelTargetSpecification(
                 derivedGeneTargetMap(
                     SequencingTest(
                         test = TEST,
-                        fusions = setOf(SequencedFusion(geneUp = GENE, geneDown = geneDown))
+                        fusions = setOf(SequencedFusion(geneUp = GENE, geneDown = geneDown)),
+                        amplifications = setOf(SequencedAmplification(gene = GENE))
                     )
                 )
             )
-        assertThat(derivedSpecification.testsGene(GENE, predicateForTargets(MolecularTestTarget.FUSION))).isTrue()
+        assertThat(derivedSpecification.testsGene(GENE) {
+            it == listOf(
+                MolecularTestTarget.FUSION,
+                MolecularTestTarget.MUTATION,
+                MolecularTestTarget.AMPLIFICATION
+            )
+        }).isTrue()
         assertThat(derivedSpecification.testsGene(geneDown, predicateForTargets(MolecularTestTarget.FUSION))).isTrue()
         assertThat(derivedSpecification.testsGene(ANOTHER_GENE, predicateForTargets(MolecularTestTarget.FUSION))).isFalse()
-        assertThat(derivedSpecification.testsGene(GENE, predicateForTargets(MolecularTestTarget.MUTATION))).isFalse()
+        assertThat(derivedSpecification.testsGene(GENE, predicateForTargets(MolecularTestTarget.DELETION))).isFalse()
     }
 
     @Test

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
@@ -3,6 +3,7 @@ package com.hartwig.actin.molecular.panel
 import com.hartwig.actin.datamodel.clinical.SequencedAmplification
 import com.hartwig.actin.datamodel.clinical.SequencedDeletion
 import com.hartwig.actin.datamodel.clinical.SequencedFusion
+import com.hartwig.actin.datamodel.clinical.SequencedNegativeResult
 import com.hartwig.actin.datamodel.clinical.SequencedSkippedExons
 import com.hartwig.actin.datamodel.clinical.SequencedVariant
 import com.hartwig.actin.datamodel.clinical.SequencingTest
@@ -35,8 +36,9 @@ class PanelSpecificationsTest {
     }
 
     @Test
-    fun `Should resolve a panels specification from the set of all specification by name`() {
+    fun `Should resolve a panels specification from the set of all specification by name and negative results`() {
         val panelSpec = PanelTestSpecification("panel", null)
+        val negativeResults = setOf(SequencedNegativeResult(ANOTHER_GENE, MolecularTestTarget.FUSION))
         val specification = PanelSpecifications(
             mapOf(
                 panelSpec to listOf(
@@ -46,15 +48,16 @@ class PanelSpecificationsTest {
                     )
                 )
             )
-        ).panelTargetSpecification(panelSpec)
+        ).panelTargetSpecification(panelSpec, negativeResults)
         assertThat(specification.testsGene(GENE) { it == listOf(MolecularTestTarget.MUTATION) })
+        assertThat(specification.testsGene(ANOTHER_GENE) { it == listOf(MolecularTestTarget.FUSION) })
     }
 
     @Test
     fun `Should throw illegal state exception when a panel name is not found`() {
         assertThatThrownBy {
             val specifications = PanelSpecifications(emptyMap())
-            specifications.panelTargetSpecification(PanelTestSpecification("panel"))
+            specifications.panelTargetSpecification(PanelTestSpecification("panel"), null)
         }.isInstanceOfAny(IllegalStateException::class.java)
     }
 

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/SequencingTest.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/SequencingTest.kt
@@ -1,6 +1,7 @@
 package com.hartwig.actin.datamodel.clinical
 
 import com.hartwig.actin.datamodel.Displayable
+import com.hartwig.actin.datamodel.molecular.MolecularTestTarget
 import com.hartwig.actin.datamodel.molecular.driver.VirusType
 import java.time.LocalDate
 
@@ -43,7 +44,7 @@ data class SequencedSkippedExons(val gene: String, val exonStart: Int, val exonE
 
 data class SequencedVirus(val type: VirusType, val isLowRisk: Boolean = false)
 
-data class SequencedNegativeResult(val gene: String)
+data class SequencedNegativeResult(val gene: String, val molecularTestTarget: MolecularTestTarget)
 
 data class SequencingTest(
     val test: String,

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentResponse.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/clinical/treatment/history/TreatmentResponse.kt
@@ -18,6 +18,19 @@ enum class TreatmentResponse : Displayable {
     companion object {
         val BENEFIT_RESPONSES = setOf(PARTIAL_RESPONSE, NEAR_COMPLETE_RESPONSE, COMPLETE_RESPONSE, REMISSION)
 
+        fun createFromString(input: String): TreatmentResponse? {
+            return when (input.uppercase()) {
+                "PD" -> PROGRESSIVE_DISEASE
+                "SD" -> STABLE_DISEASE
+                "MIXED" -> MIXED
+                "PR" -> PARTIAL_RESPONSE
+                "NEAR CR" -> NEAR_COMPLETE_RESPONSE
+                "CR" -> COMPLETE_RESPONSE
+                "REMISSION" -> REMISSION
+                else -> null
+            }
+        }
+
         fun fromString(string: String): TreatmentResponse {
             return TreatmentResponse.valueOf(
                 string.trim { it <= ' ' }.replace(" ".toRegex(), "_").uppercase()

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/panel/PanelSpecificationFunctions.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/panel/PanelSpecificationFunctions.kt
@@ -17,7 +17,7 @@ object PanelSpecificationFunctions {
                         MolecularTestTarget.MUTATION
                     )
                 } +
-                testResults.negativeResults.map { it.gene to listOf(MolecularTestTarget.MUTATION) }
+                testResults.negativeResults.map { it.gene to listOf(it.molecularTestTarget) }
     }
 
     fun determineTestVersion(

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/OrangeExtractor.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/orange/OrangeExtractor.kt
@@ -44,7 +44,7 @@ class OrangeExtractor(private val geneFilter: GeneFilter, private val panelSpeci
             immunology = ImmunologyExtraction.extract(record),
             pharmaco = PharmacoExtraction.extract(record),
             targetSpecification = if (record.experimentType() == OrangeExperimentType.TARGETED) {
-                panelSpecifications.panelTargetSpecification(PanelTestSpecification(ONCO_PANEL, LocalDate.of(2024, 12, 9)))
+                panelSpecifications.panelTargetSpecification(PanelTestSpecification(ONCO_PANEL, LocalDate.of(2024, 12, 9)), null)
             } else null
         )
     }

--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelAnnotator.kt
@@ -40,7 +40,7 @@ class PanelAnnotator(
             PanelSpecificationFunctions.determineTestVersion(input, panelSpecifications.panelTestSpecifications, registrationDate)
 
         val specification = if (input.knownSpecifications) {
-            panelSpecifications.panelTargetSpecification(PanelTestSpecification(input.test, testVersion))
+            panelSpecifications.panelTargetSpecification(PanelTestSpecification(input.test, testVersion), input.negativeResults)
         } else PanelTargetSpecification(
             PanelSpecificationFunctions.derivedGeneTargetMap(input)
         )


### PR DESCRIPTION
- Adds all genes with negative test result as tested gene (also when gene isn't specified in panel specifications)
- Uses new "noFusionsfound", "noAmplificationsFound" and "noDeletionsFound" from PR X to map to correct `MolecularTestTarget` (previously "noMutationsFound" was always mapped to `MolecularTestTarget.Mutation`, though "noMutationsFound" is also used during curation for inputs like "no ALK fusion")
- Fixes bug in `PanelSpecificationFunctions` where `MolecularTestTarget` were not correctly merged, if multiple `MolecularTestTarget` for the same gene (the value was overwritten by the use of "+")
- Adds back in `TreatmentResponse.createFromString` (my bad I removed it in another PR, but now noticed that it is used in `actin-clinical`)

Relates to PR: https://github.com/hartwigmedical/actin-clinical/pull/91