### PR TITLE
ACTIN-3975: Bug fix in HAS_HAD_TREATMENT_NAME_X_WITHIN_Y_WEEKS evaluation

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
@@ -16,38 +16,33 @@ object TreatmentVersusDateFunctions {
     ): Evaluation {
         val matchingTreatments = record.oncologicalHistory
             .mapNotNull { entry -> TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(entry, predicate) }
+        val matchingPortionOfMostRecentTreatment = record.oncologicalHistory.filter { it.startYear != null }
+            .maxWithOrNull(TreatmentHistoryEntryStartDateComparator())
+            ?.let { TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(it, predicate) }
+
 
         return when {
             matchingTreatments.any { treatmentSinceMinDate(it, minDate, false) } -> {
                 EvaluationFactory.pass("Treatment $predicateDescription administered since ${Format.date(minDate)}")
             }
 
-            matchingTreatments.any { treatmentSinceMinDate(it, minDate, true) } -> {
-                EvaluationFactory.undetermined(
-                    "Treatment $predicateDescription administered with unknown date hence " +
-                            "undetermined if administered since ${Format.date(minDate)}"
-                )
-            }
-
-            matchingTreatments.any { isMostRecentTreatmentWithoutStopDate(it, record.oncologicalHistory) == true } -> {
+            matchingPortionOfMostRecentTreatment?.let { stopDateCouldBeSinceMinDate(it, minDate) } == true -> {
                 EvaluationFactory.undetermined(
                     "Undetermined if treatment $predicateDescription may have been administered since " +
                             "${Format.date(minDate)} because it is the last treatment line and stop date missing"
                 )
             }
 
-            matchingTreatments.any { isMostRecentTreatmentWithoutStopDate(it, record.oncologicalHistory) == null } -> {
-                EvaluationFactory.undetermined(
-                    "Undetermined if treatment $predicateDescription may have been administered since " +
-                            "${Format.date(minDate)} because it is undetermined if treatment may be the last treatment line"
-                )
+            matchingTreatments.any { treatmentSinceMinDate(it, minDate, true) } -> {
+                EvaluationFactory.undetermined("Treatment $predicateDescription administered with unknown date hence " +
+                        "undetermined if administered since ${Format.date(minDate)}")
             }
 
             matchingTreatments.isNotEmpty() -> {
                 EvaluationFactory.fail("All treatments $predicateDescription administered before ${Format.date(minDate)}")
             }
 
-            else -> EvaluationFactory.fail("No treatments $predicateDescription in prior history")
+            else -> EvaluationFactory.fail("No treatments $predicateDescription in history")
         }
     }
 
@@ -66,14 +61,7 @@ object TreatmentVersusDateFunctions {
             ?: includeUnknown
     }
 
-    private fun isMostRecentTreatmentWithoutStopDate(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
-        val (historyWithoutDates, historyWithDates) = history.partition { it.startYear == null }
-        val mostRecentHistoryEntryWithDate = historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator())
-
-        return when {
-            historyWithoutDates.contains(entry) -> null
-            mostRecentHistoryEntryWithDate?.stopYear() != null -> false
-            else -> mostRecentHistoryEntryWithDate == entry
-        }
+    private fun stopDateCouldBeSinceMinDate(entry: TreatmentHistoryEntry, minDate: LocalDate): Boolean {
+        return DateComparison.isAfterDate(minDate, entry.stopYear(), entry.stopMonth()) != false
     }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
@@ -18,17 +18,44 @@ object TreatmentVersusDateFunctions {
             .mapNotNull { entry -> TreatmentHistoryEntryFunctions.portionOfTreatmentHistoryEntryMatchingPredicate(entry, predicate) }
 
         return when {
-            matchingTreatments.any { treatmentSinceMinDate(it, minDate, false) } ->
+            matchingTreatments.any { treatmentSinceMinDate(it, minDate, false) } -> {
                 EvaluationFactory.pass("Treatment $predicateDescription administered since ${Format.date(minDate)}")
+            }
 
-            matchingTreatments.any { treatmentSinceMinDate(it, minDate, true) } ->
-                EvaluationFactory.undetermined("Treatment $predicateDescription administered with unknown date")
+            matchingTreatments.any { treatmentSinceMinDate(it, minDate, true) } -> {
+                EvaluationFactory.undetermined("Treatment $predicateDescription administered with unknown date hence " +
+                        "undetermined if administered since ${Format.date(minDate)}")
+            }
 
-            matchingTreatments.isNotEmpty() ->
+            matchingTreatments.any {
+                isMostRecentTreatment(
+                    it,
+                    record.oncologicalHistory
+                ) == true
+            } -> {
+                EvaluationFactory.undetermined(
+                    "Undetermined if treatment $predicateDescription may have been administered since " +
+                            "${Format.date(minDate)} because it is the last treatment line and stop date missing"
+                )
+            }
+
+            matchingTreatments.any {
+                isMostRecentTreatment(
+                    it,
+                    record.oncologicalHistory
+                ) == null
+            } -> {
+                EvaluationFactory.undetermined(
+                    "Undetermined if treatment $predicateDescription may have been administered since " +
+                            "${Format.date(minDate)} because it is undetermined if treatment may be the last treatment line"
+                )
+            }
+
+            matchingTreatments.isNotEmpty() -> {
                 EvaluationFactory.fail("All treatments $predicateDescription administered before ${Format.date(minDate)}")
+            }
 
-            else ->
-                EvaluationFactory.fail("No treatments $predicateDescription in prior history")
+            else -> EvaluationFactory.fail("No treatments $predicateDescription in prior history")
         }
     }
 
@@ -45,5 +72,15 @@ object TreatmentVersusDateFunctions {
             maxDate, treatment.treatmentHistoryDetails?.stopYear, treatment.treatmentHistoryDetails?.stopMonth
         )
             ?: includeUnknown
+    }
+
+    private fun isMostRecentTreatment(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
+        val (historyWithoutDates, historyWithDates) = history.partition { it.startYear == null }
+
+        return if (historyWithoutDates.isNotEmpty() && historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator()) == entry) {
+            null
+        } else {
+            historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator()) == entry
+        }
     }
 }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctions.kt
@@ -23,28 +23,20 @@ object TreatmentVersusDateFunctions {
             }
 
             matchingTreatments.any { treatmentSinceMinDate(it, minDate, true) } -> {
-                EvaluationFactory.undetermined("Treatment $predicateDescription administered with unknown date hence " +
-                        "undetermined if administered since ${Format.date(minDate)}")
+                EvaluationFactory.undetermined(
+                    "Treatment $predicateDescription administered with unknown date hence " +
+                            "undetermined if administered since ${Format.date(minDate)}"
+                )
             }
 
-            matchingTreatments.any {
-                isMostRecentTreatment(
-                    it,
-                    record.oncologicalHistory
-                ) == true
-            } -> {
+            matchingTreatments.any { isMostRecentTreatmentWithoutStopDate(it, record.oncologicalHistory) == true } -> {
                 EvaluationFactory.undetermined(
                     "Undetermined if treatment $predicateDescription may have been administered since " +
                             "${Format.date(minDate)} because it is the last treatment line and stop date missing"
                 )
             }
 
-            matchingTreatments.any {
-                isMostRecentTreatment(
-                    it,
-                    record.oncologicalHistory
-                ) == null
-            } -> {
+            matchingTreatments.any { isMostRecentTreatmentWithoutStopDate(it, record.oncologicalHistory) == null } -> {
                 EvaluationFactory.undetermined(
                     "Undetermined if treatment $predicateDescription may have been administered since " +
                             "${Format.date(minDate)} because it is undetermined if treatment may be the last treatment line"
@@ -74,13 +66,14 @@ object TreatmentVersusDateFunctions {
             ?: includeUnknown
     }
 
-    private fun isMostRecentTreatment(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
+    private fun isMostRecentTreatmentWithoutStopDate(entry: TreatmentHistoryEntry, history: List<TreatmentHistoryEntry>): Boolean? {
         val (historyWithoutDates, historyWithDates) = history.partition { it.startYear == null }
+        val mostRecentHistoryEntryWithDate = historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator())
 
-        return if (historyWithoutDates.isNotEmpty() && historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator()) == entry) {
-            null
-        } else {
-            historyWithDates.maxWithOrNull(TreatmentHistoryEntryStartDateComparator()) == entry
+        return when {
+            historyWithoutDates.contains(entry) -> null
+            mostRecentHistoryEntryWithDate?.stopYear() != null -> false
+            else -> mostRecentHistoryEntryWithDate == entry
         }
     }
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
@@ -7,8 +7,25 @@ import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatment
 import com.hartwig.actin.datamodel.clinical.TreatmentTestFactory.treatmentHistoryEntry
 import com.hartwig.actin.datamodel.clinical.treatment.history.TreatmentHistoryEntry
+import org.assertj.core.api.Assertions.assertThat
 import java.time.LocalDate
 import org.junit.jupiter.api.Test
+
+private const val YEARS_TO_SUBTRACT = 3
+
+private val NOW = LocalDate.now()
+private val TARGET_DATE = NOW.minusYears(1)
+private val RECENT_DATE = TARGET_DATE.plusYears(1)
+private val OLDER_DATE = TARGET_DATE.minusYears(1)
+private val NON_MATCHING_RECENT_TREATMENT = treatmentHistoryEntry(
+    setOf(treatment("other", false)), startYear = RECENT_DATE.year, startMonth = RECENT_DATE.monthValue
+)
+private val NON_MATCHING_OLDER_TREATMENT = treatmentHistoryEntry(
+    setOf(treatment("other", false)), startYear = OLDER_DATE.year, startMonth = OLDER_DATE.monthValue
+)
+private val NON_MATCHING_TREATMENT_NO_DATE = treatmentHistoryEntry(
+    setOf(treatment("other", false)), startYear = null, startMonth = null
+)
 
 abstract class TreatmentVersusDateFunctionsTestAbstract {
 
@@ -19,72 +36,98 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     ): TreatmentHistoryEntry
 
     @Test
-    fun shouldFailWhenTreatmentNotFound() {
+    fun `Should fail when treatment not found`() {
         assertEvaluation(
             EvaluationResult.FAIL,
-            function().evaluate(TreatmentTestFactory.withTreatmentHistory(listOf(NON_MATCHING_TREATMENT)))
+            function().evaluate(TreatmentTestFactory.withTreatmentHistory(listOf(NON_MATCHING_RECENT_TREATMENT)))
         )
     }
 
     @Test
-    fun shouldFailWhenMatchingTreatmentIsOlderByYear() {
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, olderTreatment())
+    fun `Should fail when matching treatment is older by year`() {
+        val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment())
         assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun shouldFailWhenMatchingTreatmentIsOlderByMonth() {
+    fun `Should fail when matching treatment is older by month`() {
         val olderDate = TARGET_DATE.minusMonths(1)
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, matchingTreatment(olderDate.year, olderDate.monthValue))
+        val treatmentHistory = listOf(
+            NON_MATCHING_RECENT_TREATMENT,
+            matchingTreatment(startYear = olderDate.year - 1, stopYear = olderDate.year, stopMonth = olderDate.monthValue)
+        )
         assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun shouldPassWhenTreatmentHistoryIncludesMatchingTreatmentWithinRange() {
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, olderTreatment(), matchingTreatment(RECENT_DATE.year, RECENT_DATE.monthValue))
+    fun `Should pass when treatment history includes matching treatment within range`() {
+        val treatmentHistory =
+            listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment(), matchingTreatment(RECENT_DATE.year, RECENT_DATE.monthValue))
         assertEvaluation(EvaluationResult.PASS, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun shouldReturnUndeterminedWhenMatchingTreatmentHasUnknownYear() {
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, olderTreatment(), matchingTreatment(null, 10))
+    fun `Should be undetermined when matching treatment has unknown stop year`() {
+        val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment(), matchingTreatment(null, 10))
         assertEvaluation(EvaluationResult.UNDETERMINED, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun shouldReturnUndeterminedWhenMatchingTreatmentMatchesYearWithUnknownMonth() {
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, matchingTreatment(TARGET_DATE.year, null))
+    fun `Should be undetermined when matching treatment matches year with unknown month`() {
+        val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingTreatment(TARGET_DATE.year, null))
         assertEvaluation(EvaluationResult.UNDETERMINED, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun shouldFailWhenPriorTreatmentHasUnknownStopDateButOlderStartDate() {
-        val olderDate = NOW.minusYears(YEARS_TO_SUBTRACT.toLong())
-        val treatmentHistory = listOf(NON_MATCHING_TREATMENT, matchingTreatment(null, null, olderDate.year, olderDate.monthValue))
-        assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
-    }
-
-    @Test
-    fun shouldPassWhenPriorTreatmentHasUnknownStopDateButStartDateInRange() {
+    fun `Should pass when prior treatment has unknown stop date but start date within range`() {
         val treatmentHistory = listOf(
-            NON_MATCHING_TREATMENT,
+            NON_MATCHING_RECENT_TREATMENT,
             matchingTreatment(NOW.minusYears(YEARS_TO_SUBTRACT.toLong()).year, null),
             matchingTreatment(NOW.year, null, RECENT_DATE.year, RECENT_DATE.monthValue)
         )
         assertEvaluation(EvaluationResult.PASS, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
+    @Test
+    fun `Should fail when prior treatment has unknown stop date and older start date and not most recent treatment line`() {
+        val olderDate = NOW.minusYears(YEARS_TO_SUBTRACT.toLong())
+        val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingTreatment(null, null, olderDate.year, olderDate.monthValue))
+        assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
+    }
+
+    @Test
+    fun `Should be undetermined when prior treatment has unknown stop date and older start date and but is most recent line`() {
+        val treatmentHistory = listOf(
+            NON_MATCHING_OLDER_TREATMENT,
+            matchingTreatment(startYear = OLDER_DATE.year, startMonth = OLDER_DATE.monthValue + 1, stopYear = null, stopMonth = null)
+        )
+        val evaluation = function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory))
+        assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly(
+            "Undetermined if treatment matching 'Treatment' may have been " +
+                    "administered since 07-Aug-2025 because it is the last treatment line and stop date missing"
+        )
+    }
+
+    @Test
+    fun `Should be undetermined when matching treatment is most recent line but there are treatments with unknown date`() {
+        val treatmentHistory = listOf(
+            NON_MATCHING_TREATMENT_NO_DATE,
+            matchingTreatment(startYear = OLDER_DATE.year, startMonth = OLDER_DATE.monthValue + 1, stopYear = null, stopMonth = null)
+        )
+        val evaluation = function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory))
+        assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
+        assertThat(evaluation.undeterminedMessagesStrings()).containsExactly(
+            "Undetermined if treatment matching 'Treatment' may have been administered since 07-Aug-2025 because it is undetermined if " +
+                    "treatment may be the last treatment line"
+        )
+    }
+
     private fun function() = functionForDate(TARGET_DATE)
 
-    private fun olderTreatment() = matchingTreatment(NOW.minusYears(YEARS_TO_SUBTRACT.toLong()).year, null)
-
-    companion object {
-        private val NOW = LocalDate.now()
-        private val TARGET_DATE = NOW.minusYears(1)
-        private val RECENT_DATE = NOW.minusMonths(4)
-        private val NON_MATCHING_TREATMENT = treatmentHistoryEntry(
-            setOf(treatment("other", false)), startYear = NOW.year, startMonth = NOW.monthValue
-        )
-        private const val YEARS_TO_SUBTRACT = 3
-    }
+    private fun matchingOlderTreatment() = matchingTreatment(
+        startYear = NOW.minusYears((YEARS_TO_SUBTRACT + 1).toLong()).year,
+        stopYear = NOW.minusYears(YEARS_TO_SUBTRACT.toLong()).year,
+        stopMonth = null
+    )
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 
 private const val YEARS_TO_SUBTRACT = 3
 
-private val NOW = LocalDate.now()
-private val TARGET_DATE = NOW.minusYears(1)
+private val CURRENT_DATE = LocalDate.of(2025, 6, 1)
+private val TARGET_DATE = CURRENT_DATE.minusYears(1)
 private val RECENT_DATE = TARGET_DATE.plusYears(1)
 private val OLDER_DATE = TARGET_DATE.minusYears(1)
 private val NON_MATCHING_RECENT_TREATMENT = treatmentHistoryEntry(
@@ -45,7 +45,7 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
 
     @Test
     fun `Should fail when matching treatment is older by year`() {
-        val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment())
+        val treatmentHistory = listOf(matchingOlderTreatment())
         assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
@@ -67,7 +67,7 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     }
 
     @Test
-    fun `Should be undetermined when matching treatment has unknown stop year`() {
+    fun `Should be undetermined when matching treatment has unknown start and stop year`() {
         val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment(), matchingTreatment(null, 10))
         assertEvaluation(EvaluationResult.UNDETERMINED, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
@@ -82,21 +82,33 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     fun `Should pass when prior treatment has unknown stop date but start date within range`() {
         val treatmentHistory = listOf(
             NON_MATCHING_RECENT_TREATMENT,
-            matchingTreatment(NOW.minusYears(YEARS_TO_SUBTRACT.toLong()).year, null),
-            matchingTreatment(NOW.year, null, RECENT_DATE.year, RECENT_DATE.monthValue)
+            matchingTreatment(CURRENT_DATE.year, CURRENT_DATE.monthValue, RECENT_DATE.year, RECENT_DATE.monthValue)
         )
         assertEvaluation(EvaluationResult.PASS, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
     fun `Should fail when prior treatment has unknown stop date and older start date and not most recent treatment line`() {
-        val olderDate = NOW.minusYears(YEARS_TO_SUBTRACT.toLong())
+        val olderDate = CURRENT_DATE.minusYears(YEARS_TO_SUBTRACT.toLong())
         val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingTreatment(null, null, olderDate.year, olderDate.monthValue))
         assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
-    fun `Should be undetermined when prior treatment has unknown stop date and older start date and but is most recent line`() {
+    fun `Should fail when matching treatment is most recent line but stop date known and before min date`() {
+        val treatmentHistory = listOf(
+            matchingTreatment(
+                startYear = OLDER_DATE.minusYears(1).year,
+                startMonth = OLDER_DATE.monthValue,
+                stopYear = OLDER_DATE.year,
+                stopMonth = OLDER_DATE.monthValue
+            )
+        )
+        assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
+    }
+
+    @Test
+    fun `Should be undetermined when matching treatment has unknown stop date and older start date but is most recent line`() {
         val treatmentHistory = listOf(
             NON_MATCHING_OLDER_TREATMENT,
             matchingTreatment(startYear = OLDER_DATE.year, startMonth = OLDER_DATE.monthValue + 1, stopYear = null, stopMonth = null)
@@ -105,7 +117,7 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
         assertThat(evaluation.undeterminedMessagesStrings()).containsExactly(
             "Undetermined if treatment matching 'Treatment' may have been " +
-                    "administered since 07-Aug-2025 because it is the last treatment line and stop date missing"
+                    "administered since 01-Jun-2024 because it is the last treatment line and stop date missing"
         )
     }
 
@@ -118,16 +130,16 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
         val evaluation = function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory))
         assertEvaluation(EvaluationResult.UNDETERMINED, evaluation)
         assertThat(evaluation.undeterminedMessagesStrings()).containsExactly(
-            "Undetermined if treatment matching 'Treatment' may have been administered since 07-Aug-2025 because it is undetermined if " +
-                    "treatment may be the last treatment line"
+            "Undetermined if treatment matching 'Treatment' may have been " +
+                    "administered since 01-Jun-2024 because it is the last treatment line and stop date missing"
         )
     }
 
     private fun function() = functionForDate(TARGET_DATE)
 
     private fun matchingOlderTreatment() = matchingTreatment(
-        startYear = NOW.minusYears((YEARS_TO_SUBTRACT + 1).toLong()).year,
-        stopYear = NOW.minusYears(YEARS_TO_SUBTRACT.toLong()).year,
+        startYear = CURRENT_DATE.minusYears((YEARS_TO_SUBTRACT + 1).toLong()).year,
+        stopYear = CURRENT_DATE.minusYears(YEARS_TO_SUBTRACT.toLong()).year,
         stopMonth = null
     )
 }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
@@ -98,7 +98,7 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     fun `Should pass when prior treatment has unknown stop date but start date within range`() {
         val treatmentHistory = listOf(
             NON_MATCHING_RECENT_TREATMENT,
-            matchingTreatment(REFERENCE_DATE.year, REFERENCE_DATE.monthValue, RECENT_DATE.year, RECENT_DATE.monthValue)
+            matchingTreatment(startYear = RECENT_DATE.year, startMonth = RECENT_DATE.monthValue, stopYear = null, stopMonth = null)
         )
         assertEvaluation(EvaluationResult.PASS, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/treatment/TreatmentVersusDateFunctionsTestAbstract.kt
@@ -13,8 +13,8 @@ import org.junit.jupiter.api.Test
 
 private const val YEARS_TO_SUBTRACT = 3
 
-private val CURRENT_DATE = LocalDate.of(2025, 6, 1)
-private val TARGET_DATE = CURRENT_DATE.minusYears(1)
+private val REFERENCE_DATE = LocalDate.of(2025, 6, 1)
+private val TARGET_DATE = REFERENCE_DATE.minusYears(1)
 private val RECENT_DATE = TARGET_DATE.plusYears(1)
 private val OLDER_DATE = TARGET_DATE.minusYears(1)
 private val NON_MATCHING_RECENT_TREATMENT = treatmentHistoryEntry(
@@ -60,6 +60,22 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     }
 
     @Test
+    fun `Should fail when matching treatment has unknown start date and known stop date before min date`() {
+        val treatmentHistory = listOf(matchingTreatment(stopYear = OLDER_DATE.year, stopMonth = OLDER_DATE.monthValue))
+        assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
+    }
+
+    @Test
+    fun `Should be undetermined when most recent line stops in min date year with unknown stop month`() {
+        val treatmentHistory = listOf(
+            matchingTreatment(
+                stopYear = TARGET_DATE.year, stopMonth = null, startYear = OLDER_DATE.year, startMonth = OLDER_DATE.monthValue
+            )
+        )
+        assertEvaluation(EvaluationResult.UNDETERMINED, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
+    }
+
+    @Test
     fun `Should pass when treatment history includes matching treatment within range`() {
         val treatmentHistory =
             listOf(NON_MATCHING_RECENT_TREATMENT, matchingOlderTreatment(), matchingTreatment(RECENT_DATE.year, RECENT_DATE.monthValue))
@@ -82,14 +98,14 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     fun `Should pass when prior treatment has unknown stop date but start date within range`() {
         val treatmentHistory = listOf(
             NON_MATCHING_RECENT_TREATMENT,
-            matchingTreatment(CURRENT_DATE.year, CURRENT_DATE.monthValue, RECENT_DATE.year, RECENT_DATE.monthValue)
+            matchingTreatment(REFERENCE_DATE.year, REFERENCE_DATE.monthValue, RECENT_DATE.year, RECENT_DATE.monthValue)
         )
         assertEvaluation(EvaluationResult.PASS, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
 
     @Test
     fun `Should fail when prior treatment has unknown stop date and older start date and not most recent treatment line`() {
-        val olderDate = CURRENT_DATE.minusYears(YEARS_TO_SUBTRACT.toLong())
+        val olderDate = REFERENCE_DATE.minusYears(YEARS_TO_SUBTRACT.toLong())
         val treatmentHistory = listOf(NON_MATCHING_RECENT_TREATMENT, matchingTreatment(null, null, olderDate.year, olderDate.monthValue))
         assertEvaluation(EvaluationResult.FAIL, function().evaluate(TreatmentTestFactory.withTreatmentHistory(treatmentHistory)))
     }
@@ -138,8 +154,8 @@ abstract class TreatmentVersusDateFunctionsTestAbstract {
     private fun function() = functionForDate(TARGET_DATE)
 
     private fun matchingOlderTreatment() = matchingTreatment(
-        startYear = CURRENT_DATE.minusYears((YEARS_TO_SUBTRACT + 1).toLong()).year,
-        stopYear = CURRENT_DATE.minusYears(YEARS_TO_SUBTRACT.toLong()).year,
+        startYear = REFERENCE_DATE.minusYears((YEARS_TO_SUBTRACT + 1).toLong()).year,
+        stopYear = REFERENCE_DATE.minusYears(YEARS_TO_SUBTRACT.toLong()).year,
         stopMonth = null
     )
 }


### PR DESCRIPTION
We saw a case where the treatment of interest is administered in the last line (without stop date), but we confidently evaluate that the treatment would have been stopped X weeks ago, which I believe is wrong.

FYI as I understand:
- If there is a stop date, the case was handled in treatmentSinceMinDate by evaluating stop date directly.
- If there is a start date, the case is handled in treatmentSinceMinDate - by evaluating if start date occurred after min date (then you are sure).
- If stop date and start date unknown, the case is implemented in treatmentSinceMinDate too.

However, the case if there is a start date, but the start date occurred _before_ min date, _but_ the treatment is the last treatment line is not handled. This is added in this PR.

Of note: I think this case is still not handled perfectly if we look for a treatment of many weeks ago, and we may want to look back multiple treatment lines (then you would actually want to derive a max stop date from the treatment occurring after the treatment of interest). But this requiring some more substantial refactoring I believe. We use this rule for HAS_HAD_TREATMENT_NAME_X_WITHIN_Y_WEEKS so only a number of weeks, hence we won’t need to look back across multiple lines I expect, so out of scope for now?
