### PR TITLE
ACTIN-3802: Assume PD when subsequent treatment line present and stop…

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -15,14 +15,16 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val treatmentEvaluations = record.oncologicalHistory.map { treatmentHistoryEntry ->
+        val history = record.oncologicalHistory
+        val treatmentEvaluations = history.map { treatmentHistoryEntry ->
             val mayMatchAsTrial = TrialFunctions.treatmentMayMatchAsTrial(treatmentHistoryEntry, setOf(category))
             val categoryMatches = treatmentHistoryEntry.categories().contains(category)
 
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) {
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry)
+                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
                 val durationWeeksMax = TreatmentHistoryEntryFunctions.maxWeeksBetweenDates(matchingPortionOfEntry)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -23,8 +23,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) {
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
-                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, history)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
                 val durationWeeksMax = TreatmentHistoryEntryFunctions.maxWeeksBetweenDates(matchingPortionOfEntry)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD.kt
@@ -23,7 +23,7 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPD(
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) {
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
-                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
                 val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
@@ -57,7 +57,7 @@ class HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks(
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) { treatment ->
                 specificDrugCombinedWithCategoryAndTypesEvaluator.treatmentWithoutDrugMatchesCategoryAndType(treatment)
             }?.let { matchingPortionOfEntry ->
-                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
                 val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
                 val durationWeeksMatchingPortion = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
@@ -57,8 +57,7 @@ class HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks(
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) { treatment ->
                 specificDrugCombinedWithCategoryAndTypesEvaluator.treatmentWithoutDrugMatchesCategoryAndType(treatment)
             }?.let { matchingPortionOfEntry ->
-                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, history)
                 val durationWeeksMatchingPortion = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
 
                 PDFollowingSpecificCombinationEvaluation.create(

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks.kt
@@ -48,6 +48,7 @@ class HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks(
         val specificDrugCombinedWithCategoryAndTypesEvaluator =
             SpecificDrugCombinedWithCategoryAndTypesEvaluator(drugToFind, category, types)
 
+        val history = record.oncologicalHistory
         val treatmentEvaluations = specificDrugCombinedWithCategoryAndTypesEvaluator.relevantHistory(record).map { treatmentHistoryEntry ->
             val mayMatchAsTrial = TrialFunctions.treatmentMayMatchAsTrial(treatmentHistoryEntry, setOf(category))
 
@@ -56,7 +57,8 @@ class HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks(
             TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(treatmentHistoryEntry) { treatment ->
                 specificDrugCombinedWithCategoryAndTypesEvaluator.treatmentWithoutDrugMatchesCategoryAndType(treatment)
             }?.let { matchingPortionOfEntry ->
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry)
+                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
                 val durationWeeksMatchingPortion = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
 
                 PDFollowingSpecificCombinationEvaluation.create(

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
@@ -36,8 +36,7 @@ class HasHadPDFollowingSpecificTreatment(private val treatments: List<Treatment>
         val treatmentCategoriesToMatch = treatments.flatMap { it.categories() }.filter(TrialFunctions::categoryAllowsTrialMatches).toSet()
 
         return treatmentHistory.map { entry ->
-            val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
-            val isPD = treatmentResultedInPD(entry, hasSubsequentLine)
+            val isPD = treatmentResultedInPD(entry, treatmentHistory)
             val treatmentsMatchingNames = treatmentsMatchingNameListExactly(entry.allTreatments(), treatmentNamesToMatch)
             val includesTrial = TrialFunctions.treatmentMayMatchAsTrial(entry, treatmentCategoriesToMatch)
             if (treatmentsMatchingNames.isNotEmpty()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
@@ -3,7 +3,6 @@ package com.hartwig.actin.algo.evaluation.treatment
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithAnd
-import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentResultedInPD
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
@@ -37,7 +36,7 @@ class HasHadPDFollowingSpecificTreatment(private val treatments: List<Treatment>
         val treatmentCategoriesToMatch = treatments.flatMap { it.categories() }.filter(TrialFunctions::categoryAllowsTrialMatches).toSet()
 
         return treatmentHistory.map { entry ->
-            val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
+            val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
             val isPD = treatmentResultedInPD(entry, hasSubsequentLine)
             val treatmentsMatchingNames = treatmentsMatchingNameListExactly(entry.allTreatments(), treatmentNamesToMatch)
             val includesTrial = TrialFunctions.treatmentMayMatchAsTrial(entry, treatmentCategoriesToMatch)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatment.kt
@@ -3,6 +3,7 @@ package com.hartwig.actin.algo.evaluation.treatment
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.util.Format.concatItemsWithAnd
+import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentResultedInPD
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
@@ -36,7 +37,8 @@ class HasHadPDFollowingSpecificTreatment(private val treatments: List<Treatment>
         val treatmentCategoriesToMatch = treatments.flatMap { it.categories() }.filter(TrialFunctions::categoryAllowsTrialMatches).toSet()
 
         return treatmentHistory.map { entry ->
-            val isPD = treatmentResultedInPD(entry)
+            val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
+            val isPD = treatmentResultedInPD(entry, hasSubsequentLine)
             val treatmentsMatchingNames = treatmentsMatchingNameListExactly(entry.allTreatments(), treatmentNamesToMatch)
             val includesTrial = TrialFunctions.treatmentMayMatchAsTrial(entry, treatmentCategoriesToMatch)
             if (treatmentsMatchingNames.isNotEmpty()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
@@ -16,9 +16,9 @@ class HasHadPDFollowingTreatmentWithCategory(private val category: TreatmentCate
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             history,
             category,
-            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, history)) },
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, history) },
             { true },
-            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, history)) != false }
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, history) != false }
         )
 
         return if (treatmentSummary.hasSpecificMatch()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
@@ -16,9 +16,9 @@ class HasHadPDFollowingTreatmentWithCategory(private val category: TreatmentCate
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
             history,
             category,
-            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, history)) },
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, history)) },
             { true },
-            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, history)) != false }
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(entry, history)) != false }
         )
 
         return if (treatmentSummary.hasSpecificMatch()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategory.kt
@@ -12,12 +12,13 @@ import com.hartwig.actin.datamodel.clinical.treatment.TreatmentCategory
 class HasHadPDFollowingTreatmentWithCategory(private val category: TreatmentCategory) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
+        val history = record.oncologicalHistory
         val treatmentSummary = TreatmentSummaryForCategory.createForTreatmentHistory(
-            record.oncologicalHistory,
+            history,
             category,
-            ProgressiveDiseaseFunctions::treatmentResultedInPD,
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, history)) },
             { true },
-            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry) != false }
+            { entry -> ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, history)) != false }
         )
 
         return if (treatmentSummary.hasSpecificMatch()) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -19,7 +19,8 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val treatmentEvaluations = record.oncologicalHistory.map { treatmentHistoryEntry ->
+        val history = record.oncologicalHistory
+        val treatmentEvaluations = history.map { treatmentHistoryEntry ->
             val mayMatchAsTrial = TrialFunctions.treatmentMayMatchAsTrial(treatmentHistoryEntry, setOf(category))
             val categoryMatches = treatmentHistoryEntry.categories().contains(category)
 
@@ -27,7 +28,8 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
                 val cycles = matchingPortionOfEntry.treatmentHistoryDetails?.cycles
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry)
+                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
                 val meetsMinCycles = minCycles == null || (cycles != null && cycles >= minCycles)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -28,7 +28,7 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
                 val cycles = matchingPortionOfEntry.treatmentHistoryDetails?.cycles
-                val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
+                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
                 val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks.kt
@@ -28,8 +28,7 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeks(
                 categoryMatches && treatmentHistoryEntry.matchesTypeFromSet(types) == true
             }?.let { matchingPortionOfEntry ->
                 val cycles = matchingPortionOfEntry.treatmentHistoryDetails?.cycles
-                val hasSubsequentLine = TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine(treatmentHistoryEntry, history)
-                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, hasSubsequentLine)
+                val treatmentResultedInPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(matchingPortionOfEntry, history)
 
                 val durationWeeks = TreatmentHistoryEntryFunctions.weeksBetweenDates(matchingPortionOfEntry)
                 val meetsMinCycles = minCycles == null || (cycles != null && cycles >= minCycles)

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
@@ -1,7 +1,9 @@
 package com.hartwig.actin.algo.evaluation.treatment
 
+import com.hartwig.actin.algo.evaluation.treatment.SystemicTreatmentAnalyser.treatmentHistoryEntryIsSystemic
 import com.hartwig.actin.calendar.DateComparison
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions
+import java.time.YearMonth
 import com.hartwig.actin.datamodel.clinical.treatment.Drug
 import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
 import com.hartwig.actin.datamodel.clinical.treatment.Treatment
@@ -34,7 +36,7 @@ object TreatmentHistoryEntryFunctions {
 
         return treatmentHistory.map { entry ->
             val categoriesToMatch = drugsToMatch.map(Drug::category).toSet()
-            val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
+            val hasSubsequentLine = hasSubsequentTreatmentLine(entry, treatmentHistory)
             val isPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, hasSubsequentLine)
             val matchingDrugs = entry.allTreatments().flatMap {
                 (it as? DrugTreatment)?.drugs?.intersect(drugsToMatch) ?: emptyList()
@@ -130,6 +132,43 @@ object TreatmentHistoryEntryFunctions {
         matchingPortionOfEntry.stopYear(),
         matchingPortionOfEntry.stopMonth()
     )
+
+    fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
+        val stopYear = entry.stopYear() ?: return null
+        val stopMonth = entry.stopMonth()
+        val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
+
+        var hasUncertain = false
+
+        for (other in history.filter { it !== entry && treatmentHistoryEntryIsSystemic(it) }) {
+            val otherStartYear = other.startYear
+
+            if (otherStartYear == null) {
+                hasUncertain = true
+                continue
+            }
+
+            val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
+
+            if (otherStart.isAfter(entryStop)) {
+                if (ProgressiveDiseaseFunctions.isWithinPDInferenceGap(stopYear, stopMonth, otherStartYear, other.startMonth)) {
+                    return true
+                }
+                continue
+            }
+
+            // Overlap: other started after current started but ends later (or is ongoing) — current was dropped
+            val entryStartYear = entry.startYear ?: continue
+            if (otherStart.isAfter(YearMonth.of(entryStartYear, entry.startMonth ?: 12))) {
+                val otherStopYear = other.stopYear()
+                val otherEndsAfterCurrent = otherStopYear == null ||
+                    YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
+                if (otherEndsAfterCurrent) return true
+            }
+        }
+
+        return if (hasUncertain) null else false
+    }
 
     private fun sumOrNullIfEmpty(list: List<Int>) = if (list.isEmpty()) null else list.sum()
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
@@ -34,7 +34,8 @@ object TreatmentHistoryEntryFunctions {
 
         return treatmentHistory.map { entry ->
             val categoriesToMatch = drugsToMatch.map(Drug::category).toSet()
-            val isPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(entry)
+            val hasSubsequentLine = ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine(entry, treatmentHistory)
+            val isPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, hasSubsequentLine)
             val matchingDrugs = entry.allTreatments().flatMap {
                 (it as? DrugTreatment)?.drugs?.intersect(drugsToMatch) ?: emptyList()
             }.toSet()

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctions.kt
@@ -1,9 +1,7 @@
 package com.hartwig.actin.algo.evaluation.treatment
 
-import com.hartwig.actin.algo.evaluation.treatment.SystemicTreatmentAnalyser.treatmentHistoryEntryIsSystemic
 import com.hartwig.actin.calendar.DateComparison
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions
-import java.time.YearMonth
 import com.hartwig.actin.datamodel.clinical.treatment.Drug
 import com.hartwig.actin.datamodel.clinical.treatment.DrugTreatment
 import com.hartwig.actin.datamodel.clinical.treatment.Treatment
@@ -36,8 +34,7 @@ object TreatmentHistoryEntryFunctions {
 
         return treatmentHistory.map { entry ->
             val categoriesToMatch = drugsToMatch.map(Drug::category).toSet()
-            val hasSubsequentLine = hasSubsequentTreatmentLine(entry, treatmentHistory)
-            val isPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, hasSubsequentLine)
+            val isPD = ProgressiveDiseaseFunctions.treatmentResultedInPD(entry, treatmentHistory)
             val matchingDrugs = entry.allTreatments().flatMap {
                 (it as? DrugTreatment)?.drugs?.intersect(drugsToMatch) ?: emptyList()
             }.toSet()
@@ -132,43 +129,6 @@ object TreatmentHistoryEntryFunctions {
         matchingPortionOfEntry.stopYear(),
         matchingPortionOfEntry.stopMonth()
     )
-
-    fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
-        val stopYear = entry.stopYear() ?: return null
-        val stopMonth = entry.stopMonth()
-        val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
-
-        var hasUncertain = false
-
-        for (other in history.filter { it !== entry && treatmentHistoryEntryIsSystemic(it) }) {
-            val otherStartYear = other.startYear
-
-            if (otherStartYear == null) {
-                hasUncertain = true
-                continue
-            }
-
-            val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
-
-            if (otherStart.isAfter(entryStop)) {
-                if (ProgressiveDiseaseFunctions.isWithinPDInferenceGap(stopYear, stopMonth, otherStartYear, other.startMonth)) {
-                    return true
-                }
-                continue
-            }
-
-            // Overlap: other started after current started but ends later (or is ongoing) — current was dropped
-            val entryStartYear = entry.startYear ?: continue
-            if (otherStart.isAfter(YearMonth.of(entryStartYear, entry.startMonth ?: 12))) {
-                val otherStopYear = other.stopYear()
-                val otherEndsAfterCurrent = otherStopYear == null ||
-                    YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
-                if (otherEndsAfterCurrent) return true
-            }
-        }
-
-        return if (hasUncertain) null else false
-    }
 
     private fun sumOrNullIfEmpty(list: List<Int>) = if (list.isEmpty()) null else list.sum()
 

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPDTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPDTest.kt
@@ -27,6 +27,15 @@ class HasHadLimitedWeeksOfTreatmentOfCategoryWithTypesAndStopReasonNotPDTest {
     }
 
     @Test
+    fun `Should fail for right category type with no stop reason but subsequent treatment line within 26 weeks`() {
+        val matchingEntry = TreatmentTestFactory.treatmentHistoryEntry(MATCHING_TREATMENT_SET, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.drugTreatment("other", TreatmentCategory.CHEMOTHERAPY)), startYear = 2020, startMonth = 9
+        )
+        evaluateFunctions(EvaluationResult.FAIL, TreatmentTestFactory.withTreatmentHistory(listOf(matchingEntry, subsequentEntry)))
+    }
+
+    @Test
     fun `Should fail for right category and type but with PD`() {
         val treatmentHistoryEntry =
             TreatmentTestFactory.treatmentHistoryEntry(

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeksTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeksTest.kt
@@ -161,6 +161,21 @@ class HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeksTe
     }
 
     @Test
+    fun `Should pass for combination of target drug and treatment with target category with no stop reason but subsequent line within 26 weeks and sufficient duration`() {
+        val matchingEntry = treatmentHistoryEntry(
+            setOf(MATCHING_DRUG_TREATMENT, drugTreatment("combined", MATCHING_CATEGORY)),
+            startYear = 2022, startMonth = 3, stopYear = 2022, stopMonth = 6
+        )
+        val subsequentEntry = treatmentHistoryEntry(
+            setOf(drugTreatment("other", TreatmentCategory.IMMUNOTHERAPY)), startYear = 2022, startMonth = 8
+        )
+        val function = HasHadPDFollowingSpecificDrugCombinedWithCategoryAndTypesAndMinimumWeeks(
+            MATCHING_DRUG_TREATMENT.drugs.first(), MATCHING_CATEGORY, emptySet(), 6
+        )
+        assertEvaluation(EvaluationResult.PASS, function.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
     fun `Should pass for combination of target drug and treatment with target category and type and stop reason PD and sufficient weeks`() {
         val treatmentHistoryEntry = treatmentHistoryEntry(
             setOf(MATCHING_DRUG_TREATMENT, drugTreatment("combined", MATCHING_CATEGORY)),

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatmentTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingSpecificTreatmentTest.kt
@@ -42,6 +42,13 @@ class HasHadPDFollowingSpecificTreatmentTest {
     }
 
     @Test
+    fun `Should pass for matching treatment with no stop reason but subsequent treatment line within 26 weeks`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(setOf(drugTreatment("other", TreatmentCategory.CHEMOTHERAPY)), startYear = 2020, startMonth = 9)
+        assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
     fun `Should pass for matching treatment and stop reason PD`() {
         val treatmentHistoryEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopReason = StopReason.PROGRESSIVE_DISEASE)
         assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistoryEntry(treatmentHistoryEntry)))

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithAnyDrugTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithAnyDrugTest.kt
@@ -43,6 +43,27 @@ class HasHadPDFollowingTreatmentWithAnyDrugTest {
     }
 
     @Test
+    fun `Should pass for matching treatment with no stop reason but subsequent treatment line within 26 weeks`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(NON_MATCHING_TREATMENTS, startYear = 2020, startMonth = 9)
+        assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
+    fun `Should return undetermined for matching treatment with no stop reason when gap to next line exceeds 26 weeks`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(NON_MATCHING_TREATMENTS, startYear = 2021, startMonth = 1)
+        assertEvaluation(EvaluationResult.UNDETERMINED, FUNCTION.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
+    fun `Should fail for matching treatment stopped due to toxicity even if subsequent line exists`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopReason = StopReason.TOXICITY, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(NON_MATCHING_TREATMENTS, startYear = 2020, startMonth = 9)
+        assertEvaluation(EvaluationResult.FAIL, FUNCTION.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
     fun `Should pass for matching treatment and stop reason PD`() {
         val treatmentHistoryEntry = treatmentHistoryEntry(MATCHING_TREATMENTS, stopReason = StopReason.PROGRESSIVE_DISEASE)
         assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistoryEntry(treatmentHistoryEntry)))

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeksTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeksTest.kt
@@ -78,6 +78,13 @@ class HasHadPDFollowingTreatmentWithCategoryOfTypesAndCyclesOrWeeksTest {
     }
 
     @Test
+    fun `Should pass for right category type with no stop reason but subsequent treatment line within 26 weeks`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENT_SET, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(setOf(drugTreatment("other", TreatmentCategory.CHEMOTHERAPY)), startYear = 2020, startMonth = 9)
+        assertEvaluation(EvaluationResult.PASS, function().evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
     fun `Should pass for right category type and stop reason PD`() {
         val treatmentHistoryEntry = treatmentHistoryEntry(MATCHING_TREATMENT_SET, stopReason = StopReason.PROGRESSIVE_DISEASE)
         assertEvaluation(EvaluationResult.PASS, function().evaluate(withTreatmentHistoryEntry(treatmentHistoryEntry)))

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/HasHadPDFollowingTreatmentWithCategoryTest.kt
@@ -44,6 +44,13 @@ class HasHadPDFollowingTreatmentWithCategoryTest {
     }
 
     @Test
+    fun `Should pass for right category with no stop reason but subsequent treatment line within 26 weeks`() {
+        val matchingEntry = treatmentHistoryEntry(MATCHING_TREATMENT_SET, stopYear = 2020, stopMonth = 6)
+        val subsequentEntry = treatmentHistoryEntry(setOf(drugTreatment("other", TreatmentCategory.CHEMOTHERAPY)), startYear = 2020, startMonth = 9)
+        assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistory(listOf(matchingEntry, subsequentEntry))))
+    }
+
+    @Test
     fun `Should pass for right category and stop reason PD`() {
         val treatmentHistoryEntry = treatmentHistoryEntry(MATCHING_TREATMENT_SET, stopReason = StopReason.PROGRESSIVE_DISEASE)
         assertEvaluation(EvaluationResult.PASS, FUNCTION.evaluate(withTreatmentHistoryEntry(treatmentHistoryEntry)))

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -1,8 +1,6 @@
 package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.treatment.TreatmentHistoryEntryFunctions.evaluateIfDrugHadPDResponse
-import com.hartwig.actin.algo.evaluation.treatment.TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine
-import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.drugTreatment
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentStage
@@ -268,56 +266,4 @@ class TreatmentHistoryEntryFunctionsTest {
         assertThat(TreatmentHistoryEntryFunctions.maxWeeksBetweenDates(entry)).isEqualTo(17)
     }
 
-    @Test
-    fun `hasSubsequentTreatmentLine should return true when another systemic entry starts shortly after stop`() {
-        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
-        val subsequent = treatmentHistoryEntry(
-            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = 1999, startMonth = 6
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isTrue()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return false when gap to next line exceeds 26 weeks`() {
-        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
-        val subsequent = treatmentHistoryEntry(
-            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = 2000, startMonth = 1
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isFalse()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return false when no other systemic entry exists`() {
-        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry))).isFalse()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return null when entry has no stop date`() {
-        val entry = treatmentHistoryEntry(treatments = setOf(TreatmentTestFactory.treatment("treatment", true)))
-        val subsequent = treatmentHistoryEntry(
-            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = 1999, startMonth = 6
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isNull()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return null when a subsequent entry has unknown start date`() {
-        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
-        val uncertain = treatmentHistoryEntry(treatments = setOf(TreatmentTestFactory.treatment("uncertain", true)))
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, uncertain))).isNull()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return true when another entry started during and ended after current entry`() {
-        val entry = treatmentHistoryEntry(startYear = 1999, startMonth = 1, stopYear = 1999, stopMonth = 9)
-        val overlapping = treatmentHistoryEntry(
-            treatments = setOf(TreatmentTestFactory.treatment("overlapping", true)),
-            startYear = 1999, startMonth = 6, stopYear = 2000, stopMonth = 1
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, overlapping))).isTrue()
-    }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -265,5 +265,4 @@ class TreatmentHistoryEntryFunctionsTest {
         val entry = TreatmentHistoryEntry(treatments = emptySet(), startYear = 2024, startMonth = 3, treatmentHistoryDetails = TreatmentHistoryDetails(maxStopYear = 2024, maxStopMonth = 8))
         assertThat(TreatmentHistoryEntryFunctions.maxWeeksBetweenDates(entry)).isEqualTo(17)
     }
-
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentHistoryEntryFunctionsTest.kt
@@ -1,6 +1,8 @@
 package com.hartwig.actin.algo.evaluation.treatment
 
 import com.hartwig.actin.algo.evaluation.treatment.TreatmentHistoryEntryFunctions.evaluateIfDrugHadPDResponse
+import com.hartwig.actin.algo.evaluation.treatment.TreatmentHistoryEntryFunctions.hasSubsequentTreatmentLine
+import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.drugTreatment
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentStage
@@ -264,5 +266,58 @@ class TreatmentHistoryEntryFunctionsTest {
     fun `Should return max number of weeks between the start and stop date of the treatment`() {
         val entry = TreatmentHistoryEntry(treatments = emptySet(), startYear = 2024, startMonth = 3, treatmentHistoryDetails = TreatmentHistoryDetails(maxStopYear = 2024, maxStopMonth = 8))
         assertThat(TreatmentHistoryEntryFunctions.maxWeeksBetweenDates(entry)).isEqualTo(17)
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return true when another systemic entry starts shortly after stop`() {
+        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
+        val subsequent = treatmentHistoryEntry(
+            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = 1999, startMonth = 6
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isTrue()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return false when gap to next line exceeds 26 weeks`() {
+        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
+        val subsequent = treatmentHistoryEntry(
+            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = 2000, startMonth = 1
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isFalse()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return false when no other systemic entry exists`() {
+        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry))).isFalse()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return null when entry has no stop date`() {
+        val entry = treatmentHistoryEntry(treatments = setOf(TreatmentTestFactory.treatment("treatment", true)))
+        val subsequent = treatmentHistoryEntry(
+            treatments = setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = 1999, startMonth = 6
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequent))).isNull()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return null when a subsequent entry has unknown start date`() {
+        val entry = treatmentHistoryEntry(stopYear = 1999, stopMonth = 4)
+        val uncertain = treatmentHistoryEntry(treatments = setOf(TreatmentTestFactory.treatment("uncertain", true)))
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, uncertain))).isNull()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return true when another entry started during and ended after current entry`() {
+        val entry = treatmentHistoryEntry(startYear = 1999, startMonth = 1, stopYear = 1999, stopMonth = 9)
+        val overlapping = treatmentHistoryEntry(
+            treatments = setOf(TreatmentTestFactory.treatment("overlapping", true)),
+            startYear = 1999, startMonth = 6, stopYear = 2000, stopMonth = 1
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, overlapping))).isTrue()
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -1,41 +1,68 @@
 package com.hartwig.actin.clinical.interpretation
 
 import com.hartwig.actin.calendar.DateComparison
+import com.hartwig.actin.datamodel.clinical.treatment.Treatment
 import com.hartwig.actin.datamodel.clinical.treatment.history.StopReason
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentResponse
-
-const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26L // half year
+import java.time.YearMonth
 
 object ProgressiveDiseaseFunctions {
 
-    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean? = null): Boolean? {
+    private const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26L // half year
+
+    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, treatmentHistory: List<TreatmentHistoryEntry> = emptyList()): Boolean? {
         val bestResponse = treatment.treatmentHistoryDetails?.bestResponse
         return when {
             bestResponse == TreatmentResponse.PROGRESSIVE_DISEASE -> true
-            else -> treatmentStoppedDueToPD(treatment, hasSubsequentLine)
+            else -> treatmentStoppedDueToPD(treatment, treatmentHistory)
         }
     }
 
-    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean? = null): Boolean? {
+    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, treatmentHistory: List<TreatmentHistoryEntry> = emptyList()): Boolean? {
         val stopReason = treatment.treatmentHistoryDetails?.stopReason
         val treatmentDuration = DateComparison.minWeeksBetweenDates(
-            treatment.startYear,
-            treatment.startMonth,
-            treatment.stopYear(),
-            treatment.stopMonth()
+            treatment.startYear, treatment.startMonth, treatment.stopYear(), treatment.stopMonth()
         )
-
         return when {
             stopReason == StopReason.PROGRESSIVE_DISEASE -> true
             stopReason != null -> false
-            hasSubsequentLine == true -> true
+            hasSubsequentTreatmentLine(treatment, treatmentHistory) == true -> true
             treatmentDuration != null && treatmentDuration > MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD -> true
             else -> null
         }
     }
 
-    fun isWithinPDInferenceGap(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
+    private fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
+        val stopYear = entry.stopYear()
+        val stopMonth = entry.stopMonth()
+        val entryStartYear = entry.startYear
+        val others = history.filter { it !== entry && it.allTreatments().any(Treatment::isSystemic) }
+
+        val hasSubsequent = if (stopYear == null) null else {
+            val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
+            others.mapNotNull { other -> other.startYear?.let { year -> other to year } }.any { (other, otherStartYear) ->
+                val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
+                when {
+                    otherStart.isAfter(entryStop) -> gapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
+                    entryStartYear != null && otherStart.isAfter(YearMonth.of(entryStartYear, entry.startMonth ?: 12)) -> {
+                        val otherStopYear = other.stopYear()
+                        otherStopYear == null || YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
+                    }
+                    else -> false
+                }
+            }
+        }
+
+        return when {
+            hasSubsequent == true -> true
+            hasSubsequent == null -> null
+            others.any { it.startYear == null } -> null
+            else -> false
+        }
+    }
+
+    private fun gapSuggestsPD(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
         val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, stopMonth, nextStartYear, nextStartMonth)
         return minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
     }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -4,20 +4,21 @@ import com.hartwig.actin.calendar.DateComparison
 import com.hartwig.actin.datamodel.clinical.treatment.history.StopReason
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentResponse
+import java.time.YearMonth
 
 private const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26 // half year
 
 object ProgressiveDiseaseFunctions {
 
-    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry): Boolean? {
+    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean = false): Boolean? {
         val bestResponse = treatment.treatmentHistoryDetails?.bestResponse
         return when {
             bestResponse == TreatmentResponse.PROGRESSIVE_DISEASE -> true
-            else -> treatmentStoppedDueToPD(treatment)
+            else -> treatmentStoppedDueToPD(treatment, hasSubsequentLine)
         }
     }
 
-    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry): Boolean? {
+    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean = false): Boolean? {
         val stopReason = treatment.treatmentHistoryDetails?.stopReason
         val treatmentDuration = DateComparison.minWeeksBetweenDates(
             treatment.startYear,
@@ -29,11 +30,24 @@ object ProgressiveDiseaseFunctions {
         return when {
             stopReason == StopReason.PROGRESSIVE_DISEASE -> true
 
+            stopReason == null && hasSubsequentLine -> true
+
             stopReason == null && treatmentDuration != null && treatmentDuration > MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD -> true
 
             stopReason != null -> false
 
             else -> null
+        }
+    }
+
+    fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean {
+        val stopYear = entry.stopYear() ?: return false
+        val entryStop = YearMonth.of(stopYear, entry.stopMonth() ?: 12)
+        return history.any { other ->
+            if (other === entry || other.startYear == null) return@any false
+            if (!YearMonth.of(other.startYear!!, other.startMonth ?: 1).isAfter(entryStop)) return@any false
+            val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, entry.stopMonth(), other.startYear!!, other.startMonth)
+            minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
         }
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -4,13 +4,12 @@ import com.hartwig.actin.calendar.DateComparison
 import com.hartwig.actin.datamodel.clinical.treatment.history.StopReason
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentResponse
-import java.time.YearMonth
 
-private const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26 // half year
+const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26L // half year
 
 object ProgressiveDiseaseFunctions {
 
-    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean = false): Boolean? {
+    fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean? = null): Boolean? {
         val bestResponse = treatment.treatmentHistoryDetails?.bestResponse
         return when {
             bestResponse == TreatmentResponse.PROGRESSIVE_DISEASE -> true
@@ -18,7 +17,7 @@ object ProgressiveDiseaseFunctions {
         }
     }
 
-    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean = false): Boolean? {
+    fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, hasSubsequentLine: Boolean? = null): Boolean? {
         val stopReason = treatment.treatmentHistoryDetails?.stopReason
         val treatmentDuration = DateComparison.minWeeksBetweenDates(
             treatment.startYear,
@@ -29,25 +28,15 @@ object ProgressiveDiseaseFunctions {
 
         return when {
             stopReason == StopReason.PROGRESSIVE_DISEASE -> true
-
-            stopReason == null && hasSubsequentLine -> true
-
-            stopReason == null && treatmentDuration != null && treatmentDuration > MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD -> true
-
             stopReason != null -> false
-
+            hasSubsequentLine == true -> true
+            treatmentDuration != null && treatmentDuration > MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD -> true
             else -> null
         }
     }
 
-    fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean {
-        val stopYear = entry.stopYear() ?: return false
-        val entryStop = YearMonth.of(stopYear, entry.stopMonth() ?: 12)
-        return history.any { other ->
-            if (other === entry || other.startYear == null) return@any false
-            if (!YearMonth.of(other.startYear!!, other.startMonth ?: 1).isAfter(entryStop)) return@any false
-            val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, entry.stopMonth(), other.startYear!!, other.startMonth)
-            minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
-        }
+    fun isWithinPDInferenceGap(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
+        val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, stopMonth, nextStartYear, nextStartMonth)
+        return minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -7,9 +7,9 @@ import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEn
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentResponse
 import java.time.YearMonth
 
-object ProgressiveDiseaseFunctions {
+private const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26 // half year
 
-    private const val MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD = 26L // half year
+object ProgressiveDiseaseFunctions {
 
     fun treatmentResultedInPD(treatment: TreatmentHistoryEntry, treatmentHistory: List<TreatmentHistoryEntry> = emptyList()): Boolean? {
         val bestResponse = treatment.treatmentHistoryDetails?.bestResponse
@@ -22,7 +22,10 @@ object ProgressiveDiseaseFunctions {
     fun treatmentStoppedDueToPD(treatment: TreatmentHistoryEntry, treatmentHistory: List<TreatmentHistoryEntry> = emptyList()): Boolean? {
         val stopReason = treatment.treatmentHistoryDetails?.stopReason
         val treatmentDuration = DateComparison.minWeeksBetweenDates(
-            treatment.startYear, treatment.startMonth, treatment.stopYear(), treatment.stopMonth()
+            treatment.startYear,
+            treatment.startMonth,
+            treatment.stopYear(),
+            treatment.stopMonth()
         )
         return when {
             stopReason == StopReason.PROGRESSIVE_DISEASE -> true
@@ -44,7 +47,7 @@ object ProgressiveDiseaseFunctions {
             others.mapNotNull { other -> other.startYear?.let { year -> other to year } }.any { (other, otherStartYear) ->
                 val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
                 when {
-                    otherStart.isAfter(entryStop) -> gapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
+                    otherStart.isAfter(entryStop) -> treatmentGapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
                     entryStartYear != null && otherStart.isAfter(YearMonth.of(entryStartYear, entry.startMonth ?: 12)) -> {
                         val otherStopYear = other.stopYear()
                         otherStopYear == null || YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
@@ -62,7 +65,7 @@ object ProgressiveDiseaseFunctions {
         }
     }
 
-    private fun gapSuggestsPD(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
+    private fun treatmentGapSuggestsPD(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
         val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, stopMonth, nextStartYear, nextStartMonth)
         return minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
     }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -30,36 +30,33 @@ object ProgressiveDiseaseFunctions {
         return when {
             stopReason == StopReason.PROGRESSIVE_DISEASE -> true
             stopReason != null -> false
-            hasSubsequentTreatmentLine(treatment, treatmentHistory) == true -> true
+            subsequentTreatmentLineSuggestsPD(treatment, treatmentHistory) == true -> true
             treatmentDuration != null && treatmentDuration > MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD -> true
             else -> null
         }
     }
 
-    private fun hasSubsequentTreatmentLine(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
+    private fun subsequentTreatmentLineSuggestsPD(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
         val stopYear = entry.stopYear()
         val stopMonth = entry.stopMonth()
-        val entryStartYear = entry.startYear
+        val startYear = entry.startYear
         val others = history.filter { it !== entry && it.allTreatments().any(Treatment::isSystemic) }
 
-        val hasSubsequent = if (stopYear == null) null else {
+        val subsequentLineSuggestsPD = if (stopYear == null) null else {
             val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
             others.mapNotNull { other -> other.startYear?.let { year -> other to year } }.any { (other, otherStartYear) ->
                 val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
                 when {
                     otherStart.isAfter(entryStop) -> treatmentGapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
-                    entryStartYear != null && otherStart.isAfter(YearMonth.of(entryStartYear, entry.startMonth ?: 12)) -> {
-                        val otherStopYear = other.stopYear()
-                        otherStopYear == null || YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
-                    }
-                    else -> false
+                    startYear != null && !otherStart.isAfter(YearMonth.of(startYear, entry.startMonth ?: 12)) -> false
+                    else -> treatmentOverlapSuggestsPD(entryStop, other)
                 }
             }
         }
 
         return when {
-            hasSubsequent == true -> true
-            hasSubsequent == null -> null
+            subsequentLineSuggestsPD == true -> true
+            subsequentLineSuggestsPD == null -> null
             others.any { it.startYear == null } -> null
             else -> false
         }
@@ -68,5 +65,10 @@ object ProgressiveDiseaseFunctions {
     private fun treatmentGapSuggestsPD(stopYear: Int, stopMonth: Int?, nextStartYear: Int, nextStartMonth: Int?): Boolean {
         val minGapWeeks = DateComparison.minWeeksBetweenDates(stopYear, stopMonth, nextStartYear, nextStartMonth)
         return minGapWeeks != null && minGapWeeks < MIN_WEEKS_TO_ASSUME_STOP_DUE_TO_PD
+    }
+
+    private fun treatmentOverlapSuggestsPD(entryStop: YearMonth, other: TreatmentHistoryEntry): Boolean {
+        val otherStopYear = other.stopYear()
+        return otherStopYear == null || YearMonth.of(otherStopYear, other.stopMonth() ?: 1).isAfter(entryStop)
     }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctions.kt
@@ -42,16 +42,28 @@ object ProgressiveDiseaseFunctions {
         val startYear = entry.startYear
         val others = history.filter { it !== entry && it.allTreatments().any(Treatment::isSystemic) }
 
-        val subsequentLineSuggestsPD = if (stopYear == null) null else {
-            val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
-            others.mapNotNull { other -> other.startYear?.let { year -> other to year } }.any { (other, otherStartYear) ->
-                val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
-                when {
-                    otherStart.isAfter(entryStop) -> treatmentGapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
-                    startYear != null && !otherStart.isAfter(YearMonth.of(startYear, entry.startMonth ?: 12)) -> false
-                    else -> treatmentOverlapSuggestsPD(entryStop, other)
+        val subsequentLineSuggestsPD = when {
+            stopYear != null -> {
+                val entryStop = YearMonth.of(stopYear, stopMonth ?: 12)
+                others.mapNotNull { other -> other.startYear?.let { year -> other to year } }.any { (other, otherStartYear) ->
+                    val otherStart = YearMonth.of(otherStartYear, other.startMonth ?: 1)
+                    when {
+                        otherStart.isAfter(entryStop) -> treatmentGapSuggestsPD(stopYear, stopMonth, otherStartYear, other.startMonth)
+                        startYear == null || !otherStart.isAfter(YearMonth.of(startYear, entry.startMonth ?: 12)) -> false
+                        else -> treatmentOverlapSuggestsPD(entryStop, other)
+                    }
                 }
             }
+
+            startYear != null -> {
+                val entryStart = YearMonth.of(startYear, entry.startMonth ?: 1)
+                others.mapNotNull { other -> other.startYear?.let { year -> other to year } }
+                    .any { (other, otherStartYear) ->
+                        YearMonth.of(otherStartYear, other.startMonth ?: 1).isAfter(entryStart) && other.stopYear() == null
+                    }
+            }
+
+            else -> null
         }
 
         return when {

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -1,6 +1,5 @@
 package com.hartwig.actin.clinical.interpretation
 
-import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentResultedInPD
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentStoppedDueToPD
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
@@ -114,45 +113,6 @@ class ProgressiveDiseaseFunctionsTest {
         val entry = treatmentHistoryEntryWithDates(StopReason.TOXICITY, null, STOP_MONTH_INSUFFICIENT_DURATION)
         assertThat(treatmentResultedInPD(entry, hasSubsequentLine = true)).isFalse()
         assertThat(treatmentStoppedDueToPD(entry, hasSubsequentLine = true)).isFalse()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return true when another entry starts shortly after this entry stops`() {
-        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
-        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
-            setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = STOP_YEAR,
-            startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequentEntry))).isTrue()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return false when gap to next line is too long`() {
-        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
-        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
-            setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = STOP_YEAR + 1,
-            startMonth = 1
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequentEntry))).isFalse()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return false when no other entry exists`() {
-        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry))).isFalse()
-    }
-
-    @Test
-    fun `hasSubsequentTreatmentLine should return false when entry has no stop date`() {
-        val entry = treatmentHistoryEntry(null, null)
-        val otherEntry = TreatmentTestFactory.treatmentHistoryEntry(
-            setOf(TreatmentTestFactory.treatment("next treatment", true)),
-            startYear = STOP_YEAR,
-            startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
-        )
-        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, otherEntry))).isFalse()
     }
 
     private fun treatmentHistoryEntry(stopReason: StopReason?, bestResponse: TreatmentResponse?): TreatmentHistoryEntry {

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -1,5 +1,6 @@
 package com.hartwig.actin.clinical.interpretation
 
+import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.hasSubsequentTreatmentLine
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentResultedInPD
 import com.hartwig.actin.clinical.interpretation.ProgressiveDiseaseFunctions.treatmentStoppedDueToPD
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
@@ -29,42 +30,42 @@ class ProgressiveDiseaseFunctionsTest {
 
     @Test
     fun `Should return true when stop reason is PD and best response is null and duration null`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, null))).isTrue()
         }
     }
 
     @Test
     fun `Should return true when stop reason is null and duration was sufficient`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION))).isTrue()
         }
     }
 
     @Test
     fun `Should return null when stop reason is null and duration was insufficient`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION))).isNull()
         }
     }
 
     @Test
     fun `Should return null when stop reason is null and best response is not PD`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntry(null, TreatmentResponse.MIXED))).isNull()
         }
     }
 
     @Test
     fun `Should return false when stop reason is not PD and best response is null`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntry(StopReason.TOXICITY, null))).isFalse()
         }
     }
 
     @Test
     fun `Should return true when stop reason is PD and best response is not PD`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, TreatmentResponse.MIXED))).isTrue()
         }
     }
@@ -81,14 +82,14 @@ class ProgressiveDiseaseFunctionsTest {
 
     @Test
     fun `Should return false when stop reason is not PD`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(function(treatmentHistoryEntry(StopReason.TOXICITY, TreatmentResponse.MIXED))).isFalse()
         }
     }
 
     @Test
     fun `Should return false when stop reason is not PD also if treatment duration was sufficient`() {
-        listOf(::treatmentResultedInPD, ::treatmentStoppedDueToPD).forEach { function ->
+        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
             assertThat(
                 function(
                     treatmentHistoryEntryWithDates(
@@ -99,6 +100,59 @@ class ProgressiveDiseaseFunctionsTest {
                 )
             ).isFalse()
         }
+    }
+
+    @Test
+    fun `Should return true when stop reason is null and has subsequent line`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        assertThat(treatmentResultedInPD(entry, hasSubsequentLine = true)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, hasSubsequentLine = true)).isTrue()
+    }
+
+    @Test
+    fun `Should not infer PD from subsequent line when stop reason is toxicity`() {
+        val entry = treatmentHistoryEntryWithDates(StopReason.TOXICITY, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        assertThat(treatmentResultedInPD(entry, hasSubsequentLine = true)).isFalse()
+        assertThat(treatmentStoppedDueToPD(entry, hasSubsequentLine = true)).isFalse()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return true when another entry starts shortly after this entry stops`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR,
+            startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequentEntry))).isTrue()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return false when gap to next line is too long`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR + 1,
+            startMonth = 1
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, subsequentEntry))).isFalse()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return false when no other entry exists`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry))).isFalse()
+    }
+
+    @Test
+    fun `hasSubsequentTreatmentLine should return false when entry has no stop date`() {
+        val entry = treatmentHistoryEntry(null, null)
+        val otherEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR,
+            startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        assertThat(hasSubsequentTreatmentLine(entry, listOf(entry, otherEntry))).isFalse()
     }
 
     private fun treatmentHistoryEntry(stopReason: StopReason?, bestResponse: TreatmentResponse?): TreatmentHistoryEntry {

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -23,50 +23,44 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
-    fun `treatmentStoppedDueToPD should return null when best response is PD but stop reason and duration are null`() {
+    fun `Should return null when stop reason is null and best response is PD and duration null`() {
         assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(null, TreatmentResponse.PROGRESSIVE_DISEASE))).isNull()
     }
 
     @Test
     fun `Should return true when stop reason is PD and best response is null and duration null`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, null))).isTrue()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, null))).isTrue()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, null))).isTrue()
     }
 
     @Test
     fun `Should return true when stop reason is null and duration was sufficient`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION))).isTrue()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION))).isTrue()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION))).isTrue()
     }
 
     @Test
     fun `Should return null when stop reason is null and duration was insufficient`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION))).isNull()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION))).isNull()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION))).isNull()
     }
 
     @Test
     fun `Should return null when stop reason is null and best response is not PD`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntry(null, TreatmentResponse.MIXED))).isNull()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntry(null, TreatmentResponse.MIXED))).isNull()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(null, TreatmentResponse.MIXED))).isNull()
     }
 
     @Test
     fun `Should return false when stop reason is not PD and best response is null`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntry(StopReason.TOXICITY, null))).isFalse()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntry(StopReason.TOXICITY, null))).isFalse()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(StopReason.TOXICITY, null))).isFalse()
     }
 
     @Test
     fun `Should return true when stop reason is PD and best response is not PD`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, TreatmentResponse.MIXED))).isTrue()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, TreatmentResponse.MIXED))).isTrue()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(StopReason.PROGRESSIVE_DISEASE, TreatmentResponse.MIXED))).isTrue()
     }
 
     @Test
@@ -81,24 +75,14 @@ class ProgressiveDiseaseFunctionsTest {
 
     @Test
     fun `Should return false when stop reason is not PD`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(function(treatmentHistoryEntry(StopReason.TOXICITY, TreatmentResponse.MIXED))).isFalse()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntry(StopReason.TOXICITY, TreatmentResponse.MIXED))).isFalse()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(StopReason.TOXICITY, TreatmentResponse.MIXED))).isFalse()
     }
 
     @Test
     fun `Should return false when stop reason is not PD also if treatment duration was sufficient`() {
-        listOf<(TreatmentHistoryEntry) -> Boolean?>({ treatmentResultedInPD(it) }, { treatmentStoppedDueToPD(it) }).forEach { function ->
-            assertThat(
-                function(
-                    treatmentHistoryEntryWithDates(
-                        StopReason.TOXICITY,
-                        TreatmentResponse.MIXED,
-                        STOP_MONTH_SUFFICIENT_DURATION
-                    )
-                )
-            ).isFalse()
-        }
+        assertThat(treatmentResultedInPD(treatmentHistoryEntryWithDates(StopReason.TOXICITY, TreatmentResponse.MIXED, STOP_MONTH_SUFFICIENT_DURATION))).isFalse()
+        assertThat(treatmentStoppedDueToPD(treatmentHistoryEntryWithDates(StopReason.TOXICITY, TreatmentResponse.MIXED, STOP_MONTH_SUFFICIENT_DURATION))).isFalse()
     }
 
     @Test
@@ -138,7 +122,7 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
-    fun `Should return null when treatment has no stop date`() {
+    fun `Should return null when treatment has no stop date and treatment gap can therefore not be determined`() {
         val entry = treatmentHistoryEntry(null, null)
         val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
             setOf(TreatmentTestFactory.treatment("next treatment", true)),
@@ -149,7 +133,7 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
-    fun `Should return true when another treatment started during and outlasted this treatment`() {
+    fun `Should return true when another treatment started during this treatment and outlasted it`() {
         val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION)
         val overlappingEntry = TreatmentTestFactory.treatmentHistoryEntry(
             setOf(TreatmentTestFactory.treatment("overlapping treatment", true)),

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -23,7 +23,7 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
-    fun `Should return null when stop reason is null and best response is PD and duration null`() {
+    fun `treatmentStoppedDueToPD should return null when best response is PD but stop reason and duration are null`() {
         assertThat(treatmentStoppedDueToPD(treatmentHistoryEntry(null, TreatmentResponse.PROGRESSIVE_DISEASE))).isNull()
     }
 
@@ -102,17 +102,63 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
-    fun `Should return true when stop reason is null and has subsequent line`() {
+    fun `Should return true when stop reason is null and subsequent line starts within 26 weeks`() {
         val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
-        assertThat(treatmentResultedInPD(entry, hasSubsequentLine = true)).isTrue()
-        assertThat(treatmentStoppedDueToPD(entry, hasSubsequentLine = true)).isTrue()
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        val history = listOf(entry, subsequentEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
     }
 
     @Test
     fun `Should not infer PD from subsequent line when stop reason is toxicity`() {
         val entry = treatmentHistoryEntryWithDates(StopReason.TOXICITY, null, STOP_MONTH_INSUFFICIENT_DURATION)
-        assertThat(treatmentResultedInPD(entry, hasSubsequentLine = true)).isFalse()
-        assertThat(treatmentStoppedDueToPD(entry, hasSubsequentLine = true)).isFalse()
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        val history = listOf(entry, subsequentEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isFalse()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isFalse()
+    }
+
+    @Test
+    fun `Should return null when stop reason is null and subsequent line starts more than 26 weeks later`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val distantEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR + 1, startMonth = 1
+        )
+        val history = listOf(entry, distantEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isNull()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isNull()
+    }
+
+    @Test
+    fun `Should return null when treatment has no stop date`() {
+        val entry = treatmentHistoryEntry(null, null)
+        val subsequentEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        assertThat(treatmentResultedInPD(entry, listOf(entry, subsequentEntry))).isNull()
+        assertThat(treatmentStoppedDueToPD(entry, listOf(entry, subsequentEntry))).isNull()
+    }
+
+    @Test
+    fun `Should return true when another treatment started during and outlasted this treatment`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION)
+        val overlappingEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("overlapping treatment", true)),
+            startYear = START_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION,
+            stopYear = STOP_YEAR + 1, stopMonth = 1
+        )
+        val history = listOf(entry, overlappingEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
     }
 
     private fun treatmentHistoryEntry(stopReason: StopReason?, bestResponse: TreatmentResponse?): TreatmentHistoryEntry {

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -134,7 +134,7 @@ class ProgressiveDiseaseFunctionsTest {
 
     @Test
     fun `Should return true when another treatment started during this treatment and outlasted it`() {
-        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_SUFFICIENT_DURATION)
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
         val overlappingEntry = TreatmentTestFactory.treatmentHistoryEntry(
             setOf(TreatmentTestFactory.treatment("overlapping treatment", true)),
             startYear = START_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION,
@@ -143,6 +143,58 @@ class ProgressiveDiseaseFunctionsTest {
         val history = listOf(entry, overlappingEntry)
         assertThat(treatmentResultedInPD(entry, history)).isTrue()
         assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
+    }
+
+    @Test
+    fun `Should not infer PD when overlapping treatment does not outlast entry`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val containedEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("contained treatment", true)),
+            startYear = START_YEAR, startMonth = START_MONTH + 1,
+            stopYear = STOP_YEAR, stopMonth = STOP_MONTH_INSUFFICIENT_DURATION - 1
+        )
+        val history = listOf(entry, containedEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isNull()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isNull()
+    }
+
+    @Test
+    fun `Should return true when overlapping treatment has no stop date and is presumed ongoing`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val ongoingEntry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("ongoing treatment", true)),
+            startYear = START_YEAR, startMonth = START_MONTH + 1
+        )
+        val history = listOf(entry, ongoingEntry)
+        assertThat(treatmentResultedInPD(entry, history)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
+    }
+
+    @Test
+    fun `Should return true when a confirmed subsequent line exists alongside another treatment with unknown start`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val confirmedSubsequent = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = STOP_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 2
+        )
+        val unknownStartTreatment = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("unknown timing treatment", true))
+        )
+        val history = listOf(entry, confirmedSubsequent, unknownStartTreatment)
+        assertThat(treatmentResultedInPD(entry, history)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
+    }
+
+    @Test
+    fun `Should not treat non-systemic treatments as subsequent lines`() {
+        val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
+        val nonSystemicSubsequent = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("non-systemic treatment", false)),
+            startYear = STOP_YEAR, startMonth = STOP_MONTH_INSUFFICIENT_DURATION + 1
+        )
+        val history = listOf(entry, nonSystemicSubsequent)
+        assertThat(treatmentResultedInPD(entry, history)).isNull()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isNull()
     }
 
     private fun treatmentHistoryEntry(stopReason: StopReason?, bestResponse: TreatmentResponse?): TreatmentHistoryEntry {

--- a/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/clinical/interpretation/ProgressiveDiseaseFunctionsTest.kt
@@ -133,6 +133,21 @@ class ProgressiveDiseaseFunctionsTest {
     }
 
     @Test
+    fun `Should return true when both treatments have no stop date and subsequent starts after entry`() {
+        val entry = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("test treatment", true)),
+            startYear = START_YEAR, startMonth = START_MONTH
+        )
+        val ongoingSubsequent = TreatmentTestFactory.treatmentHistoryEntry(
+            setOf(TreatmentTestFactory.treatment("next treatment", true)),
+            startYear = START_YEAR, startMonth = START_MONTH + 3
+        )
+        val history = listOf(entry, ongoingSubsequent)
+        assertThat(treatmentResultedInPD(entry, history)).isTrue()
+        assertThat(treatmentStoppedDueToPD(entry, history)).isTrue()
+    }
+
+    @Test
     fun `Should return true when another treatment started during this treatment and outlasted it`() {
         val entry = treatmentHistoryEntryWithDates(null, null, STOP_MONTH_INSUFFICIENT_DURATION)
         val overlappingEntry = TreatmentTestFactory.treatmentHistoryEntry(


### PR DESCRIPTION
…Reason not explicitly Tox or treatment pause of >6 months between treatment and subsequent line

This PR adds PD inference from treatment history.                                                                                                                                                                                                                                                                                                   When a treatment entry has no explicit stop reason, PD is inferred if any of the following hold:                                                                                                                                                                                                                                                                                                                                                                                       
- Stop reason is PD → confirmed PD _(existing logic)_                                                                                                                                                                                                                         
- Best response is PD (treatmentResultedInPD only) → confirmed PD _(existing logic)_                                                                                                                                                                                          
- Stop reason is non-null and not PD → confirmed **not** PD _(existing logic)_                                                                                                                                                                                                    
- Subsequent systemic line started within 26 weeks of this entry's stop → inferred PD                                                                                                                                                                      
- Another systemic treatment started during this entry and outlasted it → inferred PD
- Treatment duration exceeded 26 weeks → inferred PD _(existing logic)_                                                                                                                                                                                                         
- Otherwise → undetermined (null) _(existing logic)_                                                                                                                                                                                                                          

The 26-week threshold is the same for both the gap-to-next-line and the duration checks, and acts as "if the patient was on treatment long enough before switching or stopping, it was likely due to progression."                                                                                                                                                                                                                                                                                             Inference based on treatment gap is skipped (returns null) when the stop date is missing, since the gap to the next line cannot be computed