### PR TITLE
ACTIN-3795: Fix bug with adding medications to other oncological history

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatment.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatment.kt
@@ -2,11 +2,11 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.AtcLevel
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadAnyCancerTreatment(
     private val categoriesToIgnore: Set<TreatmentCategory>,
@@ -14,10 +14,7 @@ class HasHadAnyCancerTreatment(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistoryWithoutTrialMedication =
-            record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(
-                record.medications?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() }
-            )
+        val effectiveTreatmentHistoryWithoutTrialMedication = MedicationToTreatmentConverter.convertAndCombine(record.medications?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() }, record.oncologicalHistory)
 
         val hasHadPriorCancerTreatment =
             if (categoriesToIgnore.isEmpty()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatment.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatment.kt
@@ -14,7 +14,10 @@ class HasHadAnyCancerTreatment(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistoryWithoutTrialMedication = MedicationToTreatmentConverter.convertAndCombine(record.medications?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() }, record.oncologicalHistory)
+        val effectiveTreatmentHistoryWithoutTrialMedication = MedicationToTreatmentConverter.convertAndCombine(
+            record.medications?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() },
+            record.oncologicalHistory
+        )
 
         val hasHadPriorCancerTreatment =
             if (categoriesToIgnore.isEmpty()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDate.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDate.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.treatment.TreatmentVersusDateFunctions.treatmentSinceMinDate
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpretation
@@ -12,6 +11,7 @@ import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.AtcLevel
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 import java.time.LocalDate
 
 class HasHadAnyCancerTreatmentSinceDate(
@@ -26,10 +26,10 @@ class HasHadAnyCancerTreatmentSinceDate(
 
     override fun evaluate(record: PatientRecord): Evaluation {
         val antiCancerMedicationsWithoutTrialMedicationsAsTreatments =
-            createTreatmentHistoryEntriesFromMedications(record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }
-                ?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() })
+            MedicationToTreatmentConverter.convertAndCombine(record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }
+                ?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() }, record.oncologicalHistory)
 
-        val effectiveTreatmentHistory = (record.oncologicalHistory + antiCancerMedicationsWithoutTrialMedicationsAsTreatments)
+        val effectiveTreatmentHistory = antiCancerMedicationsWithoutTrialMedicationsAsTreatments
             .filter { entry ->
                 val treatments = entry.allTreatments().filterNot { treatment ->
                     treatment.categories().contains(categoryToIgnore) && treatment.types().any { it in typesToIgnore }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDate.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDate.kt
@@ -26,8 +26,11 @@ class HasHadAnyCancerTreatmentSinceDate(
 
     override fun evaluate(record: PatientRecord): Evaluation {
         val antiCancerMedicationsWithoutTrialMedicationsAsTreatments =
-            MedicationToTreatmentConverter.convertAndCombine(record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }
-                ?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() }, record.oncologicalHistory)
+            MedicationToTreatmentConverter.convertAndCombine(
+                record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }
+                    ?.filter { (it.allLevels() intersect atcLevelsToFind).isNotEmpty() },
+                record.oncologicalHistory
+            )
 
         val effectiveTreatmentHistory = antiCancerMedicationsWithoutTrialMedicationsAsTreatments
             .filter { entry ->

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
@@ -11,7 +11,7 @@ class HasHadSomeTreatmentsWithCategory(private val category: TreatmentCategory, 
     EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(effectiveTreatmentHistory, category)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategory.kt
@@ -2,16 +2,16 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadSomeTreatmentsWithCategory(private val category: TreatmentCategory, private val minTreatmentLines: Int) :
     EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(effectiveTreatmentHistory, category)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfAllTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfAllTypes.kt
@@ -14,7 +14,7 @@ class HasHadSomeTreatmentsWithCategoryOfAllTypes(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory, category, { historyEntry -> types.all { type -> historyEntry.isOfType(type) == true } }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfAllTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfAllTypes.kt
@@ -2,19 +2,19 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadSomeTreatmentsWithCategoryOfAllTypes(
     private val category: TreatmentCategory, private val types: Set<TreatmentType>, private val minTreatmentLines: Int
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory, category, { historyEntry -> types.all { type -> historyEntry.isOfType(type) == true } }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
@@ -2,19 +2,19 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadSomeTreatmentsWithCategoryOfTypes(
     private val category: TreatmentCategory, private val types: Set<TreatmentType>, private val minTreatmentLines: Int
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory, category, { historyEntry -> historyEntry.matchesTypeFromSet(types) }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadSomeTreatmentsWithCategoryOfTypes.kt
@@ -14,7 +14,7 @@ class HasHadSomeTreatmentsWithCategoryOfTypes(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + MedicationToTreatmentConverter.convert(record.medications ?: emptyList(), record.oncologicalHistory)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory, category, { historyEntry -> historyEntry.matchesTypeFromSet(types) }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryAndTypeButNotWithDrugs.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryAndTypeButNotWithDrugs.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithAnd
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
@@ -11,6 +10,7 @@ import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
 import com.hartwig.actin.datamodel.clinical.treatment.Treatment
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadTreatmentWithCategoryAndTypeButNotWithDrugs(
     private val category: TreatmentCategory,
@@ -19,7 +19,7 @@ class HasHadTreatmentWithCategoryAndTypeButNotWithDrugs(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory,

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryButNotOfTypes.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryButNotOfTypes.kt
@@ -2,12 +2,12 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadTreatmentWithCategoryButNotOfTypes(
     private val category: TreatmentCategory,
@@ -15,7 +15,7 @@ class HasHadTreatmentWithCategoryButNotOfTypes(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
 
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             effectiveTreatmentHistory,

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
@@ -22,7 +22,9 @@ class HasHadTreatmentWithCategoryOfTypesRecently(
 
     override fun evaluate(record: PatientRecord): Evaluation {
         val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(
-                record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }, record.oncologicalHistory)
+            record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE },
+            record.oncologicalHistory
+        )
 
         val treatmentAssessment = effectiveTreatmentHistory.map { treatmentHistoryEntry ->
             val categoryMatch = category in treatmentHistoryEntry.categories()

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithCategoryOfTypesRecently.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.calendar.DateComparison.isAfterDate
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithOr
 import com.hartwig.actin.clinical.interpretation.MedicationStatusInterpretation
@@ -11,6 +10,7 @@ import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 import java.time.LocalDate
 
 class HasHadTreatmentWithCategoryOfTypesRecently(
@@ -21,9 +21,8 @@ class HasHadTreatmentWithCategoryOfTypesRecently(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory =
-            record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(
-                record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE })
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(
+                record.medications?.filter { interpreter.interpret(it) == MedicationStatusInterpretation.ACTIVE }, record.oncologicalHistory)
 
         val treatmentAssessment = effectiveTreatmentHistory.map { treatmentHistoryEntry ->
             val categoryMatch = category in treatmentHistoryEntry.categories()

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndCycles.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndCycles.kt
@@ -2,7 +2,6 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithAnd
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithOr
 import com.hartwig.actin.datamodel.PatientRecord
@@ -11,11 +10,12 @@ import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.clinical.treatment.Drug
 import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadTreatmentWithDrugAndCycles(private val drugsToFind: Set<Drug>, private val minCycles: Int?) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val effectiveTreatmentHistory = record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
         val namesToMatch = drugsToFind.map { it.name.lowercase() }.toSet()
         val drugList = concatItemsWithOr(drugsToFind)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndDoseReduction.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndDoseReduction.kt
@@ -12,7 +12,8 @@ class HasHadTreatmentWithDrugAndDoseReduction(private val drug: Drug) : Evaluati
 
     override fun evaluate(record: PatientRecord): Evaluation {
 
-        val hasHadDrug = (MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)).any { entry ->
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)
+        val hasHadDrug = effectiveTreatmentHistory.any { entry ->
             entry.treatments.any { treatment ->
                 (treatment as? DrugTreatment)?.drugs?.any { it.name.equals(drug.name, ignoreCase = true) } == true
             }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndDoseReduction.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadTreatmentWithDrugAndDoseReduction.kt
@@ -2,17 +2,17 @@ package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
-import com.hartwig.actin.algo.evaluation.treatment.MedicationFunctions.createTreatmentHistoryEntriesFromMedications
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.datamodel.clinical.treatment.Drug
 import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 
 class HasHadTreatmentWithDrugAndDoseReduction(private val drug: Drug) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
 
-        val hasHadDrug = (record.oncologicalHistory + createTreatmentHistoryEntriesFromMedications(record.medications)).any { entry ->
+        val hasHadDrug = (MedicationToTreatmentConverter.convertAndCombine(record.medications, record.oncologicalHistory)).any { entry ->
             entry.treatments.any { treatment ->
                 (treatment as? DrugTreatment)?.drugs?.any { it.name.equals(drug.name, ignoreCase = true) } == true
             }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/MedicationFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/MedicationFunctions.kt
@@ -1,11 +1,8 @@
 package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.datamodel.clinical.Medication
-import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentType
-import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryDetails
-import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 
 object MedicationFunctions {
 
@@ -15,17 +12,5 @@ object MedicationFunctions {
 
     fun Medication.hasDrugType(types: Set<TreatmentType>): Boolean {
         return this.drug?.drugTypes?.any(types::contains) == true
-    }
-
-    fun createTreatmentHistoryEntriesFromMedications(medications: List<Medication>?): List<TreatmentHistoryEntry> {
-        return medications?.map {
-            TreatmentHistoryEntry(
-                setOf(DrugTreatment(it.name, setOfNotNull(it.drug))),
-                startYear = it.startDate?.year,
-                startMonth = it.startDate?.monthValue,
-                isTrial = it.isTrialMedication,
-                treatmentHistoryDetails = TreatmentHistoryDetails(stopYear = it.stopDate?.year, stopMonth = it.stopDate?.monthValue)
-            )
-        } ?: emptyList()
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDateTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadAnyCancerTreatmentSinceDateTest.kt
@@ -7,6 +7,7 @@ import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.clinical.AtcLevel
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
+import com.hartwig.actin.datamodel.clinical.treatment.Drug
 import com.hartwig.actin.datamodel.clinical.treatment.DrugType
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import java.time.LocalDate
@@ -236,7 +237,11 @@ class HasHadAnyCancerTreatmentSinceDateTest {
                     stopYear = OLDER_DATE.year,
                     stopMonth = OLDER_DATE.monthValue
                 )
-            ), listOf(WashoutTestFactory.medication(atc, MIN_DATE.plusMonths(1)))
+            ),
+            listOf(
+                WashoutTestFactory.medication(atc, MIN_DATE.plusMonths(1))
+                    .copy(drug = Drug(name = "", category = TreatmentCategory.CHEMOTHERAPY, drugTypes = emptySet()))
+            )
         )
         evaluateFunctions(EvaluationResult.PASS, priorCancerTreatment)
     }

--- a/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
@@ -12,10 +12,14 @@ import java.time.YearMonth
 
 object MedicationToTreatmentConverter {
 
+    fun convertAndCombine(medications: List<Medication>?, treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
+        return treatmentHistory + convert(medications ?: emptyList(), treatmentHistory)
+    }
+
     fun convert(medications: List<Medication>, treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
         val treatmentsByDrug = createTreatmentHistoryEntryPerDrugMap(treatmentHistory)
         return medications.filter { medication ->
-            val isSystemicCancerTreatment = medication.drug?.category in TreatmentCategory.Companion.SYSTEMIC_CANCER_TREATMENT_CATEGORIES
+            val isSystemicCancerTreatment = medication.drug?.category in TreatmentCategory.SYSTEMIC_CANCER_TREATMENT_CATEGORIES
             val hasNoMatchingTreatmentHistoryEntry =
                 medication.drug?.let(treatmentsByDrug::get)?.none { matchesDate(medication, it) } ?: true
             val mayBeActive = medication.status == null || medication.status == MedicationStatus.ACTIVE
@@ -25,11 +29,12 @@ object MedicationToTreatmentConverter {
             .mapNotNull { (drug, medications) ->
                 val (start, stop) = extractStartAndStopRange(medications)
                 val name = drug?.name?.lowercase()?.replaceFirstChar { char -> char.uppercase() } ?: "Unknown"
+                val isTrialMedication = medications.all { it.isTrialMedication }
                 TreatmentHistoryEntry(
                     startYear = start?.year,
                     startMonth = start?.monthValue,
                     treatments = setOf(DrugTreatment(name = name, drugs = setOfNotNull(drug))),
-                    isTrial = true,
+                    isTrial = isTrialMedication,
                     treatmentHistoryDetails = TreatmentHistoryDetails(stopYear = stop?.year, stopMonth = stop?.monthValue)
                 )
             }

--- a/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
@@ -23,7 +23,7 @@ object MedicationToTreatmentConverter {
             val hasNoMatchingTreatmentHistoryEntry =
                 medication.drug?.let(treatmentsByDrug::get)?.none { matchesDate(medication, it) } ?: true
             val mayBeActive = medication.status == null || medication.status == MedicationStatus.ACTIVE
-            isSystemicCancerTreatment && hasNoMatchingTreatmentHistoryEntry && mayBeActive
+            (isSystemicCancerTreatment || medication.isTrialMedication) && hasNoMatchingTreatmentHistoryEntry && mayBeActive
         }
             .groupBy { it.drug }
             .mapNotNull { (drug, medications) ->

--- a/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
@@ -1,4 +1,4 @@
-package com.hartwig.actin.report.interpretation
+package com.hartwig.actin.medication
 
 import com.hartwig.actin.datamodel.clinical.Medication
 import com.hartwig.actin.datamodel.clinical.MedicationStatus
@@ -15,7 +15,7 @@ object MedicationToTreatmentConverter {
     fun convert(medications: List<Medication>, treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
         val treatmentsByDrug = createTreatmentHistoryEntryPerDrugMap(treatmentHistory)
         return medications.filter { medication ->
-            val isSystemicCancerTreatment = medication.drug?.category in TreatmentCategory.SYSTEMIC_CANCER_TREATMENT_CATEGORIES
+            val isSystemicCancerTreatment = medication.drug?.category in TreatmentCategory.Companion.SYSTEMIC_CANCER_TREATMENT_CATEGORIES
             val hasNoMatchingTreatmentHistoryEntry =
                 medication.drug?.let(treatmentsByDrug::get)?.none { matchesDate(medication, it) } ?: true
             val mayBeActive = medication.status == null || medication.status == MedicationStatus.ACTIVE
@@ -29,6 +29,7 @@ object MedicationToTreatmentConverter {
                     startYear = start?.year,
                     startMonth = start?.monthValue,
                     treatments = setOf(DrugTreatment(name = name, drugs = setOfNotNull(drug))),
+                    isTrial = true,
                     treatmentHistoryDetails = TreatmentHistoryDetails(stopYear = stop?.year, stopMonth = stop?.monthValue)
                 )
             }

--- a/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverter.kt
@@ -13,12 +13,8 @@ import java.time.YearMonth
 object MedicationToTreatmentConverter {
 
     fun convertAndCombine(medications: List<Medication>?, treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
-        return treatmentHistory + convert(medications ?: emptyList(), treatmentHistory)
-    }
-
-    fun convert(medications: List<Medication>, treatmentHistory: List<TreatmentHistoryEntry>): List<TreatmentHistoryEntry> {
         val treatmentsByDrug = createTreatmentHistoryEntryPerDrugMap(treatmentHistory)
-        return medications.filter { medication ->
+        return treatmentHistory + (medications ?: emptyList()).filter { medication ->
             val isSystemicCancerTreatment = medication.drug?.category in TreatmentCategory.SYSTEMIC_CANCER_TREATMENT_CATEGORIES
             val hasNoMatchingTreatmentHistoryEntry =
                 medication.drug?.let(treatmentsByDrug::get)?.none { matchesDate(medication, it) } ?: true

--- a/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
@@ -1,4 +1,4 @@
-package com.hartwig.actin.report.interpretation
+package com.hartwig.actin.medication
 
 import com.hartwig.actin.datamodel.clinical.AtcClassification
 import com.hartwig.actin.datamodel.clinical.AtcLevel
@@ -10,9 +10,9 @@ import com.hartwig.actin.datamodel.clinical.treatment.DrugType
 import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryDetails
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
-import java.time.LocalDate
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import java.time.LocalDate
 
 class MedicationToTreatmentConverterTest {
 

--- a/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
@@ -33,14 +33,16 @@ class MedicationToTreatmentConverterTest {
 
     @Test
     fun `Should convert medications not already present in treatment history to a treatment history`() {
-        val medicationsToAdd = MedicationToTreatmentConverter.convertAndCombine(medications, oncologicalHistory)
-        Assertions.assertThat(medicationsToAdd.size).isEqualTo(1)
-        Assertions.assertThat(medicationsToAdd.first()).isEqualTo(
+        val medicationsAdded = MedicationToTreatmentConverter.convertAndCombine(medications, oncologicalHistory)
+        Assertions.assertThat(medicationsAdded.size - oncologicalHistory.size).isEqualTo(1)
+        Assertions.assertThat(
+            medicationsAdded.contains(
             createTreatmentHistoryEntry("Pembrolizumab", TreatmentCategory.IMMUNOTHERAPY, DrugType.PD_1_PD_L1_ANTIBODY, 2023, 2023).copy(
                 treatmentHistoryDetails = TreatmentHistoryDetails(stopYear = 2023, stopMonth = 12),
                 startYear = 2023,
                 startMonth = 11,
                 intents = null,
+            )
             )
         )
     }

--- a/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/medication/MedicationToTreatmentConverterTest.kt
@@ -33,7 +33,7 @@ class MedicationToTreatmentConverterTest {
 
     @Test
     fun `Should convert medications not already present in treatment history to a treatment history`() {
-        val medicationsToAdd = MedicationToTreatmentConverter.convert(medications, oncologicalHistory)
+        val medicationsToAdd = MedicationToTreatmentConverter.convertAndCombine(medications, oncologicalHistory)
         Assertions.assertThat(medicationsToAdd.size).isEqualTo(1)
         Assertions.assertThat(medicationsToAdd.first()).isEqualTo(
             createTreatmentHistoryEntry("Pembrolizumab", TreatmentCategory.IMMUNOTHERAPY, DrugType.PD_1_PD_L1_ANTIBODY, 2023, 2023).copy(

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
@@ -92,8 +92,9 @@ class ClinicalSummaryGenerator(
         val table = createDoubleColumnTable(dateWidth, treatmentWidth)
 
         val systemicTreatmentHistory = treatmentHistory.filter { treatmentHistoryEntryIsSystemic(it) == requireSystemic }
+        val effectiveTreatmentHistory = MedicationToTreatmentConverter.convertAndCombine(medications, systemicTreatmentHistory)
 
-        (MedicationToTreatmentConverter.convertAndCombine(medications, systemicTreatmentHistory)).sortedWith(TreatmentHistoryAscendingDateComparator())
+        effectiveTreatmentHistory.sortedWith(TreatmentHistoryAscendingDateComparator())
             .groupBy { Triple(extractTreatmentString(it), it.startMonth, it.startYear) }
             .forEach { (key, historyEntries) ->
                 val details =

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
@@ -11,7 +11,7 @@ import com.hartwig.actin.datamodel.clinical.TumorStatus
 import com.hartwig.actin.datamodel.clinical.treatment.history.Intent
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import com.hartwig.actin.report.datamodel.Report
-import com.hartwig.actin.report.interpretation.MedicationToTreatmentConverter
+import com.hartwig.actin.medication.MedicationToTreatmentConverter
 import com.hartwig.actin.report.pdf.tables.TableGenerator
 import com.hartwig.actin.report.pdf.tables.clinical.DateFunctions.toDateString
 import com.hartwig.actin.report.pdf.util.Cells.create

--- a/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
+++ b/report/src/main/kotlin/com/hartwig/actin/report/pdf/tables/clinical/ClinicalSummaryGenerator.kt
@@ -91,10 +91,9 @@ class ClinicalSummaryGenerator(
         val treatmentWidth = valueWidth - dateWidth
         val table = createDoubleColumnTable(dateWidth, treatmentWidth)
 
-        val medicationsToAdd = MedicationToTreatmentConverter.convert(medications, treatmentHistory)
         val systemicTreatmentHistory = treatmentHistory.filter { treatmentHistoryEntryIsSystemic(it) == requireSystemic }
 
-        (systemicTreatmentHistory + medicationsToAdd).sortedWith(TreatmentHistoryAscendingDateComparator())
+        (MedicationToTreatmentConverter.convertAndCombine(medications, systemicTreatmentHistory)).sortedWith(TreatmentHistoryAscendingDateComparator())
             .groupBy { Triple(extractTreatmentString(it), it.startMonth, it.startYear) }
             .forEach { (key, historyEntries) ->
                 val details =


### PR DESCRIPTION
I noticed for a report this week that `HasHadSomeTreatmentsWithCategory` evaluation was incorrect. Too many lines were counted, since patient had chemotherapy mentioned in the oncologicalHistory, but the medications also contained these chemotherapies, which were all counted as a separate line because of using `createTreatmentHistoryEntriesFromMedications` instead of MedicationToTreatmentConverter.convert() (which removes 'duplicates'). 
Replaced all occurrences of `createTreatmentHistoryEntriesFromMedications` with `MedicationToTreatmentConverter.convert()`