### PR TITLE
ACTIN-1494: Isolate environment configuration, clean up clinical configuration

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/TreatmentMatcherApplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/TreatmentMatcherApplication.kt
@@ -8,7 +8,7 @@ import com.hartwig.actin.algo.evaluation.RuleMappingResources
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
 import com.hartwig.actin.algo.soc.ResistanceEvidenceMatcher
 import com.hartwig.actin.algo.util.TreatmentMatchPrinter
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.AlgoConfiguration
 import com.hartwig.actin.medication.MedicationCategories
 import com.hartwig.actin.molecular.evidence.actionability.ActionabilityMatcher
 import com.hartwig.actin.molecular.interpretation.MolecularInputChecker
@@ -41,7 +41,7 @@ class TreatmentMatcherApplication(private val config: TreatmentMatcherConfig) {
         val functionInputResolver =
             FunctionInputResolver(inputData.doidModel, inputData.icdModel, molecularInputChecker,
                 treatmentDatabase, MedicationCategories.create(inputData.atcTree))
-        val configuration = EnvironmentConfiguration.createAlgoConfig(config.overridesYaml)
+        val configuration = AlgoConfiguration.create(config.overridesYaml)
         LOGGER.info(" Loaded algo config: $configuration")
 
         val maxMolecularTestAge = configuration.maxMolecularTestAgeInDays?.let { referenceDateProvider.date().minus(Period.ofDays(it)) }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/TreatmentMatcherApplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/TreatmentMatcherApplication.kt
@@ -41,7 +41,7 @@ class TreatmentMatcherApplication(private val config: TreatmentMatcherConfig) {
         val functionInputResolver =
             FunctionInputResolver(inputData.doidModel, inputData.icdModel, molecularInputChecker,
                 treatmentDatabase, MedicationCategories.create(inputData.atcTree))
-        val configuration = EnvironmentConfiguration.create(config.overridesYaml).algo
+        val configuration = EnvironmentConfiguration.createAlgoConfig(config.overridesYaml)
         LOGGER.info(" Loaded algo config: $configuration")
 
         val maxMolecularTestAge = configuration.maxMolecularTestAgeInDays?.let { referenceDateProvider.date().minus(Period.ofDays(it)) }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
@@ -5,7 +5,7 @@ import com.hartwig.actin.PatientRecordJson
 import com.hartwig.actin.TreatmentDatabaseFactory
 import com.hartwig.actin.algo.calendar.ReferenceDateProviderFactory
 import com.hartwig.actin.algo.evaluation.RuleMappingResources
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.AlgoConfiguration
 import com.hartwig.actin.doid.DoidModel
 import com.hartwig.actin.doid.DoidModelFactory
 import com.hartwig.actin.doid.datamodel.DoidEntry
@@ -53,8 +53,7 @@ class StandardOfCareApplication(private val config: StandardOfCareConfig) {
         val functionInputResolver = FunctionInputResolver(
             doidModel, icdModel, MolecularInputChecker.createAnyGeneValid(), treatmentDatabase, MedicationCategories.create(atcTree)
         )
-        val configuration = EnvironmentConfiguration.createAlgoConfig(config.overridesYaml)
-        LOGGER.info(" Loaded algo config: $configuration")
+        val configuration = AlgoConfiguration.create(config.overridesYaml)
 
         val resources = RuleMappingResources(
             referenceDateProvider = referenceDateProvider,

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/StandardOfCareApplication.kt
@@ -53,7 +53,7 @@ class StandardOfCareApplication(private val config: StandardOfCareConfig) {
         val functionInputResolver = FunctionInputResolver(
             doidModel, icdModel, MolecularInputChecker.createAnyGeneValid(), treatmentDatabase, MedicationCategories.create(atcTree)
         )
-        val configuration = EnvironmentConfiguration.create(config.overridesYaml).algo
+        val configuration = EnvironmentConfiguration.createAlgoConfig(config.overridesYaml)
         LOGGER.info(" Loaded algo config: $configuration")
 
         val resources = RuleMappingResources(

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -18,10 +18,6 @@ data class AlgoConfiguration(
     val maxMolecularTestAgeInDays: Int? = null
 )
 
-data class ClinicalConfiguration(
-    val useOnlyPriorOtherConditions: Boolean = false
-)
-
 data class ReportConfiguration(
     val includeOverviewWithClinicalHistorySummary: Boolean = false,
     val includeMolecularDetailsChapter: Boolean = true,
@@ -54,8 +50,7 @@ const val OVERRIDE_YAML_DESCRIPTION = "Optional file specifying configuration ov
 
 data class EnvironmentConfiguration(
     val algo: AlgoConfiguration = AlgoConfiguration(),
-    val report: ReportConfiguration = ReportConfiguration(),
-    val clinical: ClinicalConfiguration = ClinicalConfiguration()
+    val report: ReportConfiguration = ReportConfiguration()
 ) {
 
     companion object {

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -61,6 +61,14 @@ data class EnvironmentConfiguration(
     companion object {
         private val LOGGER = LogManager.getLogger(EnvironmentConfiguration::class.java)
 
+        fun createReportConfig(environmentConfigFile: String?): ReportConfiguration {
+            return create(environmentConfigFile).report
+        }
+
+        fun createAlgoConfig(environmentConfigFile: String?): AlgoConfiguration {
+            return create(environmentConfigFile).algo
+        }
+        
         fun create(environmentConfigFile: String?): EnvironmentConfiguration {
             val configuration = environmentConfigFile?.let { readEnvironmentConfigYaml(it) } ?: EnvironmentConfiguration()
             val configSource = environmentConfigFile?.let { "file $it" } ?: "defaults"

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -45,14 +45,14 @@ data class ReportConfiguration(
     val includeMolecularEvidenceChapter: Boolean = false,
     val includeRawPathologyReport: Boolean = false,
     val includeTreatmentEvidenceRanking: Boolean = false,
-    val countryOfReference: Country = Country.OTHER
+    val countryOfReference: Country = Country.OTHER,
+    val hospitalOfReference: String? = null
 )
 
 const val OVERRIDE_YAML_ARGUMENT = "override_yaml"
 const val OVERRIDE_YAML_DESCRIPTION = "Optional file specifying configuration overrides"
 
 data class EnvironmentConfiguration(
-    val requestingHospital: String? = null,
     val algo: AlgoConfiguration = AlgoConfiguration(),
     val report: ReportConfiguration = ReportConfiguration(),
     val clinical: ClinicalConfiguration = ClinicalConfiguration()

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -69,7 +69,7 @@ data class EnvironmentConfiguration(
             return create(environmentConfigFile).algo
         }
         
-        fun create(environmentConfigFile: String?): EnvironmentConfiguration {
+        private fun create(environmentConfigFile: String?): EnvironmentConfiguration {
             val configuration = environmentConfigFile?.let { readEnvironmentConfigYaml(it) } ?: EnvironmentConfiguration()
             val configSource = environmentConfigFile?.let { "file $it" } ?: "defaults"
 

--- a/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/configuration/EnvironmentConfiguration.kt
@@ -16,7 +16,14 @@ enum class MolecularSummaryType {
 data class AlgoConfiguration(
     val warnIfToxicitiesNotFromQuestionnaire: Boolean = true,
     val maxMolecularTestAgeInDays: Int? = null
-)
+) {
+    
+    companion object {
+        fun create(environmentConfigFile: String?): AlgoConfiguration {
+            return EnvironmentConfiguration.create(environmentConfigFile).algo
+        }
+    }
+}
 
 data class ReportConfiguration(
     val includeOverviewWithClinicalHistorySummary: Boolean = false,
@@ -43,11 +50,18 @@ data class ReportConfiguration(
     val includeTreatmentEvidenceRanking: Boolean = false,
     val countryOfReference: Country = Country.OTHER,
     val hospitalOfReference: String? = null
-)
+) {
+    
+    companion object {
+        fun create(environmentConfigFile: String?): ReportConfiguration {
+            return EnvironmentConfiguration.create(environmentConfigFile).report
+        }
+    }
+}
 
 const val OVERRIDE_YAML_ARGUMENT = "override_yaml"
 const val OVERRIDE_YAML_DESCRIPTION = "Optional file specifying configuration overrides"
-
+ 
 data class EnvironmentConfiguration(
     val algo: AlgoConfiguration = AlgoConfiguration(),
     val report: ReportConfiguration = ReportConfiguration()
@@ -55,16 +69,8 @@ data class EnvironmentConfiguration(
 
     companion object {
         private val LOGGER = LogManager.getLogger(EnvironmentConfiguration::class.java)
-
-        fun createReportConfig(environmentConfigFile: String?): ReportConfiguration {
-            return create(environmentConfigFile).report
-        }
-
-        fun createAlgoConfig(environmentConfigFile: String?): AlgoConfiguration {
-            return create(environmentConfigFile).algo
-        }
         
-        private fun create(environmentConfigFile: String?): EnvironmentConfiguration {
+        fun create(environmentConfigFile: String?): EnvironmentConfiguration {
             val configuration = environmentConfigFile?.let { readEnvironmentConfigYaml(it) } ?: EnvironmentConfiguration()
             val configSource = environmentConfigFile?.let { "file $it" } ?: "defaults"
 

--- a/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
@@ -5,32 +5,31 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class EnvironmentConfigurationTest {
-
-    private val defaultConfig = EnvironmentConfiguration()
+    
     private val minimalConfigFile = resourceOnClasspath("environment/minimal_config.yaml")
     private val properConfigFile = resourceOnClasspath("environment/proper_config.yaml")
     
     @Test
     fun `Should load proper config from file`() {
-        val reportConfig = EnvironmentConfiguration.createReportConfig(properConfigFile)
+        val reportConfig = ReportConfiguration.create(properConfigFile)
         assertThat(reportConfig.hospitalOfReference).isEqualTo("Erasmus MC")
 
-        val algoConfig = EnvironmentConfiguration.createAlgoConfig(properConfigFile)
+        val algoConfig = AlgoConfiguration.create(properConfigFile)
         assertThat(algoConfig.warnIfToxicitiesNotFromQuestionnaire).isFalse()
     }
     
     @Test
     fun `Should use defaults for fields not provided in file`() {
-        val reportConfig = EnvironmentConfiguration.createReportConfig(minimalConfigFile)
+        val reportConfig = ReportConfiguration.create(minimalConfigFile)
         assertThat(reportConfig.hospitalOfReference).isNull()
 
-        val algoConfig = EnvironmentConfiguration.createAlgoConfig(minimalConfigFile)
+        val algoConfig = AlgoConfiguration.create(minimalConfigFile)
         assertThat(algoConfig.warnIfToxicitiesNotFromQuestionnaire).isTrue()
     }
 
     @Test
     fun `Should create default configuration when provided file is null`() {
-        assertThat(EnvironmentConfiguration.createReportConfig(null)).isEqualTo(defaultConfig.report)
-        assertThat(EnvironmentConfiguration.createAlgoConfig(null)).isEqualTo(defaultConfig.algo)
+        assertThat(ReportConfiguration.create(null)).isEqualTo(ReportConfiguration())
+        assertThat(AlgoConfiguration.create(null)).isEqualTo(AlgoConfiguration())
     }
 }

--- a/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
@@ -8,27 +8,20 @@ class EnvironmentConfigurationTest {
 
     private val defaultConfig = EnvironmentConfiguration()
     private val minimalConfigFile = resourceOnClasspath("environment/minimal_config.yaml")
-    private val basicConfigFile = resourceOnClasspath("environment/basic_config.yaml")
     private val properConfigFile = resourceOnClasspath("environment/proper_config.yaml")
     
     @Test
     fun `Should load proper config from file`() {
         val config = EnvironmentConfiguration.create(properConfigFile)
         assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isFalse()
-        assertThat(config.requestingHospital).isEqualTo("Erasmus MC")
+        assertThat(config.report.hospitalOfReference).isEqualTo("Erasmus MC")
     }
-
-    @Test
-    fun `Should load config from file with requesting hospital only`() {
-        val config = EnvironmentConfiguration.create(basicConfigFile)
-        assertThat(config.requestingHospital).isEqualTo("Erasmus MC")
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue()
-    }
-
+    
     @Test
     fun `Should use defaults for fields not provided in file`() {
         val config = EnvironmentConfiguration.create(minimalConfigFile)
         assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue()
+        assertThat(config.report.hospitalOfReference).isNull()
     }
 
     @Test

--- a/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/configuration/EnvironmentConfigurationTest.kt
@@ -12,20 +12,25 @@ class EnvironmentConfigurationTest {
     
     @Test
     fun `Should load proper config from file`() {
-        val config = EnvironmentConfiguration.create(properConfigFile)
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isFalse()
-        assertThat(config.report.hospitalOfReference).isEqualTo("Erasmus MC")
+        val reportConfig = EnvironmentConfiguration.createReportConfig(properConfigFile)
+        assertThat(reportConfig.hospitalOfReference).isEqualTo("Erasmus MC")
+
+        val algoConfig = EnvironmentConfiguration.createAlgoConfig(properConfigFile)
+        assertThat(algoConfig.warnIfToxicitiesNotFromQuestionnaire).isFalse()
     }
     
     @Test
     fun `Should use defaults for fields not provided in file`() {
-        val config = EnvironmentConfiguration.create(minimalConfigFile)
-        assertThat(config.algo.warnIfToxicitiesNotFromQuestionnaire).isTrue()
-        assertThat(config.report.hospitalOfReference).isNull()
+        val reportConfig = EnvironmentConfiguration.createReportConfig(minimalConfigFile)
+        assertThat(reportConfig.hospitalOfReference).isNull()
+
+        val algoConfig = EnvironmentConfiguration.createAlgoConfig(minimalConfigFile)
+        assertThat(algoConfig.warnIfToxicitiesNotFromQuestionnaire).isTrue()
     }
 
     @Test
     fun `Should create default configuration when provided file is null`() {
-        assertThat(EnvironmentConfiguration.create(null)).isEqualTo(defaultConfig)
+        assertThat(EnvironmentConfiguration.createReportConfig(null)).isEqualTo(defaultConfig.report)
+        assertThat(EnvironmentConfiguration.createAlgoConfig(null)).isEqualTo(defaultConfig.algo)
     }
 }

--- a/common/src/test/resources/environment/basic_config.yaml
+++ b/common/src/test/resources/environment/basic_config.yaml
@@ -1,1 +1,0 @@
-requestingHospital: "Erasmus MC"

--- a/common/src/test/resources/environment/proper_config.yaml
+++ b/common/src/test/resources/environment/proper_config.yaml
@@ -1,3 +1,4 @@
-requestingHospital: "Erasmus MC"
+report:
+  hospitalOfReference: "Erasmus MC"
 algo:
   warnIfToxicitiesNotFromQuestionnaire: false

--- a/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
@@ -2,7 +2,7 @@ package com.hartwig.actin.report
 
 import com.hartwig.actin.PatientRecordJson
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.report.datamodel.ReportFactory
 import com.hartwig.actin.report.pdf.ReportWriterFactory
 import org.apache.commons.cli.DefaultParser
@@ -25,7 +25,7 @@ class ReporterApplication(private val config: ReporterConfig) {
         LOGGER.info("Loading treatment match results from {}", config.treatmentMatchJson)
         val treatmentMatch = TreatmentMatchJson.read(config.treatmentMatchJson)
 
-        val config = EnvironmentConfiguration.createReportConfig(config.overrideYaml)
+        val config = ReportConfiguration.create(config.overrideYaml)
 
         val report = ReportFactory.create(this.config.reportDate?: LocalDate.now(), patient, treatmentMatch, config)
         val writer = ReportWriterFactory.createProductionReportWriter(this.config.outputDirectory)

--- a/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/ReporterApplication.kt
@@ -25,12 +25,11 @@ class ReporterApplication(private val config: ReporterConfig) {
         LOGGER.info("Loading treatment match results from {}", config.treatmentMatchJson)
         val treatmentMatch = TreatmentMatchJson.read(config.treatmentMatchJson)
 
-        val envConfig = EnvironmentConfiguration.create(config.overrideYaml)
-        LOGGER.info(" Loaded config: $envConfig")
+        val config = EnvironmentConfiguration.createReportConfig(config.overrideYaml)
 
-        val report = ReportFactory.create(config.reportDate?: LocalDate.now(), patient, treatmentMatch, envConfig)
-        val writer = ReportWriterFactory.createProductionReportWriter(config.outputDirectory)
-        writer.write(report, config.enableExtendedMode)
+        val report = ReportFactory.create(this.config.reportDate?: LocalDate.now(), patient, treatmentMatch, config)
+        val writer = ReportWriterFactory.createProductionReportWriter(this.config.outputDirectory)
+        writer.write(report, this.config.enableExtendedMode)
         LOGGER.info("Done!")
     }
 

--- a/report/src/main/kotlin/com/hartwig/actin/report/datamodel/Report.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/datamodel/Report.kt
@@ -8,7 +8,6 @@ import java.time.LocalDate
 data class Report(
     val reportDate: LocalDate,
     val patientId: String,
-    val requestingHospital: String?,
     val patientRecord: PatientRecord,
     val treatmentMatch: TreatmentMatch,
     val config: ReportConfiguration

--- a/report/src/main/kotlin/com/hartwig/actin/report/datamodel/ReportFactory.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/datamodel/ReportFactory.kt
@@ -1,6 +1,6 @@
 package com.hartwig.actin.report.datamodel
 
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.TreatmentMatch
 import org.apache.logging.log4j.LogManager
@@ -10,7 +10,7 @@ object ReportFactory {
 
     private val LOGGER = LogManager.getLogger(ReportFactory::class.java)
 
-    fun create(reportDate: LocalDate, patient: PatientRecord, treatmentMatch: TreatmentMatch, config: EnvironmentConfiguration): Report {
+    fun create(reportDate: LocalDate, patient: PatientRecord, treatmentMatch: TreatmentMatch, config: ReportConfiguration): Report {
         if (patient.patientId != treatmentMatch.patientId) {
             LOGGER.warn(
                 "Patient record patientId '${patient.patientId}' not the same as " +
@@ -23,7 +23,7 @@ object ReportFactory {
             patientId = patient.patientId,
             patientRecord = patient,
             treatmentMatch = treatmentMatch,
-            config = config.report,
+            config = config,
         )
     }
 }

--- a/report/src/main/kotlin/com/hartwig/actin/report/datamodel/ReportFactory.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/datamodel/ReportFactory.kt
@@ -21,7 +21,6 @@ object ReportFactory {
         return Report(
             reportDate = reportDate,
             patientId = patient.patientId,
-            requestingHospital = config.requestingHospital,
             patientRecord = patient,
             treatmentMatch = treatmentMatch,
             config = config.report,

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/ReportContentProvider.kt
@@ -112,7 +112,7 @@ class ReportContentProvider(private val report: Report, private val enableExtend
         val trialTableGenerators = createTrialTableGenerators(
             cohorts = cohorts,
             externalTrials = trialsProvider.externalTrials(),
-            requestingSource = TrialSource.fromDescription(report.requestingHospital)
+            requestingSource = TrialSource.fromDescription(report.config.hospitalOfReference)
         ).filterNotNull()
 
         val approvedTreatmentsGenerator = EligibleApprovedTreatmentGenerator(report)

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/TrialMatchingOtherResultsChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/TrialMatchingOtherResultsChapter.kt
@@ -40,7 +40,7 @@ class TrialMatchingOtherResultsChapter(
     }
 
     fun createTrialTableGenerators(): List<TableGenerator> {
-        val requestingSource = TrialSource.fromDescription(report.requestingHospital)
+        val requestingSource = TrialSource.fromDescription(report.config.hospitalOfReference)
         val externalTrials = trialsProvider.externalTrials()
 
         val localTrialGenerators = createTrialTableGenerators(

--- a/report/src/test/kotlin/com/hartwig/actin/report/datamodel/ReportFactoryTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/datamodel/ReportFactoryTest.kt
@@ -1,6 +1,6 @@
 package com.hartwig.actin.report.datamodel
 
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.TestTreatmentMatchFactory
 import com.hartwig.actin.report.datamodel.ReportFactory.create
@@ -18,7 +18,7 @@ class ReportFactoryTest {
                 reportDate,
                 TestPatientFactory.createMinimalTestWGSPatientRecord(),
                 TestTreatmentMatchFactory.createMinimalTreatmentMatch(),
-                EnvironmentConfiguration()
+                ReportConfiguration()
             )
         ).isNotNull()
 
@@ -27,7 +27,7 @@ class ReportFactoryTest {
                 reportDate,
                 TestPatientFactory.createProperTestPatientRecord(),
                 TestTreatmentMatchFactory.createProperTreatmentMatch(),
-                EnvironmentConfiguration()
+                ReportConfiguration()
             )
         ).isNotNull()
     }
@@ -37,6 +37,6 @@ class ReportFactoryTest {
         val patient = TestPatientFactory.createMinimalTestWGSPatientRecord().copy(patientId = "clinical")
         val treatmentMatch = TestTreatmentMatchFactory.createMinimalTreatmentMatch().copy(patientId = "treatment-match")
 
-        assertThat(create(reportDate, patient, treatmentMatch, EnvironmentConfiguration()).patientId).isEqualTo("clinical")
+        assertThat(create(reportDate, patient, treatmentMatch, ReportConfiguration()).patientId).isEqualTo("clinical")
     }
 }

--- a/report/src/test/kotlin/com/hartwig/actin/report/datamodel/TestReportFactory.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/datamodel/TestReportFactory.kt
@@ -14,12 +14,11 @@ object TestReportFactory {
 
     fun createMinimalTestReport(): Report {
         return Report(
+            reportDate = LocalDate.now(),
             patientId = TestPatientFactory.TEST_PATIENT,
             patientRecord = TestPatientFactory.createMinimalTestWGSPatientRecord(),
             treatmentMatch = TestTreatmentMatchFactory.createMinimalTreatmentMatch(),
-            config = ReportConfiguration(),
-            reportDate = LocalDate.now(),
-            requestingHospital = "NKI-AvL"
+            config = ReportConfiguration()
         )
     }
 

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/EligibleApprovedTreatmentGeneratorTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/EligibleApprovedTreatmentGeneratorTest.kt
@@ -1,7 +1,7 @@
 package com.hartwig.actin.report.pdf.tables.trial
 
 import com.hartwig.actin.PatientRecordFactory
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.datamodel.algo.TestTreatmentMatchFactory
 import com.hartwig.actin.datamodel.algo.TreatmentMatch
 import com.hartwig.actin.datamodel.clinical.ClinicalRecord
@@ -68,7 +68,7 @@ class EligibleApprovedTreatmentGeneratorTest {
             LocalDate.of(2025, 7, 1),
             PatientRecordFactory.fromInputs(clinicalRecord, molecularTests),
             treatmentMatch,
-            EnvironmentConfiguration.createReportConfig(null)
+            ReportConfiguration()
         )
         return EligibleApprovedTreatmentGenerator(report).contents()
     }

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/EligibleApprovedTreatmentGeneratorTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/trial/EligibleApprovedTreatmentGeneratorTest.kt
@@ -68,7 +68,7 @@ class EligibleApprovedTreatmentGeneratorTest {
             LocalDate.of(2025, 7, 1),
             PatientRecordFactory.fromInputs(clinicalRecord, molecularTests),
             treatmentMatch,
-            EnvironmentConfiguration.create(null)
+            EnvironmentConfiguration.createReportConfig(null)
         )
         return EligibleApprovedTreatmentGenerator(report).contents()
     }

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
@@ -28,7 +28,7 @@ object ExampleFunctions {
 
     private val LOGGER = LogManager.getLogger(ExampleFunctions::class.java)
 
-    private const val REQUESTING_HOSPITAL = "Example"
+    private const val HOSPITAL_OF_REFERENCE = "Example"
 
     private const val EXAMPLE_TREATMENT_MATCH_DIRECTORY = "example_treatment_match"
     private const val EXAMPLE_TRIAL_DATABASE_DIRECTORY = "example_trial_database"
@@ -66,13 +66,13 @@ object ExampleFunctions {
     fun createTrialMatchingEnvironmentConfiguration(): EnvironmentConfiguration {
         val base = EnvironmentConfiguration.create(null)
         return base.copy(
-            requestingHospital = REQUESTING_HOSPITAL,
             algo = AlgoConfiguration(),
             report = ReportConfiguration(
                 includeApprovedTreatmentsInSummary = false,
                 includeMolecularDetailsChapter = false,
                 includeClinicalDetailsChapter = false,
-                countryOfReference = Country.NETHERLANDS
+                countryOfReference = Country.NETHERLANDS,
+                hospitalOfReference = HOSPITAL_OF_REFERENCE
             )
         )
     }
@@ -80,7 +80,6 @@ object ExampleFunctions {
     fun createPersonalizationEnvironmentConfiguration(): EnvironmentConfiguration {
         val base = EnvironmentConfiguration.create(null)
         return base.copy(
-            requestingHospital = REQUESTING_HOSPITAL,
             algo = AlgoConfiguration(),
             report = ReportConfiguration(
                 includeOverviewWithClinicalHistorySummary = true,
@@ -91,7 +90,8 @@ object ExampleFunctions {
                 molecularSummaryType = MolecularSummaryType.NONE,
                 includePatientHeader = false,
                 filterOnSOCExhaustionAndTumorType = true,
-                countryOfReference = Country.NETHERLANDS
+                countryOfReference = Country.NETHERLANDS,
+                hospitalOfReference = HOSPITAL_OF_REFERENCE
             )
         )
     }
@@ -99,7 +99,6 @@ object ExampleFunctions {
     fun createExhaustiveEnvironmentConfiguration(): EnvironmentConfiguration {
         val base = EnvironmentConfiguration.create(null)
         return base.copy(
-            requestingHospital = REQUESTING_HOSPITAL,
             algo = AlgoConfiguration(),
             report = ReportConfiguration(
                 includeOverviewWithClinicalHistorySummary = true,
@@ -121,7 +120,8 @@ object ExampleFunctions {
                 includeMolecularEvidenceChapter = true,
                 includeRawPathologyReport = true,
                 includeTreatmentEvidenceRanking = true,
-                countryOfReference = Country.NETHERLANDS
+                countryOfReference = Country.NETHERLANDS,
+                hospitalOfReference = HOSPITAL_OF_REFERENCE
             )
         )
     }

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.system.example
 
 import com.hartwig.actin.PatientRecordJson
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
-import com.hartwig.actin.configuration.AlgoConfiguration
 import com.hartwig.actin.configuration.EnvironmentConfiguration
 import com.hartwig.actin.configuration.MolecularSummaryType
 import com.hartwig.actin.configuration.ReportConfiguration
@@ -63,79 +62,64 @@ object ExampleFunctions {
         return listOf(systemTestResourcesDirectory(), EXAMPLE_TREATMENT_MATCH_DIRECTORY).joinToString(File.separator)
     }
 
-    fun createTrialMatchingEnvironmentConfiguration(): EnvironmentConfiguration {
-        val base = EnvironmentConfiguration.create(null)
-        return base.copy(
-            algo = AlgoConfiguration(),
-            report = ReportConfiguration(
-                includeApprovedTreatmentsInSummary = false,
-                includeMolecularDetailsChapter = false,
-                includeClinicalDetailsChapter = false,
-                countryOfReference = Country.NETHERLANDS,
-                hospitalOfReference = HOSPITAL_OF_REFERENCE
-            )
+    fun createTrialMatchingReportConfiguration(): ReportConfiguration {
+        return EnvironmentConfiguration.createReportConfig(null).copy(
+            includeApprovedTreatmentsInSummary = false,
+            includeMolecularDetailsChapter = false,
+            includeClinicalDetailsChapter = false,
+            countryOfReference = Country.NETHERLANDS,
+            hospitalOfReference = HOSPITAL_OF_REFERENCE
         )
     }
 
-    fun createPersonalizationEnvironmentConfiguration(): EnvironmentConfiguration {
-        val base = EnvironmentConfiguration.create(null)
-        return base.copy(
-            algo = AlgoConfiguration(),
-            report = ReportConfiguration(
-                includeOverviewWithClinicalHistorySummary = true,
-                includeMolecularDetailsChapter = false,
-                includeApprovedTreatmentsInSummary = false,
-                includeSOCLiteratureEfficacyEvidence = true,
-                includeEligibleSOCTreatmentSummary = true,
-                molecularSummaryType = MolecularSummaryType.NONE,
-                includePatientHeader = false,
-                filterOnSOCExhaustionAndTumorType = true,
-                countryOfReference = Country.NETHERLANDS,
-                hospitalOfReference = HOSPITAL_OF_REFERENCE
-            )
+    fun createPersonalizationReportConfiguration(): ReportConfiguration {
+        return EnvironmentConfiguration.createReportConfig(null).copy(
+            includeOverviewWithClinicalHistorySummary = true,
+            includeMolecularDetailsChapter = false,
+            includeApprovedTreatmentsInSummary = false,
+            includeSOCLiteratureEfficacyEvidence = true,
+            includeEligibleSOCTreatmentSummary = true,
+            molecularSummaryType = MolecularSummaryType.NONE,
+            includePatientHeader = false,
+            filterOnSOCExhaustionAndTumorType = true,
+            countryOfReference = Country.NETHERLANDS,
+            hospitalOfReference = HOSPITAL_OF_REFERENCE
         )
     }
 
-    fun createExhaustiveEnvironmentConfiguration(): EnvironmentConfiguration {
-        val base = EnvironmentConfiguration.create(null)
-        return base.copy(
-            algo = AlgoConfiguration(),
-            report = ReportConfiguration(
-                includeOverviewWithClinicalHistorySummary = true,
-                includeMolecularDetailsChapter = true,
-                includeSOCLiteratureEfficacyEvidence = true,
-                includeEligibleSOCTreatmentSummary = true,
-                molecularSummaryType = MolecularSummaryType.STANDARD,
-                includeOtherOncologicalHistoryInSummary = true,
-                includePatientHeader = true,
-                includeRelevantNonOncologicalHistoryInSummary = true,
-                includeApprovedTreatmentsInSummary = true,
-                includeTrialMatchingInSummary = true,
-                includeExternalTrialsInSummary = true,
-                filterOnSOCExhaustionAndTumorType = true,
-                includeClinicalDetailsChapter = true,
-                includeTrialMatchingChapter = true,
-                includeOnlyExternalTrialsInTrialMatching = true,
-                includeLongitudinalMolecularChapter = true,
-                includeMolecularEvidenceChapter = true,
-                includeRawPathologyReport = true,
-                includeTreatmentEvidenceRanking = true,
-                countryOfReference = Country.NETHERLANDS,
-                hospitalOfReference = HOSPITAL_OF_REFERENCE
-            )
+    fun createExhaustiveReportConfiguration(): ReportConfiguration {
+        return EnvironmentConfiguration.createReportConfig(null).copy(
+            includeOverviewWithClinicalHistorySummary = true,
+            includeMolecularDetailsChapter = true,
+            includeSOCLiteratureEfficacyEvidence = true,
+            includeEligibleSOCTreatmentSummary = true,
+            molecularSummaryType = MolecularSummaryType.STANDARD,
+            includeOtherOncologicalHistoryInSummary = true,
+            includePatientHeader = true,
+            includeRelevantNonOncologicalHistoryInSummary = true,
+            includeApprovedTreatmentsInSummary = true,
+            includeTrialMatchingInSummary = true,
+            includeExternalTrialsInSummary = true,
+            filterOnSOCExhaustionAndTumorType = true,
+            includeClinicalDetailsChapter = true,
+            includeTrialMatchingChapter = true,
+            includeOnlyExternalTrialsInTrialMatching = true,
+            includeLongitudinalMolecularChapter = true,
+            includeMolecularEvidenceChapter = true,
+            includeRawPathologyReport = true,
+            includeTreatmentEvidenceRanking = true,
+            countryOfReference = Country.NETHERLANDS,
+            hospitalOfReference = HOSPITAL_OF_REFERENCE
         )
     }
 
-    fun runExample(
-        exampleToRun: String,
-        environmentConfigProvider: () -> EnvironmentConfiguration
-    ) {
+    fun runExample(exampleToRun: String, reportConfigProvider: () -> ReportConfiguration) {
         val localOutputPath = System.getProperty("user.home") + "/hmf/tmp"
 
         try {
             val examplePatientRecordJson = resolveExamplePatientRecordJson(exampleToRun)
             val exampleTreatmentMatchJson = resolveExampleTreatmentMatchJson(exampleToRun)
-            run(LocalDate.now(), examplePatientRecordJson, exampleTreatmentMatchJson, localOutputPath, environmentConfigProvider())
+            run(LocalDate.now(), examplePatientRecordJson, exampleTreatmentMatchJson, localOutputPath, reportConfigProvider())
         } catch (exception: ParseException) {
             LOGGER.warn(exception)
             exitProcess(1)
@@ -147,7 +131,7 @@ object ExampleFunctions {
         examplePatientRecordJson: String,
         exampleTreatmentMatchJson: String,
         outputDirectory: String,
-        environmentConfiguration: EnvironmentConfiguration
+        reportConfiguration: ReportConfiguration
     ) {
         LOGGER.info("Loading patient record from {}", examplePatientRecordJson)
         val patient = PatientRecordJson.read(examplePatientRecordJson)
@@ -155,7 +139,7 @@ object ExampleFunctions {
         LOGGER.info("Loading treatment match results from {}", exampleTreatmentMatchJson)
         val treatmentMatch = TreatmentMatchJson.read(exampleTreatmentMatchJson)
 
-        val report = ReportFactory.create(reportDate, patient, treatmentMatch, environmentConfiguration)
+        val report = ReportFactory.create(reportDate, patient, treatmentMatch, reportConfiguration)
         val writer = ReportWriterFactory.createProductionReportWriter(outputDirectory)
 
         writer.write(report, enableExtendedMode = false)

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/ExampleFunctions.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.system.example
 
 import com.hartwig.actin.PatientRecordJson
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
-import com.hartwig.actin.configuration.EnvironmentConfiguration
 import com.hartwig.actin.configuration.MolecularSummaryType
 import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.datamodel.molecular.evidence.Country
@@ -63,7 +62,7 @@ object ExampleFunctions {
     }
 
     fun createTrialMatchingReportConfiguration(): ReportConfiguration {
-        return EnvironmentConfiguration.createReportConfig(null).copy(
+        return ReportConfiguration().copy(
             includeApprovedTreatmentsInSummary = false,
             includeMolecularDetailsChapter = false,
             includeClinicalDetailsChapter = false,
@@ -73,7 +72,7 @@ object ExampleFunctions {
     }
 
     fun createPersonalizationReportConfiguration(): ReportConfiguration {
-        return EnvironmentConfiguration.createReportConfig(null).copy(
+        return ReportConfiguration().copy(
             includeOverviewWithClinicalHistorySummary = true,
             includeMolecularDetailsChapter = false,
             includeApprovedTreatmentsInSummary = false,
@@ -88,7 +87,7 @@ object ExampleFunctions {
     }
 
     fun createExhaustiveReportConfiguration(): ReportConfiguration {
-        return EnvironmentConfiguration.createReportConfig(null).copy(
+        return ReportConfiguration().copy(
             includeOverviewWithClinicalHistorySummary = true,
             includeMolecularDetailsChapter = true,
             includeSOCLiteratureEfficacyEvidence = true,

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/LocalExampleTreatmentMatchApplication.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/LocalExampleTreatmentMatchApplication.kt
@@ -10,7 +10,7 @@ import com.hartwig.actin.algo.evaluation.RuleMappingResources
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
 import com.hartwig.actin.algo.soc.ResistanceEvidenceMatcher
 import com.hartwig.actin.algo.util.TreatmentMatchPrinter
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.AlgoConfiguration
 import com.hartwig.actin.doid.DoidModel
 import com.hartwig.actin.doid.DoidModelFactory
 import com.hartwig.actin.doid.config.DoidManualConfig
@@ -96,7 +96,7 @@ class LocalExampleTreatmentMatchApplication {
                 medicationCategories = MedicationCategories.create(atcTree)
             )
 
-        val algoConfiguration = EnvironmentConfiguration.createAlgoConfig(null)
+        val algoConfiguration = AlgoConfiguration()
 
         return RuleMappingResources(
             referenceDateProvider = referenceDateProvider,

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/LocalExampleTreatmentMatchApplication.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/LocalExampleTreatmentMatchApplication.kt
@@ -10,6 +10,7 @@ import com.hartwig.actin.algo.evaluation.RuleMappingResources
 import com.hartwig.actin.algo.serialization.TreatmentMatchJson
 import com.hartwig.actin.algo.soc.ResistanceEvidenceMatcher
 import com.hartwig.actin.algo.util.TreatmentMatchPrinter
+import com.hartwig.actin.configuration.EnvironmentConfiguration
 import com.hartwig.actin.doid.DoidModel
 import com.hartwig.actin.doid.DoidModelFactory
 import com.hartwig.actin.doid.config.DoidManualConfig
@@ -95,7 +96,7 @@ class LocalExampleTreatmentMatchApplication {
                 medicationCategories = MedicationCategories.create(atcTree)
             )
 
-        val environmentConfiguration = ExampleFunctions.createTrialMatchingEnvironmentConfiguration()
+        val algoConfiguration = EnvironmentConfiguration.createAlgoConfig(null)
 
         return RuleMappingResources(
             referenceDateProvider = referenceDateProvider,
@@ -106,8 +107,8 @@ class LocalExampleTreatmentMatchApplication {
             treatmentDatabase = treatmentDatabase,
             personalizationDataPath = null,
             treatmentEfficacyPredictionJson = null,
-            algoConfiguration = environmentConfiguration.algo,
-            maxMolecularTestAge = environmentConfiguration.algo.maxMolecularTestAgeInDays?.let {
+            algoConfiguration = algoConfiguration,
+            maxMolecularTestAge = algoConfiguration.maxMolecularTestAgeInDays?.let {
                 referenceDateProvider.date().minus(Period.ofDays(it))
             }
         )

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/LocalPersonalizationExampleReportApplication.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/LocalPersonalizationExampleReportApplication.kt
@@ -14,5 +14,5 @@ fun main() {
     Locale.setDefault(Locale.US)
 
     LocalPersonalizationExampleReportApplication.LOGGER.info("Running ACTIN Personalization Example Reporter")
-    ExampleFunctions.runExample(PERSONALIZATION_EXAMPLE_TO_RUN) { ExampleFunctions.createPersonalizationEnvironmentConfiguration() }
+    ExampleFunctions.runExample(PERSONALIZATION_EXAMPLE_TO_RUN) { ExampleFunctions.createPersonalizationReportConfiguration() }
 }

--- a/system/src/test/kotlin/com/hartwig/actin/system/example/LocalTrialMatchingExampleReportApplication.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/example/LocalTrialMatchingExampleReportApplication.kt
@@ -14,5 +14,5 @@ fun main() {
     Locale.setDefault(Locale.US)
 
     LocalTrialMatchingExampleReportApplication.LOGGER.info("Running ACTIN Trial Example Reporter")
-    ExampleFunctions.runExample(TRIAL_EXAMPLE_TO_RUN) { ExampleFunctions.createTrialMatchingEnvironmentConfiguration() }
+    ExampleFunctions.runExample(TRIAL_EXAMPLE_TO_RUN) { ExampleFunctions.createTrialMatchingReportConfiguration() }
 }

--- a/system/src/test/kotlin/com/hartwig/actin/system/regression/ReportRegressionTest.kt
+++ b/system/src/test/kotlin/com/hartwig/actin/system/regression/ReportRegressionTest.kt
@@ -1,6 +1,6 @@
 package com.hartwig.actin.system.regression
 
-import com.hartwig.actin.configuration.EnvironmentConfiguration
+import com.hartwig.actin.configuration.ReportConfiguration
 import com.hartwig.actin.system.example.CRC_01_EXAMPLE
 import com.hartwig.actin.system.example.ExampleFunctions
 import com.hartwig.actin.system.example.LUNG_01_EXAMPLE
@@ -42,15 +42,15 @@ class ReportRegressionTest {
 
     @Test
     fun `Regress trial matching report textually and visually`() {
-        regressReport(exampleName = LUNG_01_EXAMPLE) { ExampleFunctions.createExhaustiveEnvironmentConfiguration() }
+        regressReport(exampleName = LUNG_01_EXAMPLE) { ExampleFunctions.createExhaustiveReportConfiguration() }
     }
 
     @Test
     fun `Regress personalization report textually and visually`() {
-        regressReport(exampleName = CRC_01_EXAMPLE) { ExampleFunctions.createPersonalizationEnvironmentConfiguration() }
+        regressReport(exampleName = CRC_01_EXAMPLE) { ExampleFunctions.createPersonalizationReportConfiguration() }
     }
 
-    private fun regressReport(exampleName: String, environmentConfigProvider: () -> EnvironmentConfiguration) {
+    private fun regressReport(exampleName: String, reportConfigProvider: () -> ReportConfiguration) {
         val outputDirectory = System.getProperty("user.dir") + "/target/test-classes"
 
         ExampleFunctions.run(
@@ -58,7 +58,7 @@ class ReportRegressionTest {
             ExampleFunctions.resolveExamplePatientRecordJson(exampleName),
             ExampleFunctions.resolveExampleTreatmentMatchJson(exampleName),
             outputDirectory,
-            environmentConfigProvider()
+            reportConfigProvider()
         )
 
         assertThat(logLevelRecorder.levelRecorded(Level.WARN) || logLevelRecorder.levelRecorded(Level.ERROR))


### PR DESCRIPTION
Changes
 - `EnvironmentConfiguration` no longer exposed globally (reporter now only knows about report config etc)
 - Remove `ClinicalConfiguration`, an artefact from pre-feed-era.
 - Move `requestingHospital` into report configuration and rename to `hospitalOfReference`