### PR TITLE
ACTIN-2504: ResistanceEvidenceMatcher performance improvement

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
@@ -9,6 +9,7 @@ import com.hartwig.actin.datamodel.clinical.treatment.Treatment
 import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.evidence.Actionable
 import com.hartwig.actin.doid.DoidModel
+import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
 import com.hartwig.actin.molecular.evidence.actionability.MatchesForActionable
 import com.hartwig.serve.datamodel.efficacy.EfficacyEvidence
 import com.hartwig.serve.datamodel.efficacy.EvidenceLevel
@@ -145,14 +146,16 @@ class ResistanceEvidenceMatcher(
             evidences: List<EfficacyEvidence>,
             treatmentDatabase: TreatmentDatabase,
             molecularTests: List<MolecularTest>,
-            actionabilityMatcher: com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
+            actionabilityMatcher: ActionabilityMatcher
         ): ResistanceEvidenceMatcher {
             val expandedTumorDoids = expandDoids(doidModel, tumorDoids)
             val onLabelNonPositiveEvidence = evidences.filter { hasNoPositiveResponse(it) && isOnLabel(it, expandedTumorDoids) }
-
             val molecularTestsAndMatches = molecularTests.map { it to actionabilityMatcher.match(it) }
 
-            return ResistanceEvidenceMatcher(onLabelNonPositiveEvidence, treatmentDatabase, molecularTestsAndMatches)
+            return ResistanceEvidenceMatcher(
+                onLabelNonPositiveEvidence,
+                treatmentDatabase,
+                molecularTestsAndMatches)
         }
 
         private fun isOnLabel(event: EfficacyEvidence, expandedTumorDoids: Set<String>): Boolean {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
@@ -155,7 +155,8 @@ class ResistanceEvidenceMatcher(
             return ResistanceEvidenceMatcher(
                 onLabelNonPositiveEvidence,
                 treatmentDatabase,
-                molecularTestsAndMatches)
+                molecularTestsAndMatches
+            )
         }
 
         private fun isOnLabel(event: EfficacyEvidence, expandedTumorDoids: Set<String>): Boolean {

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
@@ -16,6 +16,7 @@ import com.hartwig.actin.datamodel.algo.TreatmentCandidate
 import com.hartwig.actin.datamodel.algo.TreatmentMatch
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.TestMolecularFactory
 import com.hartwig.actin.datamodel.trial.EligibilityFunction
 import com.hartwig.actin.datamodel.trial.EligibilityRule
@@ -45,7 +46,10 @@ class TreatmentMatcherTest {
     private val evidences: List<EfficacyEvidence> = emptyList()
     private val standardOfCareEvaluator = mockk<StandardOfCareEvaluator>()
     private val doidModel = TestDoidModelFactory.createMinimalTestDoidModel()
-    private val actionabilityMatcher = mockk<ActionabilityMatcher>(relaxed = true)
+    private val actionabilityMatcher = mockk<ActionabilityMatcher> {
+        every { match(any<MolecularTest>()) } returns emptyMap()
+    }
+
     private val resistanceEvidenceMatcher = ResistanceEvidenceMatcher.create(
         doidModel,
         emptySet(),

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/TreatmentMatcherTest.kt
@@ -32,7 +32,7 @@ import java.time.LocalDate
 private val MAX_AGE = LocalDate.of(2023, 12, 10)
 
 class TreatmentMatcherTest {
-    
+
     private val patient = TestPatientFactory.createMinimalTestWGSPatientRecord()
     private val trials = listOf(TestTrialFactory.createMinimalTestTrial())
     private val trialMatches = TestTreatmentMatchFactory.createProperTreatmentMatch().trialMatches
@@ -45,15 +45,16 @@ class TreatmentMatcherTest {
     private val evidences: List<EfficacyEvidence> = emptyList()
     private val standardOfCareEvaluator = mockk<StandardOfCareEvaluator>()
     private val doidModel = TestDoidModelFactory.createMinimalTestDoidModel()
+    private val actionabilityMatcher = mockk<ActionabilityMatcher>(relaxed = true)
     private val resistanceEvidenceMatcher = ResistanceEvidenceMatcher.create(
         doidModel,
         emptySet(),
         evidences,
         treatmentDatabase,
         TestMolecularFactory.createMinimalMolecularTests(),
-        mockk<ActionabilityMatcher>()
+        actionabilityMatcher
     )
-    
+
     private val treatmentMatcher = TreatmentMatcher(
         trialMatcher = trialMatcher,
         standardOfCareEvaluator = standardOfCareEvaluator,
@@ -64,7 +65,7 @@ class TreatmentMatcherTest {
         treatmentEfficacyPredictionPath = null,
         maxMolecularTestAge = MAX_AGE
     )
-    
+
     private val expectedTreatmentMatch = TreatmentMatch(
         patientId = patient.patientId,
         referenceDate = LocalDate.now(),

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
@@ -24,13 +24,14 @@ class EvaluatedTreatmentAnnotatorTest {
     private val evidences: List<EfficacyEvidence> = emptyList()
     private val doidModel = TestDoidModelFactory.createMinimalTestDoidModel()
     private val treatmentDatabase = TestTreatmentDatabaseFactory.createProper()
+    private val actionabilityMatcher = mockk<com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher>(relaxed = true)
     private val resistanceEvidenceMatcher = ResistanceEvidenceMatcher.create(
         doidModel,
         emptySet(),
         evidences,
         treatmentDatabase,
         TestMolecularFactory.createMinimalMolecularTests(),
-        mockk()
+        actionabilityMatcher
     )
     private val annotator = EvaluatedTreatmentAnnotator.create(efficacyEntries, resistanceEvidenceMatcher)
     private val evaluations = listOf(Evaluation(result = EvaluationResult.PASS, recoverable = true))

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
@@ -13,6 +13,7 @@ import com.hartwig.actin.datamodel.molecular.TestMolecularFactory
 import com.hartwig.actin.datamodel.trial.EligibilityFunction
 import com.hartwig.actin.datamodel.trial.EligibilityRule
 import com.hartwig.actin.doid.TestDoidModelFactory
+import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
 import com.hartwig.serve.datamodel.efficacy.EfficacyEvidence
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -24,7 +25,7 @@ class EvaluatedTreatmentAnnotatorTest {
     private val evidences: List<EfficacyEvidence> = emptyList()
     private val doidModel = TestDoidModelFactory.createMinimalTestDoidModel()
     private val treatmentDatabase = TestTreatmentDatabaseFactory.createProper()
-    private val actionabilityMatcher = mockk<com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher>(relaxed = true)
+    private val actionabilityMatcher = mockk<ActionabilityMatcher>(relaxed = true)
     private val resistanceEvidenceMatcher = ResistanceEvidenceMatcher.create(
         doidModel,
         emptySet(),

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/EvaluatedTreatmentAnnotatorTest.kt
@@ -9,12 +9,14 @@ import com.hartwig.actin.datamodel.algo.TreatmentCandidate
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.efficacy.TestExtendedEvidenceEntryFactory
+import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.TestMolecularFactory
 import com.hartwig.actin.datamodel.trial.EligibilityFunction
 import com.hartwig.actin.datamodel.trial.EligibilityRule
 import com.hartwig.actin.doid.TestDoidModelFactory
 import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
 import com.hartwig.serve.datamodel.efficacy.EfficacyEvidence
+import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -25,7 +27,9 @@ class EvaluatedTreatmentAnnotatorTest {
     private val evidences: List<EfficacyEvidence> = emptyList()
     private val doidModel = TestDoidModelFactory.createMinimalTestDoidModel()
     private val treatmentDatabase = TestTreatmentDatabaseFactory.createProper()
-    private val actionabilityMatcher = mockk<ActionabilityMatcher>(relaxed = true)
+    private val actionabilityMatcher = mockk<ActionabilityMatcher> {
+        every { match(any<MolecularTest>()) } returns emptyMap()
+    }
     private val resistanceEvidenceMatcher = ResistanceEvidenceMatcher.create(
         doidModel,
         emptySet(),

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
@@ -6,6 +6,7 @@ import com.hartwig.actin.datamodel.algo.ResistanceEvidence
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.treatment.DrugType
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.TestMolecularFactory
 import com.hartwig.actin.datamodel.molecular.driver.CodingEffect
 import com.hartwig.actin.datamodel.molecular.driver.CopyNumberType
@@ -228,7 +229,7 @@ class ResistanceEvidenceMatcherTest {
 
     private fun resistanceEvidenceMatcher(
         efficacyEvidence: List<EfficacyEvidence> = emptyList(),
-        molecularTests: List<com.hartwig.actin.datamodel.molecular.MolecularTest> = MOLECULAR_HISTORY
+        molecularTests: List<MolecularTest> = MOLECULAR_HISTORY
     ) = ResistanceEvidenceMatcher.create(
         DOID_MODEL,
         TUMOR_DOIDS,

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
@@ -50,8 +50,6 @@ private val TREATMENT_DATABASE = TestTreatmentDatabaseFactory.createProper()
 private val MOLECULAR_HISTORY = TestMolecularFactory.createMinimalMolecularTests()
 
 class ResistanceEvidenceMatcherTest {
-
-    private val actionabilityMatcher = mockk<ActionabilityMatcher>()
     
     @Test
     fun `Should match resistance evidence to SOC treatments`() {
@@ -103,12 +101,14 @@ class ResistanceEvidenceMatcherTest {
         ).molecularTests
 
         val resistanceEvidenceMatcher =
-            resistanceEvidenceMatcher(listOf(amplificationWithResistanceEvidence))
+            resistanceEvidenceMatcher(efficacyEvidence = listOf(amplificationWithResistanceEvidence), molecularTests = hasAmplification)
 
-        val amplificationFound = resistanceEvidenceMatcher.isFound(amplificationWithResistanceEvidence, hasAmplification)
+        val amplificationFound = resistanceEvidenceMatcher.isFound(amplificationWithResistanceEvidence)
         assertThat(amplificationFound).isTrue()
 
-        val amplificationNotFound = resistanceEvidenceMatcher.isFound(amplificationWithResistanceEvidence, hasDel)
+        val anotherResistanceEvidenceMatcher =
+            resistanceEvidenceMatcher(efficacyEvidence = listOf(amplificationWithResistanceEvidence), molecularTests = hasDel)
+        val amplificationNotFound = anotherResistanceEvidenceMatcher.isFound(amplificationWithResistanceEvidence)
         assertThat(amplificationNotFound).isFalse()
     }
 
@@ -129,8 +129,7 @@ class ResistanceEvidenceMatcherTest {
                 )
         ).molecularTests
 
-        val resistanceEvidenceMatcher =
-            resistanceEvidenceMatcher(listOf(hotspotWithResistanceEvidence))
+        
 
         val hasOtherHotspot = MolecularTestFactory.withVariant(
             TestVariantFactory.createMinimal()
@@ -145,10 +144,14 @@ class ResistanceEvidenceMatcherTest {
                 )
         ).molecularTests
 
-        val hotspotFound = resistanceEvidenceMatcher.isFound(hotspotWithResistanceEvidence, hasHotspot)
+        val resistanceEvidenceMatcher =
+            resistanceEvidenceMatcher(efficacyEvidence = listOf(hotspotWithResistanceEvidence), molecularTests = hasHotspot)
+        val hotspotFound = resistanceEvidenceMatcher.isFound(hotspotWithResistanceEvidence)
         assertThat(hotspotFound).isTrue()
 
-        val anotherHotspotFound = resistanceEvidenceMatcher.isFound(hotspotWithResistanceEvidence, hasOtherHotspot)
+        val anotherResistanceEvidenceMatcher =
+            resistanceEvidenceMatcher(efficacyEvidence = listOf(hotspotWithResistanceEvidence), molecularTests = hasOtherHotspot)
+        val anotherHotspotFound = anotherResistanceEvidenceMatcher.isFound(hotspotWithResistanceEvidence)
         assertThat(anotherHotspotFound).isFalse()
     }
 
@@ -163,19 +166,18 @@ class ResistanceEvidenceMatcherTest {
             .copy(geneStart = "gene 2", driverType = FusionDriverType.PROMISCUOUS_5, isReportable = true)
         val hasOtherFusion = MolecularTestFactory.withFusion(otherFusion).molecularTests
 
-        every { actionabilityMatcher.match(hasFusion.first()) } returns mapOf(
-            fusion to ActionabilityMatch(
-                listOf(
-                    fusionWithResistanceEvidence
-                ), emptyMap()
-            )
+        val fusionMatcher = resistanceEvidenceMatcher(
+            efficacyEvidence = listOf(fusionWithResistanceEvidence),
+            molecularTests = hasFusion
         )
-        val fusionFound = resistanceEvidenceMatcher(listOf(fusionWithResistanceEvidence)).isFound(fusionWithResistanceEvidence, hasFusion)
+        val fusionFound = fusionMatcher.isFound(fusionWithResistanceEvidence)
         assertThat(fusionFound).isTrue()
 
-        every { actionabilityMatcher.match(hasOtherFusion.first()) } returns emptyMap()
-        val anotherFusionFound =
-            resistanceEvidenceMatcher(listOf(fusionWithResistanceEvidence)).isFound(fusionWithResistanceEvidence, hasOtherFusion)
+        val otherFusionMatcher = resistanceEvidenceMatcher(
+            efficacyEvidence = listOf(fusionWithResistanceEvidence),
+            molecularTests = hasOtherFusion
+        )
+        val anotherFusionFound = otherFusionMatcher.isFound(fusionWithResistanceEvidence)
         assertThat(anotherFusionFound).isFalse()
     }
 
@@ -212,22 +214,31 @@ class ResistanceEvidenceMatcherTest {
             )
         ).molecularTests
 
-        val resistanceEvidenceMatcher = resistanceEvidenceMatcher(listOf(rangeWithResistanceEvidence))
+        val resistanceEvidenceMatcher = resistanceEvidenceMatcher(
+            efficacyEvidence = listOf(rangeWithResistanceEvidence),
+            molecularTests = hasRange
+        )
 
-        val rangeFound = resistanceEvidenceMatcher.isFound(rangeWithResistanceEvidence, hasRange)
+        val rangeFound = resistanceEvidenceMatcher.isFound(rangeWithResistanceEvidence)
         assertThat(rangeFound).isTrue()
 
-        val anotherRangeFound = resistanceEvidenceMatcher.isFound(rangeWithResistanceEvidence, hasAnotherRange)
+        val anotherResistanceEvidenceMatcher = resistanceEvidenceMatcher(
+            efficacyEvidence = listOf(rangeWithResistanceEvidence),
+            molecularTests = hasAnotherRange
+        )
+        val anotherRangeFound = anotherResistanceEvidenceMatcher.isFound(rangeWithResistanceEvidence)
         assertThat(anotherRangeFound).isFalse()
     }
 
-    private fun resistanceEvidenceMatcher(efficacyEvidence: List<EfficacyEvidence> = emptyList()) =
-        ResistanceEvidenceMatcher.create(
-            DOID_MODEL,
-            TUMOR_DOIDS,
-            listOf(EFFICACY_EVIDENCE),
-            TREATMENT_DATABASE,
-            MOLECULAR_HISTORY,
-            ActionabilityMatcher(evidences = efficacyEvidence, emptyList())
-        )
+    private fun resistanceEvidenceMatcher(
+        efficacyEvidence: List<EfficacyEvidence> = emptyList(),
+        molecularTests: List<com.hartwig.actin.datamodel.molecular.MolecularTest> = MOLECULAR_HISTORY
+    ) = ResistanceEvidenceMatcher.create(
+        DOID_MODEL,
+        TUMOR_DOIDS,
+        listOf(EFFICACY_EVIDENCE),
+        TREATMENT_DATABASE,
+        molecularTests,
+        ActionabilityMatcher(evidences = efficacyEvidence, emptyList())
+    )
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcherTest.kt
@@ -21,15 +21,12 @@ import com.hartwig.actin.molecular.evidence.TestServeEvidenceFactory
 import com.hartwig.actin.molecular.evidence.TestServeFactory
 import com.hartwig.actin.molecular.evidence.TestServeMolecularFactory
 import com.hartwig.actin.molecular.evidence.actionability.ActionabilityConstants
-import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatch
 import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
 import com.hartwig.serve.datamodel.efficacy.EfficacyEvidence
 import com.hartwig.serve.datamodel.efficacy.EvidenceDirection
 import com.hartwig.serve.datamodel.efficacy.EvidenceLevel
 import com.hartwig.serve.datamodel.molecular.MutationType
 import com.hartwig.serve.datamodel.molecular.gene.GeneEvent
-import io.mockk.every
-import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -50,7 +47,7 @@ private val TREATMENT_DATABASE = TestTreatmentDatabaseFactory.createProper()
 private val MOLECULAR_HISTORY = TestMolecularFactory.createMinimalMolecularTests()
 
 class ResistanceEvidenceMatcherTest {
-    
+
     @Test
     fun `Should match resistance evidence to SOC treatments`() {
         val socTreatment =
@@ -129,7 +126,6 @@ class ResistanceEvidenceMatcherTest {
                 )
         ).molecularTests
 
-        
 
         val hasOtherHotspot = MolecularTestFactory.withVariant(
             TestVariantFactory.createMinimal()


### PR DESCRIPTION
This addresses the sporadic timeouts on algo jobs. ResistanceEvidencematcher recomputes actionability matches in an inner loop, for the problematic case I estimate this was being rerun close to 10,000 times.

I've hoisted this computation out to class construction. Running the problematic case on ops vm the time goes from 22 mins to less than 30 seconds, with the treatment match json's being identical.

Note that we will now pay a bit extra at construction time vs if the matcher was never used, by i measured this to just a couple seconds, so don't think it's worth making this lazy.

