### PR TITLE
ACTIN-2605: Remove permutation logic from EfficacyEntryFactory in favor of canonicalized lookups in TreatmentDatabase

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/ckb/EfficacyEntryFactory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/ckb/EfficacyEntryFactory.kt
@@ -48,32 +48,10 @@ class EfficacyEntryFactory(private val treatmentDatabase: TreatmentDatabase) {
     }
 
     private fun findTreatmentInDatabase(therapyName: String, therapySynonyms: String?): Treatment {
-        return generateOptions((therapySynonyms?.split("|") ?: emptyList()) + therapyName)
+        return ((therapySynonyms?.split("|") ?: emptyList()) + therapyName)
             .mapNotNull(treatmentDatabase::findTreatmentByName)
             .distinct().singleOrNull()
             ?: throw IllegalStateException("Multiple or no matches found in treatment.json for therapy: $therapyName")
-    }
-
-    fun generateOptions(therapies: List<String>): List<String> {
-        return therapies.flatMap { therapy ->
-            if (therapy.contains(" + ")) {
-                permutations(therapy.uppercase().split(" + ")).map { it.joinToString("+") }
-            } else {
-                listOf(therapy.uppercase())
-            }
-        }
-    }
-
-    fun permutations(drugs: List<String>): Set<List<String>> {
-        if (drugs.isEmpty()) return setOf(emptyList())
-
-        val result: MutableSet<List<String>> = mutableSetOf()
-        for (i in drugs.indices) {
-            permutations(drugs - drugs[i]).forEach { item ->
-                result.add(item + drugs[i])
-            }
-        }
-        return result
     }
 
     fun extractTherapeuticSettingFromString(therapeuticSetting: String): Intent {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/soc/ResistanceEvidenceMatcher.kt
@@ -89,10 +89,7 @@ class ResistanceEvidenceMatcher(
         matches[it]?.evidenceMatches?.contains(evidence) == true
 
     private fun findTreatmentInDatabase(treatment: ServeTreatment, treatmentToFind: Treatment): String? {
-        return EfficacyEntryFactory(treatmentDatabase).generateOptions(listOf(treatment.name()))
-            .mapNotNull(treatmentDatabase::findTreatmentByName)
-            .distinct()
-            .singleOrNull()
+        return treatmentDatabase.findTreatmentByName(treatment.name())
             ?.takeIf { drugsInOtherTreatment(treatmentToFind, it) }
             ?.name
     }

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
         <actin-datamodel.version>2.12.0</actin-datamodel.version>
-        <actin-treatment-database.version>0.2.0</actin-treatment-database.version>
+        <actin-treatment-database.version>0.3.0</actin-treatment-database.version>
         <serve.version>8.6.0</serve.version>
         <orange-datamodel.version>3.0.0</orange-datamodel.version>
         <actin-transvar.version>1.2.0</actin-transvar.version>


### PR DESCRIPTION
## Changes
- Remove permutation logic from EfficacyEntryFactory in favor of canonicalized lookups in TreatmentDatabase https://github.com/hartwigmedical/actin-treatment-database/pull/5
