### PR TITLE
ACTIN-3476: Don't show immunology section when fail no tumor

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/chapters/MolecularDetailsChapter.kt
@@ -164,7 +164,7 @@ class MolecularDetailsChapter(
     ): List<ImmunologyGenerator> {
         val isStandardWithPathology = configuration.molecularChapterType == MolecularChapterType.STANDARD_WITH_PATHOLOGY
         return molecularTests.mapNotNull { molecularTest ->
-            val showImmunology = if (isStandardWithPathology) molecularTest.immunology?.isReliable == true else molecularTest.immunology != null
+            val showImmunology = if (isStandardWithPathology) molecularTest.immunology?.isReliable == true else molecularTest.immunology != null && molecularTest.hasSufficientQuality
             if (showImmunology) {
                 val displayMode = if (isStandardWithPathology) ImmunologyDisplayMode.DETAILED_INLINE else ImmunologyDisplayMode.DETAILED_TABLE
                 ImmunologyGenerator(molecularTest, displayMode, "Immunology", keyWidth, valueWidth)


### PR DESCRIPTION
Currently we still show the immunology section (with tumor CN's etc.) in the molecular details when a sample is fail no tumor, which is incorrect 

We should ideally still show the alleles like on the ORANGE report (only set tumor CN and mutations in tumor to NA), instead of removing the whole section, this is a quick fix