### PR TITLE
ACTIN-2991: Remove clinicalStatus filter from HasIntoleranceRelatedToStudyMedication and unused fields from actin

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceRelatedToStudyMedication.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceRelatedToStudyMedication.kt
@@ -7,7 +7,6 @@ import com.hartwig.actin.algo.icd.IcdConstants
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.IcdCode
-import com.hartwig.actin.datamodel.clinical.Intolerance
 import com.hartwig.actin.datamodel.clinical.Toxicity
 import com.hartwig.actin.icd.IcdModel
 
@@ -16,7 +15,6 @@ class HasIntoleranceRelatedToStudyMedication(private val icdModel: IcdModel) : E
     override fun evaluate(record: PatientRecord): Evaluation {
         val targetIcdCodes = IcdConstants.DRUG_ALLERGY_SET.map { IcdCode(it, IcdConstants.ANTI_NEOPLASTIC_AGENTS) }
         val allergies = icdModel.findInstancesMatchingAnyIcdCode(record.comorbidities, targetIcdCodes).fullMatches
-            .filter { (it as? Intolerance)?.clinicalStatus?.equals(CLINICAL_STATUS_ACTIVE, ignoreCase = true) != false }
             .filterNot { it is Toxicity && it.grade?.let { grade -> grade < 2 } ?: true }
             .toSet()
 
@@ -27,7 +25,4 @@ class HasIntoleranceRelatedToStudyMedication(private val icdModel: IcdModel) : E
         } else EvaluationFactory.fail("Has no intolerances to study medication")
     }
 
-    companion object {
-        const val CLINICAL_STATUS_ACTIVE: String = "Active"
-    }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/comorbidity/ComorbidityTestFactory.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/comorbidity/ComorbidityTestFactory.kt
@@ -41,16 +41,11 @@ internal object ComorbidityTestFactory {
     fun intolerance(
         name: String = "",
         icdMainCode: String = "",
-        icdExtensionCode: String? = null,
-        clinicalStatus: String = ""
+        icdExtensionCode: String? = null
     ): Intolerance {
         return Intolerance(
             name = name,
-            icdCodes = setOf(IcdCode(icdMainCode, icdExtensionCode)),
-            type = "",
-            clinicalStatus = clinicalStatus,
-            verificationStatus = "",
-            criticality = ""
+            icdCodes = setOf(IcdCode(icdMainCode, icdExtensionCode))
         )
     }
 

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceRelatedToStudyMedicationTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceRelatedToStudyMedicationTest.kt
@@ -35,12 +35,6 @@ class HasIntoleranceRelatedToStudyMedicationTest {
     }
 
     @Test
-    fun `Should fail when intolerance with matching ICD code is not active`() {
-        val intolerance = ComorbidityTestFactory.intolerance(icdMainCode = matchingIcdCodes.first(), clinicalStatus = "other")
-        assertEvaluation(EvaluationResult.FAIL, function.evaluate(ComorbidityTestFactory.withComorbidity(intolerance)))
-    }
-
-    @Test
     fun `Should fail when toxicity with matching ICD code has grade below 2 or null`() {
         val icdMainCode = matchingIcdCodes.first()
         listOf(
@@ -55,18 +49,16 @@ class HasIntoleranceRelatedToStudyMedicationTest {
     fun `Should fail when allergy is not to anti-cancer agent`() {
         val intolerance = ComorbidityTestFactory.intolerance(
             icdMainCode = matchingIcdCodes.first(),
-            icdExtensionCode = IcdConstants.CEFAMYCIN_ANTIBIOTIC,
-            clinicalStatus = HasIntoleranceRelatedToStudyMedication.CLINICAL_STATUS_ACTIVE
+            icdExtensionCode = IcdConstants.CEFAMYCIN_ANTIBIOTIC
         )
         assertEvaluation(EvaluationResult.FAIL, function.evaluate(ComorbidityTestFactory.withComorbidity(intolerance)))
     }
 
     @Test
-    fun `Should evaluate to undetermined when active intolerance has matching ICD code`() {
+    fun `Should evaluate to undetermined when intolerance has matching ICD code`() {
         val intolerance = ComorbidityTestFactory.intolerance(
             icdMainCode = matchingIcdCodes.first(),
-            icdExtensionCode = IcdConstants.NIVOLUMAB_CODE,
-            clinicalStatus = HasIntoleranceRelatedToStudyMedication.CLINICAL_STATUS_ACTIVE
+            icdExtensionCode = IcdConstants.NIVOLUMAB_CODE
         )
         assertEvaluation(EvaluationResult.UNDETERMINED, function.evaluate(ComorbidityTestFactory.withComorbidity(intolerance)))
     }

--- a/common/src/test/resources/clinical/records/patient.clinical.json
+++ b/common/src/test/resources/clinical/records/patient.clinical.json
@@ -154,10 +154,6 @@
           "extensionCode": null
         }
       ],
-      "type": "allergy",
-      "clinicalStatus": "Active",
-      "verificationStatus": "Confirmed",
-      "criticality": "low",
       "comorbidityClass": "INTOLERANCE"
     },
     {
@@ -168,10 +164,6 @@
           "extensionCode": null
         }
       ],
-      "type": "allergy",
-      "clinicalStatus": "Active",
-      "verificationStatus": "Confirmed",
-      "criticality": "unable-to-assess",
       "comorbidityClass": "INTOLERANCE"
     },
     {

--- a/database/src/main/kotlin/com/hartwig/actin/database/dao/ClinicalDAO.kt
+++ b/database/src/main/kotlin/com/hartwig/actin/database/dao/ClinicalDAO.kt
@@ -431,20 +431,12 @@ class ClinicalDAO(private val context: DSLContext) {
                 Tables.INTOLERANCE,
                 Tables.INTOLERANCE.PATIENTID,
                 Tables.INTOLERANCE.NAME,
-                Tables.INTOLERANCE.ICDCODES,
-                Tables.INTOLERANCE.TYPE,
-                Tables.INTOLERANCE.CLINICALSTATUS,
-                Tables.INTOLERANCE.VERIFICATIONSTATUS,
-                Tables.INTOLERANCE.CRITICALITY
+                Tables.INTOLERANCE.ICDCODES
             )
                 .values(
                     patientId,
                     intolerance.name,
-                    DataUtil.concatObjects(intolerance.icdCodes),
-                    intolerance.type,
-                    intolerance.clinicalStatus,
-                    intolerance.verificationStatus,
-                    intolerance.criticality
+                    DataUtil.concatObjects(intolerance.icdCodes)
                 )
                 .execute()
         }

--- a/database/src/main/resources/generate_database.sql
+++ b/database/src/main/resources/generate_database.sql
@@ -189,10 +189,6 @@ CREATE TABLE `intolerance`
     `icdCodes` varchar(50) NOT NULL,
     `category` varchar(50) NOT NULL,
     `subcategories` varchar(100) NOT NULL,
-    `type` varchar(50) NOT NULL,
-    `clinicalStatus` varchar(50) NOT NULL,
-    `verificationStatus` varchar(50) NOT NULL,
-    `criticality` varchar(50) NOT NULL,
     PRIMARY KEY (`id`)
 );
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
-        <actin-datamodel.version>3.7.0-beta.1</actin-datamodel.version>
+        <actin-datamodel.version>3.7.0</actin-datamodel.version>
         <actin-treatment-database.version>0.4.6</actin-treatment-database.version>
         <actin-utils.version>2.1.0</actin-utils.version>
         <serve.version>8.6.0</serve.version>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
 
-        <actin-datamodel.version>3.5.1</actin-datamodel.version>
+        <actin-datamodel.version>3.7.0-beta.1</actin-datamodel.version>
         <actin-treatment-database.version>0.4.6</actin-treatment-database.version>
         <actin-utils.version>2.1.0</actin-utils.version>
         <serve.version>8.6.0</serve.version>

--- a/system/src/test/resources/example_patient_data/EXAMPLE-CRC-01.patient_record.json
+++ b/system/src/test/resources/example_patient_data/EXAMPLE-CRC-01.patient_record.json
@@ -126,10 +126,6 @@
           "extensionCode": "XM1KZ5"
         }
       ],
-      "type": "Allergy",
-      "clinicalStatus": "Active",
-      "verificationStatus": "Unconfirmed",
-      "criticality": "Unable-to-assess",
       "year": null,
       "month": null,
       "comorbidityClass": "INTOLERANCE"


### PR DESCRIPTION
## Summary
-  Removes the `clinicalStatus == "Active"` filter from `HasIntoleranceRelatedToStudyMedication` as  inactive allergies will be filtered at the hospital source (EMC / NKI)
-  Removes 4 unused fields (`type`, `clinicalStatus`, `verificationStatus`, `criticality`) from `ClinicalDAO` and `generate_database.sql`


## Notes: 
- Blocked on https://github.com/hartwigmedical/actin-datamodel/pull/36/
