### PR TITLE
ACTIN-3988: Create IhcTestItemConstants

### DIFF
--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/IhcTestItemConstants.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/IhcTestItemConstants.kt
@@ -1,0 +1,10 @@
+package com.hartwig.actin.algo.evaluation
+
+object IhcTestItemConstants {
+
+    const val SCC_TRANSFORMATION_TERM = "SCC transformation"
+
+    const val MMR_TERM = "MMR"
+
+    val SMALL_CELL_TRANSFORMATION_TERMS = setOf("SCLC transformation", "small cell transformation")
+}

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/IsMmrDeficient.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/IsMmrDeficient.kt
@@ -3,6 +3,7 @@ package com.hartwig.actin.algo.evaluation.molecular
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.IhcTestEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
@@ -16,7 +17,7 @@ import java.time.LocalDate
 class IsMmrDeficient: EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val mmrIhcTestEvaluation = IhcTestEvaluation.create("MMR", record.ihcTests)
+        val mmrIhcTestEvaluation = IhcTestEvaluation.create(IhcTestItemConstants.MMR_TERM, record.ihcTests)
         val isMmrDeficientIhcResult = isMmrDeficientIhc(mmrIhcTestEvaluation)
         val isMmrProficientIhcResult = isMmrProficientIhc(mmrIhcTestEvaluation)
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/MmrStatusIsAvailable.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/molecular/MmrStatusIsAvailable.kt
@@ -3,13 +3,14 @@ package com.hartwig.actin.algo.evaluation.molecular
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.IhcTestEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 
 class MmrStatusIsAvailable : EvaluationFunction {
 
     override fun evaluate(record: PatientRecord): Evaluation {
-        val ihcResultAvailable = IhcTestEvaluation.create("MMR", record.ihcTests).filteredTests.isNotEmpty()
+        val ihcResultAvailable = IhcTestEvaluation.create(IhcTestItemConstants.MMR_TERM, record.ihcTests).filteredTests.isNotEmpty()
         val molecularResultAvailable = record.molecularTests.any { it.characteristics.microsatelliteStability != null }
 
         return if (ihcResultAvailable || molecularResultAvailable) {

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasCancerWithSmallCellComponent.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasCancerWithSmallCellComponent.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.algo.doid.DoidConstants
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.IhcTestEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.doid.DoidModel
@@ -16,18 +17,19 @@ class HasCancerWithSmallCellComponent(private val doidModel: DoidModel) : Evalua
             return EvaluationFactory.undetermined("Undetermined if tumor may have small cell component")
         }
         val isNsclc = DoidEvaluationFunctions.isOfDoidType(doidModel, record.tumor.doids, DoidConstants.LUNG_NON_SMALL_CELL_CARCINOMA_DOID)
-        val ihcTestEvaluation = IhcTestEvaluation.create(item = "SCLC transformation", ihcTests = record.ihcTests)
+        val ihcTestEvaluations =
+            IhcTestItemConstants.SMALL_CELL_TRANSFORMATION_TERMS.map { IhcTestEvaluation.create(it, record.ihcTests) }
 
         return when {
             TumorEvaluationFunctions.hasTumorWithSmallCellComponent(doidModel, tumorDoids, record.tumor.name) -> {
                 EvaluationFactory.pass("Has cancer with small cell component")
             }
 
-            isNsclc && ihcTestEvaluation.hasCertainBroadPositiveResultsForItem() -> {
+            isNsclc && ihcTestEvaluations.any(IhcTestEvaluation::hasCertainBroadPositiveResultsForItem) -> {
                 EvaluationFactory.warn("Has potentially cancer with small cell component (positive SCLC transformation)")
             }
 
-            isNsclc && ihcTestEvaluation.hasPossiblePositiveResultsForItem() -> {
+            isNsclc && ihcTestEvaluations.any(IhcTestEvaluation::hasPossiblePositiveResultsForItem) -> {
                 EvaluationFactory.warn("Has potentially cancer with small cell component (possible SCLC transformation)")
             }
 

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownSclcTransformation.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasKnownSclcTransformation.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.algo.doid.DoidConstants
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.IhcTestEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.algo.evaluation.molecular.MolecularRuleEvaluator
 import com.hartwig.actin.algo.evaluation.util.Format
 import com.hartwig.actin.datamodel.PatientRecord
@@ -25,7 +26,7 @@ class HasKnownSclcTransformation(private val doidModel: DoidModel) : EvaluationF
             TumorEvaluationFunctions.hasTumorWithSmallCellComponent(doidModel, record.tumor.doids, record.tumor.name)
 
         val ihcTestEvaluations =
-            listOf("SCLC transformation", "small cell transformation").map { IhcTestEvaluation.create(it, record.ihcTests) }
+            IhcTestItemConstants.SMALL_CELL_TRANSFORMATION_TERMS.map { IhcTestEvaluation.create(it, record.ihcTests) }
 
         val indicativeGenes = setOf("TP53", "RB1")
         val allIndicativeGenesInactivated = indicativeGenes.all { MolecularRuleEvaluator.geneIsInactivatedForPatient(it, record) }

--- a/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasNonSquamousNsclc.kt
+++ b/algo/src/main/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasNonSquamousNsclc.kt
@@ -4,6 +4,7 @@ import com.hartwig.actin.algo.doid.DoidConstants
 import com.hartwig.actin.algo.evaluation.EvaluationFactory
 import com.hartwig.actin.algo.evaluation.EvaluationFunction
 import com.hartwig.actin.algo.evaluation.IhcTestEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.datamodel.PatientRecord
 import com.hartwig.actin.datamodel.algo.Evaluation
 import com.hartwig.actin.doid.DoidModel
@@ -30,7 +31,7 @@ class HasNonSquamousNsclc(private val doidModel: DoidModel) : EvaluationFunction
         val isExactLungCarcinoma = DoidEvaluationFunctions.isOfExactDoid(tumorDoids, DoidConstants.LUNG_CARCINOMA_DOID)
         val isExactLungCancer = DoidEvaluationFunctions.isOfExactDoid(tumorDoids, DoidConstants.LUNG_CANCER_DOID)
 
-        val ihcTestEvaluation = IhcTestEvaluation.create(item = "SCC transformation", ihcTests = record.ihcTests)
+        val ihcTestEvaluation = IhcTestEvaluation.create(item = IhcTestItemConstants.SCC_TRANSFORMATION_TERM, ihcTests = record.ihcTests)
 
         return when {
             isSquamousNsclc -> EvaluationFactory.fail("Has no non-squamous NSCLC")

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/IsMmrDeficientTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/molecular/IsMmrDeficientTest.kt
@@ -1,6 +1,7 @@
 package com.hartwig.actin.algo.evaluation.molecular
 
 import com.hartwig.actin.algo.evaluation.EvaluationAssert.assertMolecularEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.molecular.driver.CopyNumberType
@@ -13,6 +14,8 @@ import com.hartwig.actin.datamodel.molecular.driver.Variant
 import com.hartwig.actin.molecular.util.GeneConstants
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+
+private const val MMR_TERM = IhcTestItemConstants.MMR_TERM
 
 class IsMmrDeficientTest {
 
@@ -146,7 +149,7 @@ class IsMmrDeficientTest {
 
     @Test
     fun `Should pass with IHC MMR deficient test result`() {
-        val result = function.evaluate(MolecularTestFactory.withIhcTests(MolecularTestFactory.ihcTest("MMR", scoreText = "Deficient")))
+        val result = function.evaluate(MolecularTestFactory.withIhcTests(MolecularTestFactory.ihcTest(MMR_TERM, scoreText = "Deficient")))
 
         assertMolecularEvaluation(EvaluationResult.PASS, result)
         assertThat(result.passMessagesStrings()).containsExactly("dMMR by IHC")
@@ -156,7 +159,7 @@ class IsMmrDeficientTest {
     fun `Should fail with IHC MMR proficient test result`() {
         assertMolecularEvaluation(
             EvaluationResult.FAIL,
-            function.evaluate(MolecularTestFactory.withIhcTests(MolecularTestFactory.ihcTest("MMR", scoreText = "Proficient")))
+            function.evaluate(MolecularTestFactory.withIhcTests(MolecularTestFactory.ihcTest(MMR_TERM, scoreText = "Proficient")))
         )
     }
 
@@ -181,7 +184,7 @@ class IsMmrDeficientTest {
             MolecularTestFactory.withOnlyIhcTests(
                 listOf(
                     MolecularTestFactory.ihcTest(
-                        "MMR",
+                        MMR_TERM,
                         scoreText = "Proficient",
                         impliesIndeterminate = true
                     )
@@ -200,7 +203,7 @@ class IsMmrDeficientTest {
                 MolecularTestFactory.withIhcTestsMicrosatelliteStabilityAndVariant(
                     listOf(
                         MolecularTestFactory.ihcTest(
-                            "MMR",
+                            MMR_TERM,
                             scoreText = "Proficient"
                         )
                     ), true, msiVariant(isReportable = true, isBiallelic = true)
@@ -217,7 +220,7 @@ class IsMmrDeficientTest {
                 MolecularTestFactory.withIhcTestsMicrosatelliteStabilityAndVariant(
                     listOf(
                         MolecularTestFactory.ihcTest(
-                            "MMR",
+                            MMR_TERM,
                             scoreText = "Deficient"
                         )
                     ), false, msiVariant(isReportable = true)
@@ -240,7 +243,7 @@ class IsMmrDeficientTest {
             EvaluationResult.PASS,
             function.evaluate(
                 TestPatientFactory.createEmptyMolecularTestPatientRecord()
-                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest("MMR", scoreText = "Deficient")))
+                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest(MMR_TERM, scoreText = "Deficient")))
             )
         )
     }
@@ -251,7 +254,7 @@ class IsMmrDeficientTest {
             EvaluationResult.FAIL,
             function.evaluate(
                 TestPatientFactory.createEmptyMolecularTestPatientRecord()
-                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest("MMR", scoreText = "Proficient")))
+                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest(MMR_TERM, scoreText = "Proficient")))
             )
         )
     }
@@ -262,7 +265,7 @@ class IsMmrDeficientTest {
             EvaluationResult.UNDETERMINED,
             function.evaluate(
                 TestPatientFactory.createEmptyMolecularTestPatientRecord()
-                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest("MMR", scoreText = "Proficient", impliesIndeterminate = true)))
+                    .copy(ihcTests = listOf(MolecularTestFactory.ihcTest(MMR_TERM, scoreText = "Proficient", impliesIndeterminate = true)))
             )
         )
     }

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasNonSquamousNsclcTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/tumor/HasNonSquamousNsclcTest.kt
@@ -2,6 +2,7 @@ package com.hartwig.actin.algo.evaluation.tumor
 
 import com.hartwig.actin.algo.doid.DoidConstants
 import com.hartwig.actin.algo.evaluation.EvaluationAssert.assertEvaluation
+import com.hartwig.actin.algo.evaluation.IhcTestItemConstants
 import com.hartwig.actin.datamodel.TestPatientFactory
 import com.hartwig.actin.datamodel.algo.EvaluationResult
 import com.hartwig.actin.datamodel.clinical.IhcTest
@@ -43,7 +44,7 @@ class HasNonSquamousNsclcTest {
     fun `Should return warn when known non-squamous NSCLC type but possible SCC transformation`() {
         val evaluation = function.evaluate(
             TumorTestFactory.withIhcTestsAndDoids(
-                listOf(IhcTest(item = "SCC transformation", scoreText = "Possible")),
+                listOf(IhcTest(item = IhcTestItemConstants.SCC_TRANSFORMATION_TERM, scoreText = "Possible")),
                 setOf(DoidConstants.LUNG_ADENOCARCINOMA_DOID)
             )
         )
@@ -55,7 +56,7 @@ class HasNonSquamousNsclcTest {
     fun `Should return warn when known non-squamous NSCLC type but certain SCC transformation`() {
         val evaluation = function.evaluate(
             TumorTestFactory.withIhcTestsAndDoids(
-                listOf(IhcTest(item = "SCC transformation", scoreText = "Positive")),
+                listOf(IhcTest(item = IhcTestItemConstants.SCC_TRANSFORMATION_TERM, scoreText = "Positive")),
                 setOf(DoidConstants.LUNG_ADENOCARCINOMA_DOID)
             )
         )


### PR DESCRIPTION
Added because of the SCLC terms, since they were different in `HasKnownSclcTransformation` and `HasCancerWithSmallCellComponent`