### PR TITLE
ACTIN-3867: Allow for DOID codes

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/priortumor/HasHistoryOfSecondMalignancyIgnoringDoidTerms.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/priortumor/HasHistoryOfSecondMalignancyIgnoringDoidTerms.kt
@@ -10,11 +10,10 @@ import com.hartwig.actin.doid.DoidModel
 import java.time.LocalDate
 
 class HasHistoryOfSecondMalignancyIgnoringDoidTerms(
-    private val doidModel: DoidModel, private val doidTermsToIgnore: List<String>, private val minDate: LocalDate?
+    private val doidModel: DoidModel, private val doidsToIgnore: Set<String>, private val minDate: LocalDate?
 ) : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val doidsToIgnore = doidTermsToIgnore.mapNotNull(doidModel::resolveDoidForTerm).toSet()
         val priorPrimaries = record.priorPrimaries
         val priorPrimariesByDate = groupByDate(priorPrimaries)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/priortumor/PreviousTumorRuleMapper.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/priortumor/PreviousTumorRuleMapper.kt
@@ -34,17 +34,17 @@ class PreviousTumorRuleMapper(resources: RuleMappingResources) : RuleMapper(reso
 
     private fun hasHistoryOfSecondMalignancyIgnoringSomeDoidsCreator(): FunctionCreator {
         return { function: EligibilityFunction ->
-            val doidTermsToIgnore = function.param<ManyDoidTermsParameter>(0).value
-            HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel(), doidTermsToIgnore, minDate = null)
+            val doidInputsToIgnore = function.param<ManyDoidTermsParameter>(0).value
+            val doidsToIgnore = doidInputsToIgnore.map { doidModel().toDoid(it) }.toSet()
+            HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel(), doidsToIgnore, minDate = null)
         }
     }
 
     private fun hasHistoryOfSecondMalignancyWithDoidTermCreator(): FunctionCreator {
         return { function: EligibilityFunction ->
-            val doidTermToMatch = function.param<DoidTermParameter>(0).value
-            val doidToMatch = doidModel().resolveDoidForTerm(doidTermToMatch)
-            doidToMatch?.let { HasHistoryOfSecondMalignancyWithDoid(doidModel(), it) }
-                ?: error("DOID term not found: $doidTermToMatch")
+            val doidInputToMatch = function.param<DoidTermParameter>(0).value
+            val doidToMatch = doidModel().toDoid(doidInputToMatch)
+            HasHistoryOfSecondMalignancyWithDoid(doidModel(), doidToMatch)
         }
     }
 
@@ -60,9 +60,10 @@ class PreviousTumorRuleMapper(resources: RuleMappingResources) : RuleMapper(reso
         return { function: EligibilityFunction ->
             function.expectTypes(Parameter.Type.INTEGER, Parameter.Type.MANY_DOID_TERMS)
             val maxYears = function.param<IntegerParameter>(0).value
-            val doidTermsToIgnore = function.param<ManyDoidTermsParameter>(1).value
+            val doidInputsToIgnore = function.param<ManyDoidTermsParameter>(1).value
+            val doidsToIgnore = doidInputsToIgnore.map { doidModel().toDoid(it) }.toSet()
             val minDate = referenceDateProvider().date().minusYears(maxYears.toLong())
-            HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel(), doidTermsToIgnore, minDate)
+            HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel(), doidsToIgnore, minDate)
         }
     }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/TumorRuleMapper.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/TumorRuleMapper.kt
@@ -129,18 +129,18 @@ class TumorRuleMapper(resources: RuleMappingResources) : RuleMapper(resources) {
 
     private fun hasPrimaryTumorBelongsToDoidTermsCreator(): FunctionCreator {
         return { function: EligibilityFunction ->
-            val doidTermToMatch = function.param<ManyDoidTermsParameter>(0).value
-            val doidTermsResolved = doidTermToMatch.mapNotNull { doidModel().resolveDoidForTerm(it) }.toSet()
-            PrimaryTumorLocationBelongsToDoid(doidModel(), cuppaToDoidMapping(), doidTermsResolved, null)
+            val doidInputToMatch = function.param<ManyDoidTermsParameter>(0).value
+            val doidsToMatch = doidInputToMatch.map { doidModel().toDoid(it) }.toSet()
+            PrimaryTumorLocationBelongsToDoid(doidModel(), cuppaToDoidMapping(), doidsToMatch, null)
         }
     }
 
     private fun hasPrimaryTumorBelongsToDoidTermsWithSubLocationCreator(): FunctionCreator {
         return { function: EligibilityFunction ->
-            val doidTermToMatch = function.param<ManyDoidTermsParameter>(0).value
-            val doidTermsResolved = doidTermToMatch.mapNotNull { doidModel().resolveDoidForTerm(it) }.toSet()
+            val doidInputToMatch = function.param<ManyDoidTermsParameter>(0).value
+            val doidsToMatch = doidInputToMatch.map { doidModel().toDoid(it) }.toSet()
             val subLocation = function.param<StringParameter>(1).value
-            PrimaryTumorLocationBelongsToDoid(doidModel(), cuppaToDoidMapping(), doidTermsResolved, subLocation)
+            PrimaryTumorLocationBelongsToDoid(doidModel(), cuppaToDoidMapping(), doidsToMatch, subLocation)
         }
     }
 

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/priortumor/HasHistoryOfSecondMalignancyIgnoringDoidTermsTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/priortumor/HasHistoryOfSecondMalignancyIgnoringDoidTermsTest.kt
@@ -18,8 +18,8 @@ class HasHistoryOfSecondMalignancyIgnoringDoidTermsTest {
         mapOf(ignoreDoid to parentDoid),
         mapOf(ignoreDoid to ignoreTerm, parentDoid to parentTerm),
     )
-    private val functionWithoutMinDate = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, listOf(ignoreTerm), minDate = null)
-    private val functionWithMinDate = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, listOf(ignoreTerm), minDate = minDate)
+    private val functionWithoutMinDate = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, setOf(ignoreDoid), minDate = null)
+    private val functionWithMinDate = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, setOf(ignoreDoid), minDate = minDate)
 
     @Test
     fun `Should fail when no prior tumors present`() {
@@ -35,7 +35,7 @@ class HasHistoryOfSecondMalignancyIgnoringDoidTermsTest {
     @Test
     fun `Should fail when prior tumors present in history but doid is child of doid to ignore`() {
         val priorTumors = listOf(PriorTumorTestFactory.priorPrimary(doid = ignoreDoid))
-        val function = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, listOf(parentTerm), minDate = null)
+        val function = HasHistoryOfSecondMalignancyIgnoringDoidTerms(doidModel, setOf(parentDoid), minDate = null)
         assertEvaluation(EvaluationResult.FAIL, function.evaluate(PriorTumorTestFactory.withPriorPrimaries(priorTumors)))
     }
 

--- a/common/src/main/kotlin/com/hartwig/actin/doid/DoidModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/doid/DoidModel.kt
@@ -36,6 +36,14 @@ data class DoidModel(
         return doidForLowerCaseTermMap[term.lowercase()]
     }
 
+    fun toDoid(input: String): String {
+        return when {
+            termForDoidMap.containsKey(input) -> input
+            doidForLowerCaseTermMap.containsKey(input.lowercase()) -> resolveDoidForTerm(input)!!
+            else -> throw IllegalStateException("DOID term(s) or code(s) not valid: $input")
+        }
+    }
+
     private tailrec fun expandedParentsDoidSet(doidsToExpand: Set<String>, expandedDoids: Set<String>, excludedDoids: Set<String>, mapping: Map<String, List<String>>): Set<String> {
         val remainingDoids = doidsToExpand - excludedDoids
         if (remainingDoids.isEmpty()) {

--- a/common/src/test/kotlin/com/hartwig/actin/doid/DoidModelTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/doid/DoidModelTest.kt
@@ -62,6 +62,13 @@ class DoidModelTest {
         assertThat(model.resolveDoidForTerm("tumor B")).isNull()
     }
 
+    @Test
+    fun `Should return doid`() {
+        val model = createTestModel(TestDoidManualConfigFactory.createMinimalTestDoidManualConfig())
+        assertThat(model.toDoid("tumor a")).isEqualTo("200")
+        assertThat(model.toDoid("200")).isEqualTo("200")
+    }
+
     private fun createTestModel(manualConfig: DoidManualConfig): DoidModel {
         val childToParentsMap = mapOf(
             "200" to listOf("300"),


### PR DESCRIPTION
Same as for ICD titles/code, since this merge (https://github.com/hartwigmedical/actin-trial/pull/238) we are now allowed to also input DOID codes instead of only terms during trial curation, we should correctly ingest this in algo. 