### PR TITLE
ACTIN-3474: Assume that requested PD-L1 measurement is TPS if not def…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctions.kt
@@ -25,8 +25,9 @@ object PDL1EvaluationFunctions {
     ): Evaluation {
         val ihcTests = record.ihcTests
         val isLungCancer = doidModel?.let { DoidEvaluationFunctions.isOfDoidType(it, record.tumor.doids, DoidConstants.LUNG_CANCER_DOID) }
+        val effectiveMeasure = measure ?: if (isLungCancer == true) "TPS" else null
         val pdl1TestsWithRequestedMeasurement =
-            measure?.let { IhcTestFilter.allPDL1TestsByMeasureToFind(ihcTests, measure, isLungCancer) } ?: emptyList()
+            effectiveMeasure?.let { IhcTestFilter.allPDL1TestsByMeasureToFind(ihcTests, it, isLungCancer) } ?: emptyList()
 
         val testEvaluations = pdl1TestsWithRequestedMeasurement.mapNotNull { ihcTest ->
             ihcTest.scoreValue?.let { scoreValue ->
@@ -79,7 +80,7 @@ object PDL1EvaluationFunctions {
             }
 
             IhcTestFilter.mostRecentAndUnknownDateIhcTestsForItem(ihcTests, "PD-L1").isNotEmpty() -> {
-                val message = measure?.let { "Available PD-L1 tests not in requested measure ($measure)" }
+                val message = effectiveMeasure?.let { "Available PD-L1 tests not in requested measure ($effectiveMeasure)" }
                     ?: "No specific PD-L1 measure requested - hence PD-L1 cannot be evaluated"
                 EvaluationFactory.recoverableFail(message)
             }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctionsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/PDL1EvaluationFunctionsTest.kt
@@ -79,6 +79,16 @@ class PDL1EvaluationFunctionsTest {
         evaluateFunctions(EvaluationResult.PASS, record, measure = "TPS")
     }
 
+    @Test
+    fun `Should assume that requested measurement is TPS if tumor type is non-small cell lung cancer and requested measurement is null`() {
+        val record = TestPatientFactory.createMinimalTestWGSPatientRecord().copy(
+            tumor = TumorDetails(
+                doids = setOf(DoidConstants.LUNG_NON_SMALL_CELL_CARCINOMA_DOID)
+            ), ihcTests = listOf(pdl1Test.copy(measure = "TPS", scoreValue = 2.0))
+        )
+        evaluateFunctions(EvaluationResult.PASS, record, measure = null)
+    }
+
     // Tests specific for evaluateLimitedPDL1byIHC
     @Test
     fun `Should pass when test value is below max`() {


### PR DESCRIPTION
…ined and tumor type is lung cancer

This prevents message "No specific PD-L1 measure requested - hence PD-L1 cannot be evaluated" from occurring when rule PD_L1_SCORE_OF_AT_LEAST/MOST_X is used and tumor type is lung cancer.

PD-L1 is always TPS for lung cancer (confirmed by pathologist)