### PR TITLE
ACTIN-2204: Warn on subclonal matches in GeneHasVariantInExonRangeOfType

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfType.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfType.kt
@@ -22,11 +22,11 @@ class GeneHasVariantInExonRangeOfType(
 ) {
 
     private enum class VariantClassification {
-        CANONICAL_HIGH_DRIVER,
+        CANONICAL_REPORTABLE_HIGH_DRIVER,
         CANONICAL_REPORTABLE_SUBCLONAL,
         CANONICAL_REPORTABLE_NON_HIGH_DRIVER,
         CANONICAL_UNREPORTABLE,
-        REPORTABLE_OTHER,
+        NON_CANONICAL_REPORTABLE,
         NONE
     }
 
@@ -46,7 +46,7 @@ class GeneHasVariantInExonRangeOfType(
                         }
 
                         hasCanonicalEffectInExonRange && variant.isReportable && variant.driverLikelihood == DriverLikelihood.HIGH -> {
-                            VariantClassification.CANONICAL_HIGH_DRIVER
+                            VariantClassification.CANONICAL_REPORTABLE_HIGH_DRIVER
                         }
 
                         hasCanonicalEffectInExonRange && variant.isReportable -> {
@@ -58,14 +58,14 @@ class GeneHasVariantInExonRangeOfType(
                         }
 
                         variant.isReportable && variant.otherImpacts.any { hasEffectInExonRange(it.affectedExon, minExon, maxExon) } -> {
-                            VariantClassification.REPORTABLE_OTHER
+                            VariantClassification.NON_CANONICAL_REPORTABLE
                         }
 
                         else -> VariantClassification.NONE
                     }
                 }.mapValues { (_, variants) -> variants.map(Variant::event).toSet() }
-        val highDriverEvents = variantClassifications[VariantClassification.CANONICAL_HIGH_DRIVER]
-        val reportableOtherVariantMatches = variantClassifications[VariantClassification.REPORTABLE_OTHER]
+        val highDriverEvents = variantClassifications[VariantClassification.CANONICAL_REPORTABLE_HIGH_DRIVER]
+        val reportableOtherVariantMatches = variantClassifications[VariantClassification.NON_CANONICAL_REPORTABLE]
         val subclonalVariantMatches = variantClassifications[VariantClassification.CANONICAL_REPORTABLE_SUBCLONAL]
 
         val (reportableExonSkips, unreportableExonSkips) =
@@ -91,10 +91,7 @@ class GeneHasVariantInExonRangeOfType(
             }
 
             !highDriverEvents.isNullOrEmpty() -> {
-                val extensions = listOfNotNull(
-                    if (!reportableOtherVariantMatches.isNullOrEmpty()) "variant(s) in non-canonical transcript: ${concat(reportableOtherVariantMatches)}" else null,
-                    if (!subclonalVariantMatches.isNullOrEmpty()) "variant(s) in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}: ${concat(subclonalVariantMatches)}" else null
-                )
+                val extensions = buildWarnExtensions(reportableOtherVariantMatches, subclonalVariantMatches)
                 EvaluationFactory.warn(
                     "Variant(s) ${concat(highDriverEvents)} $baseMessage in canonical transcript together with ${concat(extensions)}",
                     inclusionEvents = highDriverEvents + reportableOtherVariantMatches.orEmpty() + subclonalVariantMatches.orEmpty()
@@ -102,10 +99,7 @@ class GeneHasVariantInExonRangeOfType(
             }
 
             highDriverExonSkipEvents.isNotEmpty() -> {
-                val extensions = listOfNotNull(
-                    if (!reportableOtherVariantMatches.isNullOrEmpty()) "variant(s) in non-canonical transcript: ${concat(reportableOtherVariantMatches)}" else null,
-                    if (!subclonalVariantMatches.isNullOrEmpty()) "variant(s) in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}: ${concat(subclonalVariantMatches)}" else null
-                )
+                val extensions = buildWarnExtensions(reportableOtherVariantMatches, subclonalVariantMatches)
                 EvaluationFactory.warn(
                     "Exon(s) skipped $baseMessage due to ${concat(highDriverExonSkipEvents)} together with ${concat(extensions)}",
                     inclusionEvents = highDriverExonSkipEvents + reportableOtherVariantMatches.orEmpty() + subclonalVariantMatches.orEmpty()
@@ -200,6 +194,14 @@ class GeneHasVariantInExonRangeOfType(
             }
         }
     }
+
+    private fun buildWarnExtensions(
+        nonCanonicalMatches: Set<String>?,
+        subclonalMatches: Set<String>?
+    ): List<String> = listOfNotNull(
+        nonCanonicalMatches?.ifEmpty { null }?.let { "variant(s) in non-canonical transcript: ${concat(it)}" },
+        subclonalMatches?.ifEmpty { null }?.let { "variant(s) in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}: ${concat(it)}" }
+    )
 
     companion object {
         private const val CLONAL_CUTOFF = 0.5

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfType.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfType.kt
@@ -2,6 +2,7 @@ package com.hartwig.actin.algo.evaluation.molecular
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.util.Format.concat
+import com.hartwig.actin.algo.evaluation.util.Format.percentage
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.molecular.MolecularTest
 import com.hartwig.actin.datamodel.molecular.MolecularTestTarget
@@ -22,6 +23,7 @@ class GeneHasVariantInExonRangeOfType(
 
     private enum class VariantClassification {
         CANONICAL_HIGH_DRIVER,
+        CANONICAL_REPORTABLE_SUBCLONAL,
         CANONICAL_REPORTABLE_NON_HIGH_DRIVER,
         CANONICAL_UNREPORTABLE,
         REPORTABLE_OTHER,
@@ -39,6 +41,10 @@ class GeneHasVariantInExonRangeOfType(
                 .groupBy { variant ->
                     val hasCanonicalEffectInExonRange = hasEffectInExonRange(variant.canonicalImpact.affectedExon, minExon, maxExon)
                     when {
+                        hasCanonicalEffectInExonRange && variant.isReportable && variant.clonalLikelihood?.let { it < CLONAL_CUTOFF } == true -> {
+                            VariantClassification.CANONICAL_REPORTABLE_SUBCLONAL
+                        }
+
                         hasCanonicalEffectInExonRange && variant.isReportable && variant.driverLikelihood == DriverLikelihood.HIGH -> {
                             VariantClassification.CANONICAL_HIGH_DRIVER
                         }
@@ -60,6 +66,7 @@ class GeneHasVariantInExonRangeOfType(
                 }.mapValues { (_, variants) -> variants.map(Variant::event).toSet() }
         val highDriverEvents = variantClassifications[VariantClassification.CANONICAL_HIGH_DRIVER]
         val reportableOtherVariantMatches = variantClassifications[VariantClassification.REPORTABLE_OTHER]
+        val subclonalVariantMatches = variantClassifications[VariantClassification.CANONICAL_REPORTABLE_SUBCLONAL]
 
         val (reportableExonSkips, unreportableExonSkips) =
             if (requiredVariantType == VariantTypeInput.DELETE || requiredVariantType == null)
@@ -72,30 +79,36 @@ class GeneHasVariantInExonRangeOfType(
         val highDriverExonSkipEvents = highDriverExonSkips.map { it.event }.toSet()
 
         return when {
-            !highDriverEvents.isNullOrEmpty() && reportableOtherVariantMatches.isNullOrEmpty() -> {
+            !highDriverEvents.isNullOrEmpty() && reportableOtherVariantMatches.isNullOrEmpty() && subclonalVariantMatches.isNullOrEmpty() -> {
                 EvaluationFactory.pass(
                     "Variant(s) $baseMessage in canonical transcript",
                     inclusionEvents = highDriverEvents
                 )
             }
 
-            highDriverExonSkipEvents.isNotEmpty() && reportableOtherVariantMatches.isNullOrEmpty() -> {
+            highDriverExonSkipEvents.isNotEmpty() && reportableOtherVariantMatches.isNullOrEmpty() && subclonalVariantMatches.isNullOrEmpty() -> {
                 EvaluationFactory.pass("Exon(s) skipped $baseMessage", inclusionEvents = highDriverExonSkipEvents)
             }
 
             !highDriverEvents.isNullOrEmpty() -> {
+                val extensions = listOfNotNull(
+                    if (!reportableOtherVariantMatches.isNullOrEmpty()) "variant(s) in non-canonical transcript: ${concat(reportableOtherVariantMatches)}" else null,
+                    if (!subclonalVariantMatches.isNullOrEmpty()) "variant(s) in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}: ${concat(subclonalVariantMatches)}" else null
+                )
                 EvaluationFactory.warn(
-                    "Variant(s) ${concat(highDriverEvents)} $baseMessage in canonical transcript together with " +
-                            "variant(s) in non-canonical transcript: ${concat(reportableOtherVariantMatches!!)}",
-                    inclusionEvents = highDriverEvents + reportableOtherVariantMatches
+                    "Variant(s) ${concat(highDriverEvents)} $baseMessage in canonical transcript together with ${concat(extensions)}",
+                    inclusionEvents = highDriverEvents + reportableOtherVariantMatches.orEmpty() + subclonalVariantMatches.orEmpty()
                 )
             }
 
             highDriverExonSkipEvents.isNotEmpty() -> {
+                val extensions = listOfNotNull(
+                    if (!reportableOtherVariantMatches.isNullOrEmpty()) "variant(s) in non-canonical transcript: ${concat(reportableOtherVariantMatches)}" else null,
+                    if (!subclonalVariantMatches.isNullOrEmpty()) "variant(s) in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}: ${concat(subclonalVariantMatches)}" else null
+                )
                 EvaluationFactory.warn(
-                    "Exon(s) skipped $baseMessage due to ${concat(highDriverExonSkipEvents)} together with variant(s) in " +
-                            "non-canonical transcript: ${concat(reportableOtherVariantMatches!!)}",
-                    inclusionEvents = highDriverExonSkipEvents + reportableOtherVariantMatches
+                    "Exon(s) skipped $baseMessage due to ${concat(highDriverExonSkipEvents)} together with ${concat(extensions)}",
+                    inclusionEvents = highDriverExonSkipEvents + reportableOtherVariantMatches.orEmpty() + subclonalVariantMatches.orEmpty()
                 )
             }
 
@@ -106,6 +119,7 @@ class GeneHasVariantInExonRangeOfType(
                     unreportableExonSkips.map { it.event }.toSet(),
                     variantClassifications[VariantClassification.CANONICAL_REPORTABLE_NON_HIGH_DRIVER],
                     nonHighDriverExonSkips.map { it.event }.toSet(),
+                    subclonalVariantMatches,
                     baseMessage
                 )
                     ?: EvaluationFactory.fail("No variant $baseMessage in canonical transcript")
@@ -124,6 +138,7 @@ class GeneHasVariantInExonRangeOfType(
         unreportableFusions: Set<String>?,
         nonHighDriverVariants: Set<String>?,
         nonHighDriverExonSkips: Set<String>?,
+        subclonalVariantMatches: Set<String>?,
         baseMessage: String
     ): Evaluation? {
         return MolecularEventUtil.evaluatePotentialWarnsForEventGroups(
@@ -135,7 +150,11 @@ class GeneHasVariantInExonRangeOfType(
                 EventsWithMessages(reportableOtherVariantMatches, "Variant(s) $baseMessage but in non-canonical transcript"),
                 EventsWithMessages(unreportableFusions, "Exon skip(s) $baseMessage but not reportable"),
                 EventsWithMessages(nonHighDriverVariants, "Variant(s) $baseMessage in canonical transcript but not high driver"),
-                EventsWithMessages(nonHighDriverExonSkips, "Exon skip(s) $baseMessage but not high driver")
+                EventsWithMessages(nonHighDriverExonSkips, "Exon skip(s) $baseMessage but not high driver"),
+                EventsWithMessages(
+                    subclonalVariantMatches,
+                    "Variant(s) $baseMessage in canonical transcript but subclonal likelihood of > ${percentage(1 - CLONAL_CUTOFF)}"
+                )
             )
         )
     }
@@ -180,6 +199,10 @@ class GeneHasVariantInExonRangeOfType(
                 throw IllegalStateException("Could not map required variant type: $requiredVariantType")
             }
         }
+    }
+
+    companion object {
+        private const val CLONAL_CUTOFF = 0.5
     }
 }
 

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfTypeTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfTypeTest.kt
@@ -18,6 +18,8 @@ import org.junit.jupiter.params.provider.ValueSource
 private const val MATCHING_EXON = 1
 private const val OTHER_EXON = 6
 private const val TARGET_GENE = "gene A"
+private const val CLONAL_LIKELIHOOD = 0.6
+private const val SUBCLONAL_LIKELIHOOD = 0.3
 
 class GeneHasVariantInExonRangeOfTypeTest {
     
@@ -327,7 +329,7 @@ class GeneHasVariantInExonRangeOfTypeTest {
             EvaluationResult.WARN,
             function.evaluate(
                 MolecularTestFactory.withDrivers(
-                    canonicalVariant(VariantType.DELETE, clonalLikelihood = 0.3, isReportable = true),
+                    canonicalVariant(VariantType.DELETE, clonalLikelihood = SUBCLONAL_LIKELIHOOD, isReportable = true),
                     highDriverExonSkipFusion()
                 )
             )
@@ -341,7 +343,7 @@ class GeneHasVariantInExonRangeOfTypeTest {
             EvaluationResult.WARN,
             function.evaluate(
                 MolecularTestFactory.withDrivers(
-                    canonicalVariant(VariantType.DELETE, clonalLikelihood = 0.3, isReportable = true),
+                    canonicalVariant(VariantType.DELETE, clonalLikelihood = SUBCLONAL_LIKELIHOOD, isReportable = true),
                     nonCanonicalVariant(VariantType.DELETE),
                     highDriverExonSkipFusion()
                 )
@@ -370,33 +372,33 @@ class GeneHasVariantInExonRangeOfTypeTest {
     }
 
     @Test
-    fun `Should pass when reportable canonical high driver match has clonality above boundary`() {
+    fun `Should pass when reportable canonical high driver clonal match`() {
         assertMolecularEvaluation(
             EvaluationResult.PASS,
             function.evaluate(
-                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = 0.6, isReportable = true))
+                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = CLONAL_LIKELIHOOD, isReportable = true))
             )
         )
     }
 
     @Test
-    fun `Should warn when reportable canonical match is subclonal`() {
+    fun `Should warn when reportable canonical high driver match is subclonal`() {
         assertMolecularEvaluation(
             EvaluationResult.WARN,
             function.evaluate(
-                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = 0.3, isReportable = true))
+                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = SUBCLONAL_LIKELIHOOD, isReportable = true))
             )
         )
     }
 
     @Test
-    fun `Should warn when high driver canonical match coexists with subclonal canonical match`() {
+    fun `Should warn when reportable canonical high driver match coexists with subclonal canonical match`() {
         assertMolecularEvaluation(
             EvaluationResult.WARN,
             function.evaluate(
                 MolecularTestFactory.withDrivers(
-                    canonicalVariant(clonalLikelihood = 0.8, isReportable = true),
-                    canonicalVariant(clonalLikelihood = 0.3, isReportable = true)
+                    canonicalVariant(clonalLikelihood = CLONAL_LIKELIHOOD, isReportable = true),
+                    canonicalVariant(clonalLikelihood = SUBCLONAL_LIKELIHOOD, isReportable = true)
                 )
             )
         )
@@ -409,7 +411,7 @@ class GeneHasVariantInExonRangeOfTypeTest {
             function.evaluate(
                 MolecularTestFactory.withVariant(
                     canonicalVariant(
-                        clonalLikelihood = 0.3,
+                        clonalLikelihood = SUBCLONAL_LIKELIHOOD,
                         driverLikelihood = DriverLikelihood.MEDIUM,
                         isReportable = true
                     )
@@ -430,12 +432,12 @@ class GeneHasVariantInExonRangeOfTypeTest {
     }
 
     @Test
-    fun `Should warn when high driver canonical match is subclonal and non-canonical match also present`() {
+    fun `Should warn when reportable canonical high driver match is subclonal and non-canonical match also present`() {
         assertMolecularEvaluation(
             EvaluationResult.WARN,
             function.evaluate(
                 MolecularTestFactory.withDrivers(
-                    canonicalVariant(clonalLikelihood = 0.3, isReportable = true),
+                    canonicalVariant(clonalLikelihood = SUBCLONAL_LIKELIHOOD, isReportable = true),
                     nonCanonicalVariant()
                 )
             )

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfTypeTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/GeneHasVariantInExonRangeOfTypeTest.kt
@@ -12,6 +12,8 @@ import com.hartwig.actin.datamodel.molecular.driver.VariantType
 import com.hartwig.actin.datamodel.trial.VariantTypeInput
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 private const val MATCHING_EXON = 1
 private const val OTHER_EXON = 6
@@ -319,6 +321,35 @@ class GeneHasVariantInExonRangeOfTypeTest {
     }
 
     @Test
+    fun `Should warn when high driver exon skip coexists with subclonal canonical match`() {
+        val function = GeneHasVariantInExonRangeOfType(TARGET_GENE, 1, 4, VariantTypeInput.DELETE)
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withDrivers(
+                    canonicalVariant(VariantType.DELETE, clonalLikelihood = 0.3, isReportable = true),
+                    highDriverExonSkipFusion()
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Should warn when high driver exon skip coexists with non-canonical and subclonal matches`() {
+        val function = GeneHasVariantInExonRangeOfType(TARGET_GENE, 1, 4, VariantTypeInput.DELETE)
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withDrivers(
+                    canonicalVariant(VariantType.DELETE, clonalLikelihood = 0.3, isReportable = true),
+                    nonCanonicalVariant(VariantType.DELETE),
+                    highDriverExonSkipFusion()
+                )
+            )
+        )
+    }
+
+    @Test
     fun `Should pass for variant with matching canonical and non-canonical impact`() {
         val function = GeneHasVariantInExonRangeOfType(TARGET_GENE, 1, 4, VariantTypeInput.DELETE)
         assertMolecularEvaluation(
@@ -333,6 +364,79 @@ class GeneHasVariantInExonRangeOfTypeTest {
                         canonicalImpact = impactWithExon(MATCHING_EXON),
                         otherImpacts = setOf(impactWithExon(MATCHING_EXON))
                     )
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Should pass when reportable canonical high driver match has clonality above boundary`() {
+        assertMolecularEvaluation(
+            EvaluationResult.PASS,
+            function.evaluate(
+                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = 0.6, isReportable = true))
+            )
+        )
+    }
+
+    @Test
+    fun `Should warn when reportable canonical match is subclonal`() {
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = 0.3, isReportable = true))
+            )
+        )
+    }
+
+    @Test
+    fun `Should warn when high driver canonical match coexists with subclonal canonical match`() {
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withDrivers(
+                    canonicalVariant(clonalLikelihood = 0.8, isReportable = true),
+                    canonicalVariant(clonalLikelihood = 0.3, isReportable = true)
+                )
+            )
+        )
+    }
+
+    @Test
+    fun `Should warn when reportable canonical medium driver match is subclonal`() {
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withVariant(
+                    canonicalVariant(
+                        clonalLikelihood = 0.3,
+                        driverLikelihood = DriverLikelihood.MEDIUM,
+                        isReportable = true
+                    )
+                )
+            )
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = [0.3, 0.7])
+    fun `Should warn when canonical match is not reportable regardless of clonality`(clonalLikelihood: Double) {
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withVariant(canonicalVariant(clonalLikelihood = clonalLikelihood, isReportable = false))
+            )
+        )
+    }
+
+    @Test
+    fun `Should warn when high driver canonical match is subclonal and non-canonical match also present`() {
+        assertMolecularEvaluation(
+            EvaluationResult.WARN,
+            function.evaluate(
+                MolecularTestFactory.withDrivers(
+                    canonicalVariant(clonalLikelihood = 0.3, isReportable = true),
+                    nonCanonicalVariant()
                 )
             )
         )
@@ -359,6 +463,37 @@ class GeneHasVariantInExonRangeOfTypeTest {
         assertThat(result.result).isEqualTo(EvaluationResult.UNDETERMINED)
         assertThat(result.undeterminedMessagesStrings()).containsExactly("Mutation in exon 1 of type insertion in gene gene A undetermined (not tested for at least mutations)")
     }
+
+    private fun nonCanonicalVariant(type: VariantType = VariantType.INSERT) = TestVariantFactory.createMinimal().copy(
+        gene = TARGET_GENE,
+        isReportable = true,
+        type = type,
+        canonicalImpact = impactWithExon(OTHER_EXON),
+        otherImpacts = setOf(impactWithExon(MATCHING_EXON))
+    )
+
+    private fun canonicalVariant(
+        type: VariantType = VariantType.INSERT,
+        clonalLikelihood: Double? = null,
+        driverLikelihood: DriverLikelihood = DriverLikelihood.HIGH,
+        isReportable: Boolean = false
+    ) = TestVariantFactory.createMinimal().copy(
+        gene = TARGET_GENE,
+        isReportable = isReportable,
+        driverLikelihood = driverLikelihood,
+        type = type,
+        canonicalImpact = impactWithExon(MATCHING_EXON),
+        clonalLikelihood = clonalLikelihood
+    )
+
+    private fun highDriverExonSkipFusion() = TestFusionFactory.createMinimal().copy(
+        geneStart = TARGET_GENE,
+        geneEnd = TARGET_GENE,
+        isReportable = true,
+        driverLikelihood = DriverLikelihood.HIGH,
+        fusedExonUp = 2,
+        fusedExonDown = 3
+    )
 
     private fun impactWithExon(affectedExon: Int) = TestTranscriptVariantImpactFactory.createMinimal().copy(affectedExon = affectedExon)
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                  
- Add `CANONICAL_REPORTABLE_SUBCLONAL` classification to `GeneHasVariantInExonRangeOfType`, mirroring `GeneHasVariantInCodon`                                                                                                        
- Subclonal matches (clonalLikelihood < 0.5) now emit WARN instead of  silently passing
- PASS branches (high-driver variant and high-driver exon skip) are guarded: they downgrade to WARN when a subclonal match coexists  

### Testing: 
Created a mocked patient with these cases: 
```                                                                                                                                                                                
- subclonal-only canonical match                                                                                                                                            
                                                                                                                                                                                 
- clonal HIGH driver coexisting with subclonal match                                                                                                                        
                                                                                                                                                                                
- exon skip fusion coexisting with subclonal canonical variant
                                                                                                                                
-  exon skip fusion coexisting with both subclonal and non-canonical              
``` 

|Before|After|
|-|-|
|<img width="724" height="425" alt="Screenshot 2026-05-05 at 15 45 34" src="https://github.com/user-attachments/assets/ed509c81-a7e6-463a-9751-5e2ca686136b" />|<img width="685" height="646" alt="Screenshot 2026-05-05 at 15 47 52" src="https://github.com/user-attachments/assets/f7100524-e2c7-4e18-999e-7a8b383c1c15" />|




