### PR TITLE
ACTIN-2411: Make exon/codon rank available for OncoActin

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidence.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidence.kt
@@ -9,8 +9,8 @@ import com.hartwig.actin.datamodel.molecular.evidence.TreatmentEvidenceCategorie
 import com.hartwig.actin.datamodel.molecular.evidence.TreatmentEvidenceCategories.suspectResistant
 
 data class AggregatedEvidence(
-    val treatmentEvidencePerEvent: Map<String, Set<TreatmentEvidence>> = emptyMap(),
-    val eligibleTrialsPerEvent: Map<String, Set<ExternalTrial>> = emptyMap(),
+    val treatmentEvidencePerEvent: Map<AggregatedEvidenceKey, Set<TreatmentEvidence>> = emptyMap(),
+    val eligibleTrialsPerEvent: Map<AggregatedEvidenceKey, Set<ExternalTrial>> = emptyMap(),
 ) {
     fun approvedTreatmentsPerEvent() = filterMap { approved(it.value) }
     fun onLabelExperimentalTreatmentPerEvent() = filterMap { experimental(it.value, true) }
@@ -19,6 +19,6 @@ data class AggregatedEvidence(
     fun knownResistantTreatmentsPerEvent() = filterMap { knownResistant(it.value, true) }
     fun suspectResistantTreatmentsPerEvent() = filterMap { suspectResistant(it.value, true) }
 
-    private fun filterMap(mappingFunction: (Map.Entry<String, Set<TreatmentEvidence>>) -> List<TreatmentEvidence>) =
+    private fun filterMap(mappingFunction: (Map.Entry<AggregatedEvidenceKey, Set<TreatmentEvidence>>) -> List<TreatmentEvidence>) =
         treatmentEvidencePerEvent.mapValues(mappingFunction).filterValues { it.isNotEmpty() }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidenceKey.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidenceKey.kt
@@ -1,0 +1,7 @@
+package com.hartwig.actin.molecular.interpretation
+
+data class AggregatedEvidenceKey(
+    val codon: Int?,
+    val exon: Int?,
+    val event: String
+)

--- a/common/src/main/kotlin/com/hartwig/actin/molecular/util/MolecularTestPrinter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/util/MolecularTestPrinter.kt
@@ -6,6 +6,7 @@ import com.hartwig.actin.datamodel.molecular.panel.PanelRecord
 import com.hartwig.actin.datamodel.molecular.characteristics.PredictedTumorOrigin
 import com.hartwig.actin.datamodel.molecular.driver.Drivers
 import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceFactory
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKey
 import com.hartwig.actin.util.DatamodelPrinter
 import com.hartwig.actin.util.DatamodelPrinter.Companion.withDefaultIndentation
 import java.text.DecimalFormat
@@ -118,11 +119,11 @@ class MolecularTestPrinter(private val printer: DatamodelPrinter) {
         }
     }
 
-    private fun keys(map: Map<String, Any>): String {
+    private fun keys(map: Map<AggregatedEvidenceKey, Any>): String {
         return concat(map.keys)
     }
 
-    private fun concat(strings: Iterable<String>): String {
+    private fun concat(strings: Iterable<AggregatedEvidenceKey>): String {
         return strings.joinToString(", ").ifEmpty { "None" }
     }
 

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidenceKeyTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/interpretation/AggregatedEvidenceKeyTest.kt
@@ -1,0 +1,10 @@
+package com.hartwig.actin.molecular.interpretation
+
+class AggregatedEvidenceKeyTest {
+
+    companion object {
+        fun createAggregatedEvidenceKey(aggregatedEvidenceKey: String): AggregatedEvidenceKey {
+            return AggregatedEvidenceKey(null, null, aggregatedEvidenceKey)
+        }
+    }
+}

--- a/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
+++ b/interpretation/src/main/kotlin/com/hartwig/actin/report/trial/TrialsProvider.kt
@@ -5,12 +5,13 @@ import com.hartwig.actin.datamodel.algo.TreatmentMatch
 import com.hartwig.actin.datamodel.molecular.evidence.Country
 import com.hartwig.actin.datamodel.molecular.evidence.ExternalTrial
 import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceFactory
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKey
 import com.hartwig.actin.report.interpretation.InterpretedCohort
 import com.hartwig.actin.report.interpretation.InterpretedCohortFactory
 
 const val YOUNG_ADULT_CUT_OFF = 40
 
-data class EventWithExternalTrial(val event: String, val trial: ExternalTrial)
+data class EventWithExternalTrial(val aggregatedEvidenceKey: AggregatedEvidenceKey, val trial: ExternalTrial)
 
 class MolecularFilteredExternalTrials(val original: Set<EventWithExternalTrial>, val filtered: Set<EventWithExternalTrial>) {
 
@@ -164,7 +165,7 @@ fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresentInInterpret
 
 fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresentInTrials(trials: Set<EventWithExternalTrial>):
         Set<EventWithExternalTrial> {
-    return filterMolecularCriteriaAlreadyPresent(trials.map { it.event }.toSet())
+    return filterMolecularCriteriaAlreadyPresent(trials.map { it.aggregatedEvidenceKey.event }.toSet())
 }
 
 private fun hospitalsForCountry(trial: ExternalTrial, country: Country) =
@@ -185,7 +186,7 @@ fun Set<EventWithExternalTrial>.filterExclusivelyInChildrensHospitalsInReference
 
 private fun Set<EventWithExternalTrial>.filterMolecularCriteriaAlreadyPresent(presentEvents: Set<String>): Set<EventWithExternalTrial> {
     return filter {
-        !presentEvents.contains(it.event)
+        !presentEvents.contains(it.aggregatedEvidenceKey.event)
     }.toSet()
 }
 

--- a/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
+++ b/interpretation/src/test/kotlin/com/hartwig/actin/report/trial/TrialsProviderTest.kt
@@ -4,6 +4,8 @@ import com.hartwig.actin.datamodel.molecular.evidence.Country
 import com.hartwig.actin.datamodel.molecular.evidence.CountryDetails
 import com.hartwig.actin.datamodel.molecular.evidence.Hospital
 import com.hartwig.actin.datamodel.molecular.evidence.TestExternalTrialFactory
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKey
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKeyTest
 import com.hartwig.actin.report.interpretation.InterpretedCohortTestFactory
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -48,10 +50,10 @@ class TrialsProviderTest {
 
     @Test
     fun `Should filter internal trials`() {
-        val notFiltered = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(NCT_02))
+        val notFiltered = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(NCT_02))
         assertThat(
             setOf(
-                EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(nctId = NCT_01)),
+                EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(nctId = NCT_01)),
                 notFiltered
             ).filterInternalTrials(setOf(NCT_01, NCT_03))
         ).containsExactly(notFiltered)
@@ -100,17 +102,17 @@ class TrialsProviderTest {
                 molecularInclusionEvents = setOf(EGFR_TARGET)
             )
         )
-        val filtered = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL)
-        val notFiltered = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL)
+        val filtered = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL)
+        val notFiltered = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL)
         val result = setOf(filtered, notFiltered).filterMolecularCriteriaAlreadyPresentInInterpretedCohorts(interpretedCohorts)
         assertThat(result).containsExactly(notFiltered)
     }
 
     @Test
     fun `Should filter molecular criteria already matched in other trials`() {
-        val otherTrial = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL)
-        val filtered = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL)
-        val notFiltered = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL)
+        val otherTrial = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL)
+        val filtered = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL)
+        val notFiltered = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL)
         val result = setOf(filtered, notFiltered).filterMolecularCriteriaAlreadyPresentInTrials(setOf(otherTrial))
         assertThat(result).containsExactly(notFiltered)
     }
@@ -118,8 +120,8 @@ class TrialsProviderTest {
     @Test
     fun `externalTrialsUnfiltered should not filter external trials`() {
         val country1Trial1 =
-            EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_01))
-        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_01))
+        val country2Trial1 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
 
         val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country2Trial1)
         val trialsProvider =
@@ -134,10 +136,10 @@ class TrialsProviderTest {
 
     @Test
     fun `externalTrials should filter internal trials and return filtered and original equal with extended mode`() {
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        val country1Trial1 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
         val country1Trial2 =
-            EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
-        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
+        val country2Trial1 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
 
         val externalTrialsSet: Set<EventWithExternalTrial> = setOf(country1Trial1, country1Trial2, country2Trial1)
         val trialsProvider =
@@ -153,15 +155,15 @@ class TrialsProviderTest {
     @Test
     fun `externalTrials should filter internal trials and filtered and original should be different without extended mode`() {
         // Should be filtered based on INTERNAL_TRIAL_IDS
-        val country1Trial1 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
+        val country1Trial1 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS)))
         val country1Trial2 =
-            EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(NETHERLANDS), nctId = NCT_02))
         // Should be filtered based on INTERNAL_TRIAL_IDS
-        val country2Trial1 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
-        val country2Trial2 = EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+        val country2Trial1 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM)))
+        val country2Trial2 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
         // Should be filtered based on national trials with same molecular criteria
-        val country2Trial3 = EventWithExternalTrial(TMB_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
-        val country2Trial4 = EventWithExternalTrial(ROS1_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+        val country2Trial3 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
+        val country2Trial4 = EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(ROS1_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countrySet(BELGIUM), nctId = NCT_02))
 
         val externalTrialsSet: Set<EventWithExternalTrial> =
             setOf(country1Trial1, country1Trial2, country2Trial1, country2Trial2, country2Trial3, country2Trial4)
@@ -183,6 +185,6 @@ class TrialsProviderTest {
             country.copy(hospitalsPerCity = hospitals)
         }.toSortedSet(Comparator.comparing { it.country })
 
-        return EventWithExternalTrial(EGFR_TARGET, BASE_EXTERNAL_TRIAL.copy(countries = countries))
+        return EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), BASE_EXTERNAL_TRIAL.copy(countries = countries))
     }
 }

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
@@ -8,7 +8,7 @@ import com.hartwig.actin.report.trial.EventWithExternalTrial
 object DriverTableFunctions {
 
     fun groupByEvent(externalTrialSummaries: Set<EventWithExternalTrial>): Map<String, String> {
-        return externalTrialSummaries.groupBy { e -> e.event }.mapValues { entry -> entry.value.joinToString(", ") { it.trial.nctId } }
+        return externalTrialSummaries.groupBy { e -> e.aggregatedEvidenceKey.event }.mapValues { entry -> entry.value.joinToString(", ") { it.trial.nctId } }
     }
 
     fun allDrivers(molecularHistory: MolecularHistory): List<Pair<MolecularTest, List<Driver>>> =

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialSummarizer.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialSummarizer.kt
@@ -25,7 +25,7 @@ object ExternalTrialSummarizer {
                 nctId = entry.key,
                 title = trial.title(),
                 countries = countries.toSortedSet(Comparator.comparing { c -> c.country }),
-                actinMolecularEvents = entry.value.map { ewt -> ewt.event }.toSortedSet(),
+                actinMolecularEvents = entry.value.map { ewt -> ewt.aggregatedEvidenceKey.event }.toSortedSet(),
                 sourceMolecularEvents = entry.value.flatMap { ewt -> ewt.trial.molecularMatches.map { it.sourceEvent } }.toSortedSet(),
                 applicableCancerTypes = entry.value.flatMap { ewt -> ewt.trial.applicableCancerTypes }
                     .toSortedSet(Comparator.comparing { cancerType -> cancerType.matchedCancerType }),

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctionsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctionsTest.kt
@@ -1,6 +1,8 @@
 package com.hartwig.actin.report.pdf.tables.molecular
 
 import com.hartwig.actin.datamodel.molecular.evidence.TestExternalTrialFactory
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKey
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKeyTest
 import com.hartwig.actin.report.trial.EventWithExternalTrial
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
@@ -21,11 +23,11 @@ class DriverTableFunctionsTest {
     @Test
     fun `Should correctly group by single event`() {
         val externalTrials = setOf(
-            EventWithExternalTrial("PTEN del", trial1),
-            EventWithExternalTrial("PTEN del", trial2),
-            EventWithExternalTrial("MYC amp", trial2),
-            EventWithExternalTrial("PTEN del", trial3),
-            EventWithExternalTrial("MYC amp", trial3)
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey("PTEN del"), trial1),
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey("PTEN del"), trial2),
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey("MYC amp"), trial2),
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey("PTEN del"), trial3),
+            EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey("MYC amp"), trial3)
         )
         val groupedByEvent = DriverTableFunctions.groupByEvent(externalTrials)
         assertThat(groupedByEvent).containsOnly(

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialSummarizerTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/ExternalTrialSummarizerTest.kt
@@ -6,6 +6,8 @@ import com.hartwig.actin.datamodel.molecular.evidence.CountryDetails
 import com.hartwig.actin.datamodel.molecular.evidence.ExternalTrial
 import com.hartwig.actin.datamodel.molecular.evidence.TestExternalTrialFactory
 import com.hartwig.actin.datamodel.molecular.evidence.TestMolecularMatchDetailsFactory
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKey
+import com.hartwig.actin.molecular.interpretation.AggregatedEvidenceKeyTest
 import com.hartwig.actin.report.trial.EventWithExternalTrial
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -60,9 +62,9 @@ class ExternalTrialSummarizerTest {
     fun `Should summarize trials by aggregating events, source events and cancer types and sorting by event`() {
         val summarized = ExternalTrialSummarizer.summarize(
             listOf(
-                EventWithExternalTrial(TMB_TARGET, TRIAL_1),
-                EventWithExternalTrial(TMB_TARGET, TRIAL_2),
-                EventWithExternalTrial(EGFR_TARGET, TRIAL_2)
+                EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), TRIAL_1),
+                EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(TMB_TARGET), TRIAL_2),
+                EventWithExternalTrial(AggregatedEvidenceKeyTest.createAggregatedEvidenceKey(EGFR_TARGET), TRIAL_2)
             )
         )
         assertThat(summarized).containsExactly(


### PR DESCRIPTION
Make a AggregatedEvidenceKey, which made all the relevant driver information available for OncoActin instead of only the event 