### PR TITLE
ACTIN-3696: Deduplicate NCT IDs in key drivers CKB trials column

### DIFF
--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctions.kt
@@ -8,7 +8,7 @@ object DriverTableFunctions {
 
     fun groupByEvent(externalTrialSummaries: Set<ActionableWithExternalTrial>): Map<String, String> {
         return externalTrialSummaries.groupBy { e -> e.actionable.event }
-            .mapValues { entry -> entry.value.joinToString(", ") { it.trial.nctId } }
+            .mapValues { entry -> entry.value.distinctBy { it.trial.nctId }.joinToString(", ") { it.trial.nctId } }
     }
 
     fun allDrivers(molecularTests: List<MolecularTest>): List<Pair<MolecularTest, List<Driver>>> =

--- a/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctionsTest.kt
+++ b/report/src/test/kotlin/com/hartwig/actin/report/pdf/tables/molecular/DriverTableFunctionsTest.kt
@@ -37,6 +37,22 @@ class DriverTableFunctionsTest {
         )
     }
 
+    @Test
+    fun `Should deduplicate nctIds when same trial appears via multiple actionables for same event`() {
+        val actionable1 = TestVariantFactory.createMinimal().copy(event = "EGFR L858R", variantAlleleFrequency = 0.5)
+        val actionable2 = TestVariantFactory.createMinimal().copy(event = "EGFR L858R", variantAlleleFrequency = 0.45)
+        val externalTrials = setOf(
+            ActionableWithExternalTrial(actionable = actionable1, trial = trial1),
+            ActionableWithExternalTrial(actionable = actionable1, trial = trial2),
+            ActionableWithExternalTrial(actionable = actionable2, trial = trial1),
+            ActionableWithExternalTrial(actionable = actionable2, trial = trial2),
+        )
+        val groupedByEvent = DriverTableFunctions.groupByEvent(externalTrials)
+        assertThat(groupedByEvent).containsOnly(
+            entry("EGFR L858R", "trial1, trial2")
+        )
+    }
+
     private fun createEventWithExternalTrial(event: String, trial: ExternalTrial): ActionableWithExternalTrial {
         return ActionableWithExternalTrial(actionable = createActionable(event), trial = trial)
     }


### PR DESCRIPTION
## Summary
  - Fixes duplicate NCT IDs in the "Trials in CKB" column of the key drivers table
  - Root cause: same nctId can appear via multiple distinct `ActionableWithExternalTrial` objects (same event, different `Actionable` or `molecularMatches`) 
- **Example**: When a patient has multiple molecular tests (e.g. a WGS and a panel test), and both tests detect the same driver event (e.g. CCNE1 amp), the ACTIN pipeline annotates each test against CKB. This produces two separate objects for the same event one from WGS and one from the panel and each with the same set of matching CKB trial NCT IDs.
- Fix: add `.distinct()` at the display layer in `DriverTableFunctions.groupByEvent()`
  
  ## Test
(Mocking test data)

Before: 
<img width="717" height="231" alt="Screenshot 2026-06-15 at 15 14 22" src="https://github.com/user-attachments/assets/1fd77375-2f2d-4388-996e-e9dd9b129692" />


After

<img width="733" height="221" alt="Screenshot 2026-06-15 at 14 59 27" src="https://github.com/user-attachments/assets/f4d0308b-fec5-43f7-b8f0-821898441658" />
