### PR TITLE
OPR-332: Bump SERVE datamodel dependency to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <actin-datamodel.version>3.7.0</actin-datamodel.version>
         <actin-treatment-database.version>0.4.6</actin-treatment-database.version>
         <actin-utils.version>2.1.0</actin-utils.version>
-        <serve.version>8.6.0</serve.version>
+        <serve.version>8.11.0</serve.version>
         <orange-datamodel.version>3.0.0</orange-datamodel.version>
         <actin-transvar.version>2.0.0</actin-transvar.version>
         <pave.version>1.8.2</pave.version>


### PR DESCRIPTION
This is to make sure ACTIN is aware of the new `HARTWIG_TRIAL_CURATED` value in the Knowledgebase enum