### PR TITLE
pom.xml: Fix up jvm bytecode version settings

### DIFF
--- a/algo/pom.xml
+++ b/algo/pom.xml
@@ -110,9 +110,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -101,7 +101,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
                     <compilerPlugins>
                         <plugin>no-arg</plugin>
                     </compilerPlugins>

--- a/database/pom.xml
+++ b/database/pom.xml
@@ -144,9 +144,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/datamodel/pom.xml
+++ b/datamodel/pom.xml
@@ -81,7 +81,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
                     <compilerPlugins>
                         <plugin>no-arg</plugin>
                     </compilerPlugins>

--- a/interpretation/pom.xml
+++ b/interpretation/pom.xml
@@ -77,7 +77,6 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
                     <compilerPlugins>
                         <plugin>no-arg</plugin>
                     </compilerPlugins>

--- a/molecular/pom.xml
+++ b/molecular/pom.xml
@@ -134,9 +134,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
+        <java.version>17</java.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+        <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
+
         <serve.version>8.2.0</serve.version>
         <actin-personalization.version>0.28.0</actin-personalization.version>
         <orange-datamodel.version>3.0.0</orange-datamodel.version>
@@ -49,7 +53,6 @@
 
         <kotlin.version>2.0.0</kotlin.version>
         <kotlin.compiler.apiVersion>2.0</kotlin.compiler.apiVersion>
-        <kotlin.jvm.target>11</kotlin.jvm.target>
         <kotlin.code.style>official</kotlin.code.style>
 
         <junit.version>4.13.2</junit.version>
@@ -112,10 +115,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven.compiler.plugin.version}</version>
-                    <configuration>
-                        <source>17</source>
-                        <target>17</target>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -131,9 +131,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/system/pom.xml
+++ b/system/pom.xml
@@ -114,9 +114,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <jvmTarget>${kotlin.jvm.target}</jvmTarget>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Use standard `kotlin.compiler.jvmTarget` and `maven.compiler.release` instead of setting these inside the `configuration` sections of the compile plugin everywhere. And set it to Java 17 instead of Java 11

