### PR TITLE
ACTIN-2634: Fix determination of tested genes when genes have multiple negative results

### DIFF
--- a/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/molecular/panel/PanelSpecifications.kt
@@ -10,7 +10,7 @@ class PanelSpecifications(panelSpecifications: Map<PanelTestSpecification, List<
     private val molecularTargetsPerTest: Map<PanelTestSpecification, Map<String, List<MolecularTestTarget>>> =
         panelSpecifications.mapValues { (_, geneSpecs) ->
             geneSpecs.groupBy(PanelGeneSpecification::geneName).mapValues { it.value.flatMap(PanelGeneSpecification::targets) }
-    }
+        }
 
     val panelTestSpecifications: Set<PanelTestSpecification>
         get() = molecularTargetsPerTest.keys
@@ -21,7 +21,8 @@ class PanelSpecifications(panelSpecifications: Map<PanelTestSpecification, List<
     ): PanelTargetSpecification {
         val baseTargets = molecularTargetsPerTest[testSpec]
             ?: throw IllegalStateException(
-                "Panel [${testSpec.testName}${testSpec.versionDate?.let { " version $it" } ?: ""}] is not found in panel specifications. Check curation and map to one " +
+                "Panel [${testSpec.testName}${testSpec.versionDate?.let { " version $it" } ?: ""}] " +
+                        "is not found in panel specifications. Check curation and map to one " +
                         "of [${molecularTargetsPerTest.keys.joinToString()}] or add this panel to the specification TSV."
             )
         val negativeTargets = (negativeResults?.associate { it.gene to listOf(it.molecularTestTarget) } ?: emptyMap())

--- a/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/molecular/panel/PanelSpecificationsTest.kt
@@ -38,16 +38,14 @@ class PanelSpecificationsTest {
     @Test
     fun `Should resolve a panels specification from the set of all specification by name and negative results`() {
         val panelSpec = PanelTestSpecification("panel", null)
-        val negativeResults = setOf(SequencedNegativeResult(GENE, MolecularTestTarget.FUSION))
-        val specification = PanelSpecifications(
-            mapOf(
-                panelSpec to listOf(
-                    PanelGeneSpecification(
-                        GENE,
-                        listOf(MolecularTestTarget.MUTATION)
-                    )
-                )
+        val negativeResults =
+            setOf(
+                SequencedNegativeResult(GENE, MolecularTestTarget.FUSION),
+                SequencedNegativeResult(GENE, MolecularTestTarget.MUTATION)
             )
+        
+        val specification = PanelSpecifications(
+            mapOf(panelSpec to listOf(PanelGeneSpecification(GENE, listOf(MolecularTestTarget.MUTATION))))
         ).panelTargetSpecification(panelSpec, negativeResults)
         assertThat(specification.testsGene(GENE) { it == listOf(MolecularTestTarget.MUTATION, MolecularTestTarget.FUSION) }).isTrue()
     }

--- a/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/panel/PanelTestSpecification.kt
+++ b/datamodel/src/main/kotlin/com/hartwig/actin/datamodel/molecular/panel/PanelTestSpecification.kt
@@ -3,5 +3,6 @@ package com.hartwig.actin.datamodel.molecular.panel
 import java.time.LocalDate
 
 data class PanelTestSpecification(val testName: String, val versionDate: LocalDate? = null) {
+    
     override fun toString(): String = "$testName${versionDate?.let { " version $it" } ?: ""}"
 }


### PR DESCRIPTION
@jbartletthmf: Everywhere where we use `List<MolecularTestTarget>` we should actually use Set<MolecularTestTarget>`, but left that out of scope (I added a `distinct()` on the list for now). Maybe a nice onboarding/clean-up task?