### PR TITLE
ACTIN-2407: Evaluate to LOW DL and provide logging instead of exception when exon not on canonical transcript

### DIFF
--- a/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelFusionAnnotator.kt
+++ b/molecular/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelFusionAnnotator.kt
@@ -104,7 +104,7 @@ class PanelFusionAnnotator(
                         KnownFusionType.PROMISCUOUS_3,
                         sequencedFusion.geneDown?.let { gene ->
                             val canonicalTranscript = canonicalTranscriptForGene(gene)
-                            checkCanonicalTranscript(canonicalTranscript, gene, it)
+                            if (!exonOnCanonicalTranscript(canonicalTranscript, gene, it)) return false
                             canonicalTranscript.transcriptName()
                         } ?: "",
                         it,
@@ -119,7 +119,7 @@ class PanelFusionAnnotator(
                         KnownFusionType.PROMISCUOUS_5,
                         sequencedFusion.geneUp?.let { gene ->
                             val canonicalTranscript = canonicalTranscriptForGene(gene)
-                            checkCanonicalTranscript(canonicalTranscript, gene, it)
+                            if (!exonOnCanonicalTranscript(canonicalTranscript, gene, it)) return false
                             canonicalTranscript.transcriptName()
                         } ?: "",
                         it,
@@ -164,10 +164,12 @@ class PanelFusionAnnotator(
             ?: throw IllegalStateException("No canonical transcript found for gene $gene")
     }
 
-    private fun checkCanonicalTranscript(transcript: TranscriptData, gene: String, exonEnd: Int) {
+    private fun exonOnCanonicalTranscript(transcript: TranscriptData, gene: String, exonEnd: Int): Boolean {
         val numberOfExons = transcript.exons().size
         if (exonEnd !in 1..numberOfExons) {
-            throw IllegalStateException("Exon $exonEnd is out of canonical transcript range 1-$numberOfExons for gene $gene")
+            logger.warn("Exon $exonEnd is out of canonical transcript range 1-$numberOfExons for gene $gene")
+            return false
         }
+        return true
     }
 }

--- a/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelFusionAnnotatorTest.kt
+++ b/molecular/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelFusionAnnotatorTest.kt
@@ -214,6 +214,25 @@ class PanelFusionAnnotatorTest {
     }
 
     @Test
+    fun `Should return false if exon is out of canonical transcript range`() {
+        every { ensembleDataCache.findGeneDataByName(GENE_START) } returns mockk {
+            every { geneId() } returns "geneId"
+        }
+
+        every { ensembleDataCache.findCanonicalTranscript("geneId") } returns mockk<TranscriptData> {
+            every { transcriptName() } returns CANONICAL_TRANSCRIPT
+            every { exons().size } returns 5
+        }
+
+        assertThat(
+            annotator.isPromiscuousWithMatchingExons(
+                FusionDriverType.PROMISCUOUS_5,
+                FULLY_SPECIFIED_SEQUENCED_FUSION.copy(exonUp = 8)
+            )
+        ).isEqualTo(false)
+    }
+
+    @Test
     fun `Should return false for known fusion pair`() {
         every { knownFusionCache.withinPromiscuousExonRange(KnownFusionType.PROMISCUOUS_5, TRANSCRIPT_END, 1, 1) } returns false
         assertThat(annotator.isPromiscuousWithMatchingExons(FusionDriverType.KNOWN_PAIR, FULLY_SPECIFIED_SEQUENCED_FUSION)).isEqualTo(false)
@@ -346,20 +365,6 @@ class PanelFusionAnnotatorTest {
     fun `Should throw exception if both genes are null`() {
         val fusion = SequencedFusion(geneUp = null, geneDown = null)
         annotator.annotate(setOf(fusion), emptySet())
-    }
-
-    @Test(expected = IllegalStateException::class)
-    fun `Should throw exception if exon is out of canonical transcript range`() {
-        every { ensembleDataCache.findGeneDataByName(GENE_START) } returns mockk {
-            every { geneId() } returns "geneId"
-        }
-
-        every { ensembleDataCache.findCanonicalTranscript("geneId") } returns mockk<TranscriptData> {
-            every { transcriptName() } returns CANONICAL_TRANSCRIPT
-            every { exons().size } returns 5
-        }
-
-        annotator.isPromiscuousWithMatchingExons(FusionDriverType.PROMISCUOUS_5, FULLY_SPECIFIED_SEQUENCED_FUSION.copy(exonUp = 8))
     }
 
     private fun setupKnownFusionCache() {


### PR DESCRIPTION
After my changes in https://github.com/hartwigmedical/actin/pull/1277 where I throw an exception if the provided exon is not present on the canonical transcript, Nina (and I) felt like a warning would be more appropriate here, since the input isn't really invalid (the exon (probably) exists on the provided transcript). Therefore changed to a warn and evaluating to LOW DL if the provided exon is not present on the canonical transcript.

We also created this related ticket: https://hartwigmedical.atlassian.net/browse/ACTIN-2406