### PR TITLE
ACTIN-3929: Restrict ICD code slot assignment (main vs extension)

### DIFF
--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/comorbidity/HasHadComorbidityWithIcdCodeTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/comorbidity/HasHadComorbidityWithIcdCodeTest.kt
@@ -21,8 +21,10 @@ private const val diseaseDescription = "parent disease"
 
 class HasHadComorbidityWithIcdCodeTest {
     private val targetIcdCodes = IcdConstants.RESPIRATORY_COMPROMISE_SET.map { IcdCode(it) }.toSet()
-    private val icdModel =
-        TestIcdFactory.createModelWithSpecificNodes(listOf("child", "otherTarget", "childParent", "extension", parentCode))
+    private val icdModel = TestIcdFactory.createModelWithSpecificNodes(
+        mainNodePrefixes = listOf("child", "otherTarget", "childParent", parentCode),
+        extensionNodePrefixes = listOf("extension")
+    )
     private val referenceDate = LocalDate.of(2024, 12, 6)
     private val minimalPatient = TestPatientFactory.createMinimalTestWGSPatientRecord()
     private val conditionWithTargetCode = ComorbidityTestFactory.otherCondition(name = OTHER_CONDITION_NAME, icdMainCode = parentCode)

--- a/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceWithSpecificIcdTitleTest.kt
+++ b/algo/src/test/kotlin/com/hartwig/actin/algo/evaluation/toxicity/HasIntoleranceWithSpecificIcdTitleTest.kt
@@ -10,8 +10,10 @@ import org.junit.jupiter.api.Test
 class HasIntoleranceWithSpecificIcdTitleTest {
 
     private val targetIcdTitle = "targetParentTitle&targetExtensionParentTitle"
-    private val icdModel =
-        TestIcdFactory.createModelWithSpecificNodes(listOf("target", "targetParent", "targetExtension", "targetExtensionParent"))
+    private val icdModel = TestIcdFactory.createModelWithSpecificNodes(
+        mainNodePrefixes = listOf("target", "targetParent"),
+        extensionNodePrefixes = listOf("targetExtension", "targetExtensionParent")
+    )
     private val targetIcdCode = icdModel.resolveCodeForTitle(targetIcdTitle)!!
     private val childCode = icdModel.resolveCodeForTitle("targetTitle&targetExtensionTitle")!!
     private val function = HasIntoleranceWithSpecificIcdTitle(icdModel, targetIcdTitle)

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -63,10 +63,10 @@ class IcdModel(
             else -> invalidMainTitleReason(slots.first) ?: slots.second?.let(::invalidExtensionTitleReason)
         }
 
-    fun invalidMainTitleReason(mainTitle: String): String? =
+    private fun invalidMainTitleReason(mainTitle: String): String? =
         unknownOrMisplacedTitleReason(mainTitle, mainTitleToCodeMap, extensionTitleToCodeMap, EXTENSION_SLOT, MAIN_SLOT)
 
-    fun invalidExtensionTitleReason(extensionTitle: String): String? =
+    private fun invalidExtensionTitleReason(extensionTitle: String): String? =
         unknownOrMisplacedTitleReason(extensionTitle, extensionTitleToCodeMap, mainTitleToCodeMap, MAIN_SLOT, EXTENSION_SLOT)
 
     private fun unknownOrMisplacedTitleReason(
@@ -79,7 +79,7 @@ class IcdModel(
         when (title.lowercase()) {
             in expectedSlotTitles -> null
             in otherSlotTitles -> "ICD title [$title] is $otherSlot and cannot be used as $expectedSlot"
-            else -> "ICD title [$title] is not known - check for existence in ICD model"
+            else -> "ICD title [$title] is not known. Check for existence in ICD model"
         }
 
     private fun malformedTitleReason(icdTitle: String): String =

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -23,6 +23,10 @@ class IcdModel(
     val mainTitleToCodeMap = titleToCodeMapForSlot(extensionSlot = false)
     val extensionTitleToCodeMap = titleToCodeMapForSlot(extensionSlot = true)
 
+    private fun titleToCodeMapForSlot(extensionSlot: Boolean): Map<String, String> =
+        codeToNodeMap.values.filter { it.isExtension == extensionSlot }
+            .associate { it.title.lowercase() to it.code }
+
     fun isMainCode(code: String): Boolean = codeToNodeMap[code]?.isExtension == false
 
     fun isExtensionCode(code: String): Boolean = codeToNodeMap[code]?.isExtension == true
@@ -32,24 +36,52 @@ class IcdModel(
     fun isValidIcdCode(icdCode: String): Boolean = resolveCodeForCodeString(icdCode) != null
 
     fun resolveCodeForTitle(icdTitle: String): IcdCode? {
-        val (mainTitle, extensionTitle) = splitSlots(icdTitle) ?: return null
-        val mainCode = mainTitleToCodeMap[mainTitle.lowercase()] ?: return null
-        val extensionCode = extensionTitle?.let { extensionTitleToCodeMap[it.lowercase()] ?: return null }
+        val slots = splitSlots(icdTitle)
+        val mainCode = slots?.first?.let { mainTitleToCodeMap[it.lowercase()] }
+        val extensionCode = slots?.second?.let { extensionTitleToCodeMap[it.lowercase()] }
 
-        return IcdCode(mainCode, extensionCode)
+        return if (slots != null && mainCode != null) IcdCode(mainCode, extensionCode) else null
     }
 
-    fun invalidTitleReason(icdTitle: String): String? {
-        val (mainTitle, extensionTitle) = splitSlots(icdTitle) ?: return malformedTitleReason(icdTitle)
-
-        return invalidMainTitleReason(mainTitle) ?: extensionTitle?.let(::invalidExtensionTitleReason)
+    private fun splitSlots(input: String): Pair<String, String?>? {
+        val slots = input.split(SLOT_SEPARATOR).map(String::trim)
+        return slots.takeIf { it.size in 1..2 && it.first().isNotEmpty() }
+            ?.let { it.first() to it.getOrNull(1)?.ifEmpty { null } }
     }
 
-    fun invalidMainTitleReason(mainTitle: String): String? =
+    private fun resolveCodeForCodeString(code: String): IcdCode? {
+        val (mainCode, extensionCode) = splitSlots(code) ?: return null
+        val slotsAreValid = isMainCode(mainCode) && (extensionCode == null || isExtensionCode(extensionCode))
+
+        return IcdCode(mainCode, extensionCode).takeIf { slotsAreValid }
+    }
+
+    fun invalidTitleReason(icdTitle: String): String =
+        splitSlots(icdTitle)?.let { (mainTitle, extensionTitle) ->
+            invalidMainTitleReason(mainTitle) ?: extensionTitle?.let(::invalidExtensionTitleReason)
+        } ?: malformedTitleReason(icdTitle)
+
+    private fun invalidMainTitleReason(mainTitle: String): String? =
         unknownOrMisplacedTitleReason(mainTitle, mainTitleToCodeMap, extensionTitleToCodeMap, EXTENSION_SLOT, MAIN_SLOT)
 
-    fun invalidExtensionTitleReason(extensionTitle: String): String? =
+    private fun invalidExtensionTitleReason(extensionTitle: String): String? =
         unknownOrMisplacedTitleReason(extensionTitle, extensionTitleToCodeMap, mainTitleToCodeMap, MAIN_SLOT, EXTENSION_SLOT)
+
+    private fun unknownOrMisplacedTitleReason(
+        title: String,
+        expectedSlotTitles: Map<String, String>,
+        otherSlotTitles: Map<String, String>,
+        otherSlot: String,
+        expectedSlot: String
+    ): String? =
+        when (title.lowercase()) {
+            in expectedSlotTitles -> null
+            in otherSlotTitles -> "ICD title [$title] is $otherSlot and cannot be used as $expectedSlot"
+            else -> "ICD title [$title] is not known - check for existence in ICD model"
+        }
+
+    private fun malformedTitleReason(icdTitle: String): String =
+        "ICD title [$icdTitle] must be a single main title, optionally followed by '$SLOT_SEPARATOR' and one extension title"
 
     fun resolveTitleForCodeString(code: String): String {
         val icdCode = resolveCodeForCodeString(code) ?: throw IllegalStateException("Invalid ICD code: $code")
@@ -92,7 +124,7 @@ class IcdModel(
         )
     }
 
-    fun <T: Comorbidity> findInstancesMatchingAnyExtensionCode(instances: List<T>, targetExtensionCodes: Set<String>): List<Comorbidity> {
+    fun <T : Comorbidity> findInstancesMatchingAnyExtensionCode(instances: List<T>, targetExtensionCodes: Set<String>): List<Comorbidity> {
         return instances.filter { entity ->
             entity.icdCodes.any { codeWithAllParents(it.extensionCode).any(targetExtensionCodes::contains) }
         }
@@ -107,35 +139,6 @@ class IcdModel(
         }.toSet()
     }
 
-    private fun titleToCodeMapForSlot(extensionSlot: Boolean): Map<String, String> =
-        codeToNodeMap.values.filter { it.isExtension == extensionSlot }
-            .associate { it.title.lowercase() to it.code }
-
-    private fun resolveCodeForCodeString(code: String): IcdCode? {
-        val (mainCode, extensionCode) = splitSlots(code) ?: return null
-        val slotsAreValid = isMainCode(mainCode) && (extensionCode == null || isExtensionCode(extensionCode))
-
-        return IcdCode(mainCode, extensionCode).takeIf { slotsAreValid }
-    }
-
-    private fun malformedTitleReason(icdTitle: String): String =
-        "ICD title [$icdTitle] must be a single main title, optionally followed by '$SLOT_SEPARATOR' and one extension title"
-
-    private fun unknownOrMisplacedTitleReason(
-        title: String,
-        expectedSlotTitles: Map<String, String>,
-        otherSlotTitles: Map<String, String>,
-        otherSlot: String,
-        expectedSlot: String
-    ): String? {
-        val lookupTitle = title.lowercase()
-        return when {
-            lookupTitle in expectedSlotTitles -> null
-            lookupTitle in otherSlotTitles -> "ICD title [$title] is $otherSlot and cannot be used as $expectedSlot"
-            else -> "ICD title [$title] is not known - check for existence in ICD model"
-        }
-    }
-
     companion object {
         fun create(nodes: List<IcdNode>): IcdModel {
             return IcdModel(createCodeToNodeMap(nodes), createTitleToCodeMap(nodes))
@@ -145,10 +148,4 @@ class IcdModel(
         private fun createTitleToCodeMap(icdNodes: List<IcdNode>): Map<String, String> =
             icdNodes.associate { it.title.lowercase() to it.code }
     }
-}
-
-private fun splitSlots(input: String): Pair<String, String?>? {
-    val slots = input.split(SLOT_SEPARATOR).map(String::trim)
-    return slots.takeIf { it.size in 1..2 && it.first().isNotEmpty() }
-        ?.let { it.first() to it.getOrNull(1)?.ifEmpty { null } }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -5,6 +5,10 @@ import com.hartwig.actin.datamodel.clinical.IcdCode
 import com.hartwig.actin.icd.datamodel.IcdMatches
 import com.hartwig.actin.icd.datamodel.IcdNode
 
+private const val SLOT_SEPARATOR = '&'
+private const val MAIN_SLOT = "a main title"
+private const val EXTENSION_SLOT = "an extension title"
+
 private enum class IcdMatchCategory {
     FULL_MATCH,
     MATCH_WITH_UNKNOWN_EXTENSION,
@@ -16,30 +20,40 @@ class IcdModel(
     val titleToCodeMap: Map<String, String>
 ) {
 
-    fun isValidIcdTitle(icdTitle: String): Boolean {
-        val titles = icdTitle.split('&')
-        return titles.size in 1..2 && titles.map(String::lowercase).all(titleToCodeMap::containsKey)
-    }
+    val mainTitleToCodeMap = titleToCodeMapForSlot(extensionSlot = false)
+    val extensionTitleToCodeMap = titleToCodeMapForSlot(extensionSlot = true)
 
-    fun isValidIcdCode(icdCode: String): Boolean {
-        val codes = icdCode.split('&')
-        return codes.size in 1..2 && codes.all(codeToNodeMap::containsKey)
-    }
+    fun isMainCode(code: String): Boolean = codeToNodeMap[code]?.isExtension == false
+
+    fun isExtensionCode(code: String): Boolean = codeToNodeMap[code]?.isExtension == true
+
+    fun isValidIcdTitle(icdTitle: String): Boolean = resolveCodeForTitle(icdTitle) != null
+
+    fun isValidIcdCode(icdCode: String): Boolean = resolveCodeForCodeString(icdCode) != null
 
     fun resolveCodeForTitle(icdTitle: String): IcdCode? {
-        val split = icdTitle.lowercase().split('&')
-        return titleToCodeMap[split[0]]?.let { mainCode ->
-            split.takeIf { it.size == 2 }?.get(1)?.trim()?.ifEmpty { null }?.let { extensionTitle ->
-                titleToCodeMap[extensionTitle]?.let { IcdCode(mainCode, it) } ?: return null
-            } ?: IcdCode(mainCode, null)
-        }
+        val (mainTitle, extensionTitle) = splitSlots(icdTitle) ?: return null
+        val mainCode = mainTitleToCodeMap[mainTitle.lowercase()] ?: return null
+        val extensionCode = extensionTitle?.let { extensionTitleToCodeMap[it.lowercase()] ?: return null }
+
+        return IcdCode(mainCode, extensionCode)
     }
 
+    fun invalidTitleReason(icdTitle: String): String? {
+        val (mainTitle, extensionTitle) = splitSlots(icdTitle) ?: return malformedTitleReason(icdTitle)
+
+        return invalidMainTitleReason(mainTitle) ?: extensionTitle?.let(::invalidExtensionTitleReason)
+    }
+
+    fun invalidMainTitleReason(mainTitle: String): String? =
+        unknownOrMisplacedTitleReason(mainTitle, mainTitleToCodeMap, extensionTitleToCodeMap, EXTENSION_SLOT, MAIN_SLOT)
+
+    fun invalidExtensionTitleReason(extensionTitle: String): String? =
+        unknownOrMisplacedTitleReason(extensionTitle, extensionTitleToCodeMap, mainTitleToCodeMap, MAIN_SLOT, EXTENSION_SLOT)
+
     fun resolveTitleForCodeString(code: String): String {
-        if (!isValidIcdCode(code)) {
-            throw IllegalStateException("Invalid ICD code: $code")
-        }
-        return resolveTitleForCode(code.split('&').let { IcdCode(it[0], it.getOrNull(1)) }, displayWithSpaces = false)
+        val icdCode = resolveCodeForCodeString(code) ?: throw IllegalStateException("Invalid ICD code: $code")
+        return resolveTitleForCode(icdCode, displayWithSpaces = false)
     }
 
     fun codeWithAllParents(code: String?): List<String> {
@@ -93,6 +107,35 @@ class IcdModel(
         }.toSet()
     }
 
+    private fun titleToCodeMapForSlot(extensionSlot: Boolean): Map<String, String> =
+        codeToNodeMap.values.filter { it.isExtension == extensionSlot }
+            .associate { it.title.lowercase() to it.code }
+
+    private fun resolveCodeForCodeString(code: String): IcdCode? {
+        val (mainCode, extensionCode) = splitSlots(code) ?: return null
+        val slotsAreValid = isMainCode(mainCode) && (extensionCode == null || isExtensionCode(extensionCode))
+
+        return IcdCode(mainCode, extensionCode).takeIf { slotsAreValid }
+    }
+
+    private fun malformedTitleReason(icdTitle: String): String =
+        "ICD title [$icdTitle] must be a single main title, optionally followed by '$SLOT_SEPARATOR' and one extension title"
+
+    private fun unknownOrMisplacedTitleReason(
+        title: String,
+        expectedSlotTitles: Map<String, String>,
+        otherSlotTitles: Map<String, String>,
+        otherSlot: String,
+        expectedSlot: String
+    ): String? {
+        val lookupTitle = title.lowercase()
+        return when {
+            lookupTitle in expectedSlotTitles -> null
+            lookupTitle in otherSlotTitles -> "ICD title [$title] is $otherSlot and cannot be used as $expectedSlot"
+            else -> "ICD title [$title] is not known - check for existence in ICD model"
+        }
+    }
+
     companion object {
         fun create(nodes: List<IcdNode>): IcdModel {
             return IcdModel(createCodeToNodeMap(nodes), createTitleToCodeMap(nodes))
@@ -102,4 +145,10 @@ class IcdModel(
         private fun createTitleToCodeMap(icdNodes: List<IcdNode>): Map<String, String> =
             icdNodes.associate { it.title.lowercase() to it.code }
     }
+}
+
+private fun splitSlots(input: String): Pair<String, String?>? {
+    val slots = input.split(SLOT_SEPARATOR).map(String::trim)
+    return slots.takeIf { it.size in 1..2 && it.first().isNotEmpty() }
+        ?.let { it.first() to it.getOrNull(1)?.ifEmpty { null } }
 }

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -35,13 +35,14 @@ class IcdModel(
 
     fun isValidIcdCode(icdCode: String): Boolean = resolveCodeForCodeString(icdCode) != null
 
-    fun resolveCodeForTitle(icdTitle: String): IcdCode? {
-        val slots = splitSlots(icdTitle)
-        val mainCode = slots?.first?.let { mainTitleToCodeMap[it.lowercase()] }
-        val extensionCode = slots?.second?.let { extensionTitleToCodeMap[it.lowercase()] }
+    fun resolveCodeForTitle(icdTitle: String): IcdCode? =
+        splitSlots(icdTitle)?.let { (mainTitle, extensionTitle) ->
+            val mainCode = mainTitleToCodeMap[mainTitle.lowercase()]
+            val extensionCode = extensionTitle?.let { extensionTitleToCodeMap[it.lowercase()] }
+            val slotsAreValid = mainCode != null && (extensionTitle == null || extensionCode != null)
 
-        return if (slots != null && mainCode != null) IcdCode(mainCode, extensionCode) else null
-    }
+            if (slotsAreValid) IcdCode(mainCode, extensionCode) else null
+        }
 
     private fun splitSlots(input: String): Pair<String, String?>? {
         val slots = input.split(SLOT_SEPARATOR).map(String::trim)
@@ -56,10 +57,11 @@ class IcdModel(
         return IcdCode(mainCode, extensionCode).takeIf { slotsAreValid }
     }
 
-    fun invalidTitleReason(icdTitle: String): String =
-        splitSlots(icdTitle)?.let { (mainTitle, extensionTitle) ->
-            invalidMainTitleReason(mainTitle) ?: extensionTitle?.let(::invalidExtensionTitleReason)
-        } ?: malformedTitleReason(icdTitle)
+    fun invalidTitleReason(icdTitle: String): String? =
+        when (val slots = splitSlots(icdTitle)) {
+            null -> malformedTitleReason(icdTitle)
+            else -> invalidMainTitleReason(slots.first) ?: slots.second?.let(::invalidExtensionTitleReason)
+        }
 
     private fun invalidMainTitleReason(mainTitle: String): String? =
         unknownOrMisplacedTitleReason(mainTitle, mainTitleToCodeMap, extensionTitleToCodeMap, EXTENSION_SLOT, MAIN_SLOT)

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -124,7 +124,7 @@ class IcdModel(
         )
     }
 
-    fun <T : Comorbidity> findInstancesMatchingAnyExtensionCode(instances: List<T>, targetExtensionCodes: Set<String>): List<Comorbidity> {
+    fun <T: Comorbidity> findInstancesMatchingAnyExtensionCode(instances: List<T>, targetExtensionCodes: Set<String>): List<Comorbidity> {
         return instances.filter { entity ->
             entity.icdCodes.any { codeWithAllParents(it.extensionCode).any(targetExtensionCodes::contains) }
         }

--- a/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/IcdModel.kt
@@ -63,10 +63,10 @@ class IcdModel(
             else -> invalidMainTitleReason(slots.first) ?: slots.second?.let(::invalidExtensionTitleReason)
         }
 
-    private fun invalidMainTitleReason(mainTitle: String): String? =
+    fun invalidMainTitleReason(mainTitle: String): String? =
         unknownOrMisplacedTitleReason(mainTitle, mainTitleToCodeMap, extensionTitleToCodeMap, EXTENSION_SLOT, MAIN_SLOT)
 
-    private fun invalidExtensionTitleReason(extensionTitle: String): String? =
+    fun invalidExtensionTitleReason(extensionTitle: String): String? =
         unknownOrMisplacedTitleReason(extensionTitle, extensionTitleToCodeMap, mainTitleToCodeMap, MAIN_SLOT, EXTENSION_SLOT)
 
     private fun unknownOrMisplacedTitleReason(

--- a/common/src/main/kotlin/com/hartwig/actin/icd/datamodel/IcdNode.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/datamodel/IcdNode.kt
@@ -1,3 +1,3 @@
 package com.hartwig.actin.icd.datamodel
 
-data class IcdNode(val code: String, val parentTreeCodes: List<String>, val title: String)
+data class IcdNode(val code: String, val parentTreeCodes: List<String>, val title: String, val isExtension: Boolean = false)

--- a/common/src/main/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializer.kt
+++ b/common/src/main/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializer.kt
@@ -36,7 +36,8 @@ object IcdDeserializer {
             val icdNode = IcdNode(
                 code = code,
                 parentTreeCodes = updatedParents,
-                title = trimTitle(node)
+                title = trimTitle(node),
+                isExtension = true
             )
 
             Pair(result + icdNode, currentParents)

--- a/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
@@ -6,6 +6,7 @@ import com.hartwig.actin.datamodel.clinical.Intolerance
 import com.hartwig.actin.datamodel.clinical.OtherCondition
 import com.hartwig.actin.datamodel.clinical.Toxicity
 import com.hartwig.actin.datamodel.clinical.ToxicitySource
+import com.hartwig.actin.icd.datamodel.IcdNode
 import java.time.LocalDate
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatIllegalStateException
@@ -14,8 +15,10 @@ import org.junit.jupiter.api.Test
 class IcdModelTest {
 
     private val date = LocalDate.of(2024, 12, 1)
-    private val icdModel =
-        TestIcdFactory.createModelWithSpecificNodes(listOf("targetMain", "targetExtension", "targetMainParent", "targetExtensionParent"))
+    private val icdModel = TestIcdFactory.createModelWithSpecificNodes(
+        mainNodePrefixes = listOf("targetMain", "targetMainParent"),
+        extensionNodePrefixes = listOf("targetExtension", "targetExtensionParent")
+    )
     private val correctMainCode = "targetMainParentCode"
     private val childOfCorrectMainCode = "targetMainCode"
     private val correctExtensionCode = "targetExtensionParentCode"
@@ -49,12 +52,74 @@ class IcdModelTest {
     @Test
     fun `Should handle title validation correctly for regular and extended titles`() {
         assertThat(icdModel.isValidIcdTitle("targetMainTitle")).isTrue()
-        assertThat(icdModel.isValidIcdTitle("targetExtensionTitle")).isTrue()
         assertThat(icdModel.isValidIcdTitle("targetMainTitle&targetExtensionTitle")).isTrue()
         assertThat(icdModel.isValidIcdTitle("targetMainTitle|targetExtensionTitle")).isFalse()
         assertThat(icdModel.isValidIcdTitle("invalidTitle")).isFalse()
         assertThat(icdModel.isValidIcdTitle("targetMainTitle&invalidTitle")).isFalse()
         assertThat(icdModel.isValidIcdTitle("targetMainTitle&targetExtensionTitle&targetExtensionParentTitle")).isFalse()
+    }
+
+    @Test
+    fun `Should reject extension title used as main title`() {
+        assertThat(icdModel.isValidIcdTitle("targetExtensionTitle")).isFalse()
+        assertThat(icdModel.resolveCodeForTitle("targetExtensionTitle")).isNull()
+        assertThat(icdModel.invalidTitleReason("targetExtensionTitle"))
+            .isEqualTo("ICD title [targetExtensionTitle] is an extension title and cannot be used as a main title")
+    }
+
+    @Test
+    fun `Should reject main title used as extension title`() {
+        assertThat(icdModel.isValidIcdTitle("targetMainTitle&targetMainParentTitle")).isFalse()
+        assertThat(icdModel.resolveCodeForTitle("targetMainTitle&targetMainParentTitle")).isNull()
+        assertThat(icdModel.invalidTitleReason("targetMainTitle&targetMainParentTitle"))
+            .isEqualTo("ICD title [targetMainParentTitle] is a main title and cannot be used as an extension title")
+    }
+
+    @Test
+    fun `Should reject codes assigned to the wrong slot`() {
+        assertThat(icdModel.isValidIcdCode("targetExtensionCode")).isFalse()
+        assertThat(icdModel.isValidIcdCode("targetMainCode&targetMainParentCode")).isFalse()
+    }
+
+    @Test
+    fun `Should identify main and extension codes`() {
+        assertThat(icdModel.isMainCode("targetMainCode")).isTrue()
+        assertThat(icdModel.isMainCode("targetExtensionCode")).isFalse()
+        assertThat(icdModel.isExtensionCode("targetExtensionCode")).isTrue()
+        assertThat(icdModel.isExtensionCode("targetMainCode")).isFalse()
+        assertThat(icdModel.isMainCode("unknownCode")).isFalse()
+        assertThat(icdModel.isExtensionCode("unknownCode")).isFalse()
+    }
+
+    @Test
+    fun `Should return no reason for valid titles`() {
+        assertThat(icdModel.invalidTitleReason("targetMainTitle")).isNull()
+        assertThat(icdModel.invalidTitleReason("targetMainTitle&targetExtensionTitle")).isNull()
+    }
+
+    @Test
+    fun `Should report unknown titles separately from misplaced titles`() {
+        assertThat(icdModel.invalidTitleReason("invalidTitle"))
+            .isEqualTo("ICD title [invalidTitle] is not known - check for existence in ICD model")
+        assertThat(icdModel.invalidTitleReason("targetMainTitle&targetExtensionTitle&targetExtensionParentTitle"))
+            .isEqualTo(
+                "ICD title [targetMainTitle&targetExtensionTitle&targetExtensionParentTitle] must be a single main title, " +
+                        "optionally followed by '&' and one extension title"
+            )
+    }
+
+    @Test
+    fun `Should resolve titles for the same code in both slots when a title exists in both`() {
+        val collidingTitle = "colliding"
+        val model = IcdModel.create(
+            listOf(
+                IcdNode("mainCode", emptyList(), collidingTitle),
+                IcdNode("extensionCode", emptyList(), collidingTitle, isExtension = true)
+            )
+        )
+
+        assertThat(model.resolveCodeForTitle(collidingTitle)).isEqualTo(IcdCode("mainCode", null))
+        assertThat(model.resolveCodeForTitle("$collidingTitle&$collidingTitle")).isEqualTo(IcdCode("mainCode", "extensionCode"))
     }
 
     @Test
@@ -67,6 +132,12 @@ class IcdModelTest {
     @Test
     fun `Should ignore case in code to title resolution`() {
         assertThat(icdModel.resolveCodeForTitle("TargetMainTitle&targetEXTENSIONTitle"))
+            .isEqualTo(IcdCode("targetMainCode", "targetExtensionCode"))
+    }
+
+    @Test
+    fun `Should resolve titles surrounded by whitespace in both slots`() {
+        assertThat(icdModel.resolveCodeForTitle("targetMainTitle & targetExtensionTitle"))
             .isEqualTo(IcdCode("targetMainCode", "targetExtensionCode"))
     }
 

--- a/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/IcdModelTest.kt
@@ -100,7 +100,7 @@ class IcdModelTest {
     @Test
     fun `Should report unknown titles separately from misplaced titles`() {
         assertThat(icdModel.invalidTitleReason("invalidTitle"))
-            .isEqualTo("ICD title [invalidTitle] is not known - check for existence in ICD model")
+            .isEqualTo("ICD title [invalidTitle] is not known. Check for existence in ICD model")
         assertThat(icdModel.invalidTitleReason("targetMainTitle&targetExtensionTitle&targetExtensionParentTitle"))
             .isEqualTo(
                 "ICD title [targetMainTitle&targetExtensionTitle&targetExtensionParentTitle] must be a single main title, " +

--- a/common/src/test/kotlin/com/hartwig/actin/icd/TestIcdFactory.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/TestIcdFactory.kt
@@ -7,25 +7,21 @@ object TestIcdFactory {
     private const val DEFAULT_ICD_CODE = "1A01"
     private val DEFAULT_ICD_PARENT_CODE_LIST = listOf("1", "Block-1A")
     private const val DEFAULT_ICD_TITLE = "node"
+    private const val DEFAULT_EXTENSION_CODE = "XA01"
+    private val DEFAULT_EXTENSION_PARENT_CODE_LIST = listOf("X")
+    private const val DEFAULT_EXTENSION_TITLE = "extension node"
 
-    fun createTestModel(): IcdModel = create(
-        codeToNodeMap = listOf(1, 2, 3).associate { i ->
-            "$DEFAULT_ICD_CODE.$i" to IcdNode(
-                "$DEFAULT_ICD_CODE.$i",
-                DEFAULT_ICD_PARENT_CODE_LIST,
-                "$DEFAULT_ICD_TITLE $i"
-            )
-        },
-        titleToCodeMap = listOf(1, 2, 3).associate { i -> "$DEFAULT_ICD_TITLE $i" to "$DEFAULT_ICD_CODE.$i" },
+    fun createTestModel(): IcdModel = IcdModel.create(
+        listOf(1, 2, 3).map { i ->
+            IcdNode("$DEFAULT_ICD_CODE.$i", DEFAULT_ICD_PARENT_CODE_LIST, "$DEFAULT_ICD_TITLE $i")
+        } + IcdNode(DEFAULT_EXTENSION_CODE, DEFAULT_EXTENSION_PARENT_CODE_LIST, DEFAULT_EXTENSION_TITLE, isExtension = true)
     )
 
-    fun createModelWithSpecificNodes(nodePrefixes: List<String>) =
-        IcdModel.create(nodePrefixes.map { IcdNode(it + "Code", listOf(it + "ParentCode"), it + "Title") })
+    fun createModelWithSpecificNodes(mainNodePrefixes: List<String>, extensionNodePrefixes: List<String> = emptyList()) =
+        IcdModel.create(
+            mainNodePrefixes.map { node(it, isExtension = false) } + extensionNodePrefixes.map { node(it, isExtension = true) }
+        )
 
-    private fun create(
-        codeToNodeMap: Map<String, IcdNode> = emptyMap(),
-        titleToCodeMap: Map<String, String> = emptyMap(),
-    ): IcdModel {
-        return IcdModel(codeToNodeMap, titleToCodeMap)
-    }
+    private fun node(prefix: String, isExtension: Boolean) =
+        IcdNode(prefix + "Code", listOf(prefix + "ParentCode"), prefix + "Title", isExtension)
 }

--- a/common/src/test/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializerTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializerTest.kt
@@ -65,6 +65,18 @@ class IcdDeserializerTest {
     }
 
     @Test
+    fun `Should mark nodes from the extension chapter as extension and all other nodes as main`() {
+        val rawNodes = CsvReader.readFromFile(ResourceLocator.resourceOnClasspath("icd/example_icd.tsv"))
+        val result = IcdDeserializer.deserialize(rawNodes).associateBy { it.title }
+
+        assertThat(result["Test category"]!!.isExtension).isFalse()
+        assertThat(result["Test chapter 1"]!!.isExtension).isFalse()
+        assertThat(result["Extension chapter X"]!!.isExtension).isTrue()
+        assertThat(result["Extension block X1"]!!.isExtension).isTrue()
+        assertThat(result["Extension category X1"]!!.isExtension).isTrue()
+    }
+
+    @Test
     fun `Should remove leading hyphens from titles before adding to IcdNode object`() {
         val rawNodes = listOf(
             createRawNode(title = "  -title"),

--- a/common/src/test/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializerTest.kt
+++ b/common/src/test/kotlin/com/hartwig/actin/icd/serialization/IcdDeserializerTest.kt
@@ -13,6 +13,8 @@ private const val DEFAULT_CODE = "1A"
 
 class IcdDeserializerTest {
 
+    private val defaultTestNodes = CsvReader.readFromFile(ResourceLocator.resourceOnClasspath("icd/example_icd.tsv"))
+
     @Test
     fun `Should correctly solve codes of full parent tree for regular chapters`() {
         val chapter = createRawNode(classKind = ClassKind.CHAPTER)
@@ -49,10 +51,7 @@ class IcdDeserializerTest {
 
     @Test
     fun `Should correctly return ICD Node with full parent tree for extension chapters`() {
-        val extensionNodes =
-            CsvReader.readFromFile(ResourceLocator.resourceOnClasspath("icd/example_icd.tsv")).filter { it.chapterNo == "X" }
-
-        val result = IcdDeserializer.deserialize(extensionNodes)
+        val result = IcdDeserializer.deserialize(defaultTestNodes.filter { it.chapterNo == "X" })
         assertThat(result).hasSize(8)
         assertThat(result[0].parentTreeCodes).isEmpty()
         assertThat(result[1].parentTreeCodes).containsExactly("X")
@@ -66,8 +65,7 @@ class IcdDeserializerTest {
 
     @Test
     fun `Should mark nodes from the extension chapter as extension and all other nodes as main`() {
-        val rawNodes = CsvReader.readFromFile(ResourceLocator.resourceOnClasspath("icd/example_icd.tsv"))
-        val result = IcdDeserializer.deserialize(rawNodes).associateBy { it.title }
+        val result = IcdDeserializer.deserialize(defaultTestNodes).associateBy { it.title }
 
         assertThat(result["Test category"]!!.isExtension).isFalse()
         assertThat(result["Test chapter 1"]!!.isExtension).isFalse()


### PR DESCRIPTION
`actin-clinical-llm`: https://github.com/hartwigmedical/actin-clinical-llm/pull/38
`actin-clinical`: https://github.com/hartwigmedical/actin-clinical/pull/496

- `IcdCode(mainCode, extensionCode?)` had no notion of which codes belong in which slot, so nothing stopped am extension code being stored as a main code. ICD matching in `IcdModel` is strictly slot-directional and every allergy/intolerance evaluator already assumes condition = main, substance = extension, so this PR aligns the model with what algo believes.
- Slot identity is only derivable from ICD-11 chapter X ("Extension Codes"), which IcdDeserializer already computes and then discarded. It's now persisted on `IcdNode.isExtension` and `IcdModel` derives per-slot title maps from it. 
- `resolveCodeForTitle`, `isValidIcdTitle` and `isValidIcdCode` are now slot-directional. `invalidTitleReason` / `invalidMainTitleReason` / `invalidExtensionTitleReason` give consumers a shared message distinguishing unknown title from known title, wrong slot.